### PR TITLE
Add capabilities to sign Transactions when the transaction is being sent

### DIFF
--- a/sdk/main/CMakeLists.txt
+++ b/sdk/main/CMakeLists.txt
@@ -40,6 +40,7 @@ add_library(${PROJECT_NAME} STATIC
         src/Status.cc
         src/Transaction.cc
         src/TransactionId.cc
+        src/TransactionReceipt.cc
         src/TransactionReceiptQuery.cc
         src/TransactionRecord.cc
         src/TransactionRecordQuery.cc

--- a/sdk/main/include/AccountBalanceQuery.h
+++ b/sdk/main/include/AccountBalanceQuery.h
@@ -4,7 +4,7 @@
  *
  * Copyright (C) 2020 - 2022 Hedera Hashgraph, LLC
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
+ * Licensed under the Apache License, Version 2.0 (the "License")
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
@@ -52,7 +52,7 @@ public:
   /**
    * Default destructor.
    */
-  ~AccountBalanceQuery() = default;
+  ~AccountBalanceQuery() override = default;
 
   /**
    * Derived from Query. Determine if payment is required for this AccountBalanceQuery.
@@ -97,7 +97,7 @@ protected:
    *
    * @return The query protobuf object that contains this AccountBalanceQuery information.
    */
-  proto::Query makeRequest() const override;
+  proto::Query makeRequest(const Client&) const override;
 
   /**
    * Derived from Executable. Create an AccountBalance object from a protobuf response object.

--- a/sdk/main/include/AccountCreateTransaction.h
+++ b/sdk/main/include/AccountCreateTransaction.h
@@ -220,7 +220,7 @@ public:
 
 protected:
   /**
-   * Derived from Executable. Construct a protobuf Transaction protobuf from this AccountCreateTransaction.
+   * Derived from Executable. Construct a protobuf Transaction from this AccountCreateTransaction.
    *
    * @param client The Client submitting this transaction.
    * @return A protobuf Transaction that contains this AccountCreateTransaction's data and is signed by the client.

--- a/sdk/main/include/AccountCreateTransaction.h
+++ b/sdk/main/include/AccountCreateTransaction.h
@@ -152,7 +152,7 @@ public:
    *
    * @return The key for this account.
    */
-  inline std::shared_ptr<PublicKey> getKey() const { return mKey; }
+  inline std::shared_ptr<PublicKey> getKey() const { return mPublicKey; }
 
   /**
    * Extract the initial balance to transfer into the account.
@@ -239,7 +239,7 @@ private:
    * The key that must sign each transfer out of the account. If mReceiverSignatureRequired is true, then it must also
    * sign any transfer into the account. Defaults to uninitialized.
    */
-  std::shared_ptr<PublicKey> mKey;
+  std::shared_ptr<PublicKey> mPublicKey;
 
   /**
    * The initial amount to transfer into this account. Defaults to 0 Hbar.

--- a/sdk/main/include/AccountCreateTransaction.h
+++ b/sdk/main/include/AccountCreateTransaction.h
@@ -4,7 +4,7 @@
  *
  * Copyright (C) 2020 - 2022 Hedera Hashgraph, LLC
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
+ * Licensed under the Apache License, Version 2.0 (the "License")
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
@@ -95,7 +95,7 @@ public:
    * @param memo The memo to set.
    * @return Reference to this AccountCreateTransaction object.
    */
-  AccountCreateTransaction& setAccountMemo(const std::string& memo);
+  AccountCreateTransaction& setAccountMemo(std::string_view memo);
 
   /**
    * Set the maximum automatic token associations.
@@ -220,11 +220,12 @@ public:
 
 protected:
   /**
-   * Derived from Transaction. Construct a transaction protobuf object from this transaction.
+   * Derived from Executable. Construct a protobuf Transaction protobuf from this AccountCreateTransaction.
    *
-   * @return The transaction protobuf object that contains this transaction information.
+   * @param client The Client submitting this transaction.
+   * @return A protobuf Transaction that contains this AccountCreateTransaction's data and is signed by the client.
    */
-  proto::Transaction makeRequest() const override;
+  proto::Transaction makeRequest(const Client& client) const override;
 
 private:
   /**

--- a/sdk/main/include/Client.h
+++ b/sdk/main/include/Client.h
@@ -86,11 +86,18 @@ public:
   inline std::optional<AccountId> getOperatorAccountId() const { return mOperator.mAccountId; }
 
   /**
-   * Get the key of the operator. Useful when the client was constructed from file.
+   * Get the public key of the operator. Useful when the client was constructed from file.
    *
    * @return The public key of this client's operator, if valid.
    */
   inline std::shared_ptr<PublicKey> getOperatorPublicKey() const { return mOperator.mPrivateKey->getPublicKey(); }
+
+  /**
+   * Get the private key of the operator. Useful when the client was constructed from file.
+   *
+   * @return The private key of this client's operator, if valid.
+   */
+  inline std::shared_ptr<PrivateKey> getOperatorPrivateKey() const { return mOperator.mPrivateKey; }
 
   /**
    * The default maximum fee used for transactions.
@@ -118,7 +125,7 @@ private:
     std::optional<AccountId> mAccountId;
 
     /**
-     * The public key of the account.
+     * The private key of the account.
      */
     std::shared_ptr<PrivateKey> mPrivateKey;
   };

--- a/sdk/main/include/Client.h
+++ b/sdk/main/include/Client.h
@@ -23,14 +23,10 @@
 #include "AccountId.h"
 #include "Hbar.h"
 #include "Network.h"
+#include "PrivateKey.h"
 #include "PublicKey.h"
 
 #include <functional>
-
-namespace Hedera
-{
-class PrivateKey;
-}
 
 namespace Hedera
 {
@@ -94,7 +90,7 @@ public:
    *
    * @return The public key of this client's operator, if valid.
    */
-  inline std::shared_ptr<PublicKey> getOperatorPublicKey() const { return mOperator.mPublicKey; }
+  inline std::shared_ptr<PublicKey> getOperatorPublicKey() const { return mOperator.mPrivateKey->getPublicKey(); }
 
   /**
    * The default maximum fee used for transactions.
@@ -124,7 +120,7 @@ private:
     /**
      * The public key of the account.
      */
-    std::shared_ptr<PublicKey> mPublicKey;
+    std::shared_ptr<PrivateKey> mPrivateKey;
   };
 
   /**

--- a/sdk/main/include/ED25519PublicKey.h
+++ b/sdk/main/include/ED25519PublicKey.h
@@ -22,8 +22,6 @@ public:
   [[nodiscard]] bool verifySignature(const std::vector<unsigned char>& signatureBytes,
                                      const std::vector<unsigned char>& signedBytes) const override;
 
-  [[nodiscard]] std::shared_ptr<PrivateKey> getPrivateKey() const override;
-
 private:
   EVP_PKEY* publicKey;
 };

--- a/sdk/main/include/ED25519PublicKey.h
+++ b/sdk/main/include/ED25519PublicKey.h
@@ -14,13 +14,15 @@ class ED25519PublicKey : public PublicKey
 public:
   explicit ED25519PublicKey(const std::vector<unsigned char>& rawPublicKey);
 
-  ~ED25519PublicKey();
+  ~ED25519PublicKey() override;
 
   [[nodiscard]] proto::Key* toProtobuf() const override;
   [[nodiscard]] std::string toString() const override;
 
   [[nodiscard]] bool verifySignature(const std::vector<unsigned char>& signatureBytes,
                                      const std::vector<unsigned char>& signedBytes) const override;
+
+  [[nodiscard]] std::shared_ptr<PrivateKey> getPrivateKey() const override;
 
 private:
   EVP_PKEY* publicKey;

--- a/sdk/main/include/Executable.h
+++ b/sdk/main/include/Executable.h
@@ -4,7 +4,7 @@
  *
  * Copyright (C) 2020 - 2022 Hedera Hashgraph, LLC
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
+ * Licensed under the Apache License, Version 2.0 (the "License")
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
@@ -83,11 +83,12 @@ protected:
   virtual ~Executable() = default;
 
   /**
-   * Construct this request and place it in a protobuf object.
+   * Construct a ProtoRequestType from this request.
    *
-   * @return The protobuf object that contains this request.
+   * @param client The Client submitting this request.
+   * @return A ProtoRequestType that contains this request's data.
    */
-  virtual ProtoRequestType makeRequest() const = 0;
+  virtual ProtoRequestType makeRequest([[maybe_unused]] const Client& client) const = 0;
 
   /**
    * Construct the response from a protobuf response object.

--- a/sdk/main/include/PrivateKey.h
+++ b/sdk/main/include/PrivateKey.h
@@ -4,7 +4,7 @@
  *
  * Copyright (C) 2020 - 2022 Hedera Hashgraph, LLC
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
+ * Licensed under the Apache License, Version 2.0 (the "License")
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
@@ -28,6 +28,7 @@ class PrivateKey
 {
 public:
   std::shared_ptr<PublicKey> getPublicKey() const { return std::shared_ptr<PublicKey>(); }
+  std::vector<unsigned char> sign(const std::vector<unsigned char>& bytesToSign);
 };
 
 } // namespace Hedera

--- a/sdk/main/include/PublicKey.h
+++ b/sdk/main/include/PublicKey.h
@@ -49,8 +49,6 @@ public:
   static std::shared_ptr<PublicKey> fromAliasBytes(const std::string&);
 
   [[nodiscard]] virtual std::string toString() const = 0;
-
-  [[nodiscard]] virtual std::shared_ptr<PrivateKey> getPrivateKey() const = 0;
 };
 
 } // namespace Hedera

--- a/sdk/main/include/PublicKey.h
+++ b/sdk/main/include/PublicKey.h
@@ -4,7 +4,7 @@
  *
  * Copyright (C) 2020 - 2022 Hedera Hashgraph, LLC
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
+ * Licensed under the Apache License, Version 2.0 (the "License")
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
@@ -31,21 +31,26 @@ class Key;
 
 namespace Hedera
 {
+class PrivateKey;
+};
+
+namespace Hedera
+{
 class PublicKey
 {
 public:
-  PublicKey();
-  PublicKey(const PublicKey& other) = default;
-  PublicKey& operator=(const PublicKey& other) = default;
-  PublicKey& operator=(const PublicKey&& other) = delete;
+  virtual ~PublicKey() = default;
 
   [[nodiscard]] virtual proto::Key* toProtobuf() const = 0;
-  [[nodiscard]] virtual bool verifySignature(const std::vector<unsigned char>& signatureBytes, const std::vector<unsigned char>& signedBytes) const = 0;
+  [[nodiscard]] virtual bool verifySignature(const std::vector<unsigned char>& signatureBytes,
+                                             const std::vector<unsigned char>& signedBytes) const = 0;
 
   static std::shared_ptr<PublicKey> fromProtobuf(const proto::Key& key);
-  static std::shared_ptr<PublicKey> fromAliasBytes(const std::string& bytes);
+  static std::shared_ptr<PublicKey> fromAliasBytes(const std::string&);
 
   [[nodiscard]] virtual std::string toString() const = 0;
+
+  [[nodiscard]] virtual std::shared_ptr<PrivateKey> getPrivateKey() const = 0;
 };
 
 } // namespace Hedera

--- a/sdk/main/include/Transaction.h
+++ b/sdk/main/include/Transaction.h
@@ -4,7 +4,7 @@
  *
  * Copyright (C) 2020 - 2022 Hedera Hashgraph, LLC
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
+ * Licensed under the Apache License, Version 2.0 (the "License")
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
@@ -37,6 +37,7 @@ class TransactionResponse;
 namespace proto
 {
 class Transaction;
+class TransactionBody;
 class TransactionResponse;
 }
 
@@ -133,6 +134,16 @@ protected:
    */
   TransactionResponse mapResponse(const proto::TransactionResponse& response) const override;
 
+  /**
+   * Sign a protobuf TransactionBody with a Client and put the signed bytes into a protobuf Transaction.
+   *
+   * @param transaction The TransactionBody to sign.
+   * @param client      The Client being used to sign the transaction.
+   * @return A protobuf Transaction containing the TransactionBody signed by the Client.
+   */
+  proto::Transaction signTransaction(const proto::TransactionBody& transaction, const Client& client) const;
+
+private:
   /**
    * The valid transaction duration. Defaults to two minutes.
    */

--- a/sdk/main/include/TransactionId.h
+++ b/sdk/main/include/TransactionId.h
@@ -51,6 +51,23 @@ public:
    */
   std::shared_ptr<proto::TransactionID> toProtobuf() const;
 
+  /**
+   * Extract the valid transaction time.
+   *
+   * @return The valid transaction time.
+   */
+  inline std::optional<std::chrono::sys_time<std::chrono::duration<double>>> getValidTransactionTime() const
+  {
+    return mValidTransactionTime;
+  }
+
+  /**
+   * Extract the account ID.
+   *
+   * @return The account ID.
+   */
+  inline std::optional<AccountId> getAccountId() const { return mAccountId; }
+
 private:
   /**
    * The time the transaction is considered "valid".

--- a/sdk/main/include/TransactionReceiptQuery.h
+++ b/sdk/main/include/TransactionReceiptQuery.h
@@ -72,7 +72,7 @@ protected:
    *
    * @return The query protobuf object that contains this TransactionReceiptQuery information.
    */
-  proto::Query makeRequest() const override;
+  proto::Query makeRequest(const Client&) const override;
 
   /**
    * Derived from Query. Create a response object from a protobuf response object.

--- a/sdk/main/include/TransactionRecordQuery.h
+++ b/sdk/main/include/TransactionRecordQuery.h
@@ -69,7 +69,7 @@ protected:
    *
    * @return The query protobuf object that contains this TransactionRecordQuery information.
    */
-  proto::Query makeRequest() const override;
+  proto::Query makeRequest(const Client&) const override;
 
   /**
    * Derived from Query. Create an TransactionRecord object from a protobuf response object.

--- a/sdk/main/include/TransferTransaction.h
+++ b/sdk/main/include/TransferTransaction.h
@@ -76,7 +76,7 @@ public:
 
 protected:
   /**
-   * Derived from Executable. Construct a protobuf Transaction protobuf from this TransferTransaction.
+   * Derived from Executable. Construct a protobuf Transaction from this TransferTransaction.
    *
    * @param client The Client submitting this transaction.
    * @return A protobuf Transaction that contains this TransferTransaction's data and is signed by the client.

--- a/sdk/main/include/TransferTransaction.h
+++ b/sdk/main/include/TransferTransaction.h
@@ -4,7 +4,7 @@
  *
  * Copyright (C) 2020 - 2022 Hedera Hashgraph, LLC
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
+ * Licensed under the Apache License, Version 2.0 (the "License")
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
@@ -76,11 +76,12 @@ public:
 
 protected:
   /**
-   * Derived from Transaction. Construct a protobuf Transaction from this TransferTransaction.
+   * Derived from Executable. Construct a protobuf Transaction protobuf from this TransferTransaction.
    *
-   * @return The protobuf Transaction that contains this TransferTransaction information.
+   * @param client The Client submitting this transaction.
+   * @return A protobuf Transaction that contains this TransferTransaction's data and is signed by the client.
    */
-  proto::Transaction makeRequest() const override;
+  proto::Transaction makeRequest(const Client& client) const override;
 
 private:
   /**

--- a/sdk/main/src/AccountBalanceQuery.cc
+++ b/sdk/main/src/AccountBalanceQuery.cc
@@ -4,7 +4,7 @@
  *
  * Copyright (C) 2020 - 2022 Hedera Hashgraph, LLC
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
+ * Licensed under the Apache License, Version 2.0 (the "License")
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
@@ -45,7 +45,7 @@ AccountBalanceQuery& AccountBalanceQuery::setContractId(const ContractId& contra
   return *this;
 }
 //-----
-proto::Query AccountBalanceQuery::makeRequest() const
+proto::Query AccountBalanceQuery::makeRequest(const Client&) const
 {
   proto::Query query;
   proto::CryptoGetAccountBalanceQuery* getAccountBalanceQuery = query.mutable_cryptogetaccountbalance();

--- a/sdk/main/src/AccountCreateTransaction.cc
+++ b/sdk/main/src/AccountCreateTransaction.cc
@@ -40,7 +40,7 @@ AccountCreateTransaction::AccountCreateTransaction()
 //-----
 AccountCreateTransaction& AccountCreateTransaction::setKey(const std::shared_ptr<PublicKey>& key)
 {
-  mKey = key;
+  mPublicKey = key;
   return *this;
 }
 
@@ -124,9 +124,9 @@ std::shared_ptr<proto::CryptoCreateTransactionBody> AccountCreateTransaction::bu
 {
   auto body = std::make_shared<proto::CryptoCreateTransactionBody>();
 
-  if (mKey != nullptr)
+  if (mPublicKey)
   {
-    body->set_allocated_key(mKey->toProtobuf());
+    body->set_allocated_key(mPublicKey->toProtobuf());
   }
 
   body->set_initialbalance(mInitialBalance.toTinybars());

--- a/sdk/main/src/AccountCreateTransaction.cc
+++ b/sdk/main/src/AccountCreateTransaction.cc
@@ -4,7 +4,7 @@
  *
  * Copyright (C) 2020 - 2022 Hedera Hashgraph, LLC
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
+ * Licensed under the Apache License, Version 2.0 (the "License")
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
@@ -19,6 +19,7 @@
  */
 #include "AccountCreateTransaction.h"
 
+#include "Client.h"
 #include "PublicKey.h"
 #include "TransactionResponse.h"
 
@@ -33,7 +34,7 @@ namespace Hedera
 //-----
 AccountCreateTransaction::AccountCreateTransaction()
 {
-  mMaxTransactionFee = Hbar::from(5LL);
+  setMaxTransactionFee(Hbar::from(5LL));
 }
 
 //-----
@@ -66,7 +67,7 @@ AccountCreateTransaction& AccountCreateTransaction::setAutoRenewPeriod(
 }
 
 //-----
-AccountCreateTransaction& AccountCreateTransaction::setAccountMemo(const std::string& memo)
+AccountCreateTransaction& AccountCreateTransaction::setAccountMemo(std::string_view memo)
 {
   mAccountMemo = memo;
   return *this;
@@ -110,21 +111,18 @@ AccountCreateTransaction& AccountCreateTransaction::setAlias(const std::shared_p
 }
 
 //-----
-proto::Transaction AccountCreateTransaction::makeRequest() const
+proto::Transaction AccountCreateTransaction::makeRequest(const Client& client) const
 {
-  proto::Transaction transaction;
   proto::TransactionBody transactionBody;
   transactionBody.set_allocated_cryptocreateaccount(build().get());
 
-  // TODO: sign here?
-
-  return transaction;
+  return signTransaction(transactionBody, client);
 }
 
 //-----
 std::shared_ptr<proto::CryptoCreateTransactionBody> AccountCreateTransaction::build() const
 {
-  std::shared_ptr<proto::CryptoCreateTransactionBody> body = std::make_shared<proto::CryptoCreateTransactionBody>();
+  auto body = std::make_shared<proto::CryptoCreateTransactionBody>();
 
   if (mKey != nullptr)
   {

--- a/sdk/main/src/Client.cc
+++ b/sdk/main/src/Client.cc
@@ -35,7 +35,7 @@ Client Client::forTestnet()
 Client& Client::setOperator(const AccountId& accountId, const PrivateKey& privateKey)
 {
   mOperator.mAccountId = accountId;
-  mOperator.mPublicKey = privateKey.getPublicKey();
+  mOperator.mPrivateKey = std::make_shared<PrivateKey>(privateKey);
 
   return *this;
 }

--- a/sdk/main/src/ED25519PublicKey.cc
+++ b/sdk/main/src/ED25519PublicKey.cc
@@ -20,7 +20,6 @@
 
 #include "ED25519PublicKey.h"
 
-#include "PrivateKey.h"
 #include "helper/HexConverter.h"
 #include "openssl/x509.h"
 
@@ -86,13 +85,6 @@ bool ED25519PublicKey::verifySignature(const std::vector<unsigned char>& signatu
   EVP_MD_CTX_free(messageDigestContext);
 
   return verificationResult == 1;
-}
-
-//-----
-std::shared_ptr<PrivateKey> ED25519PublicKey::getPrivateKey() const
-{
-  // TODO: implement stub
-  return std::make_shared<PrivateKey>();
 }
 
 } // namespace Hedera

--- a/sdk/main/src/ED25519PublicKey.cc
+++ b/sdk/main/src/ED25519PublicKey.cc
@@ -4,7 +4,7 @@
  *
  * Copyright (C) 2020 - 2022 Hedera Hashgraph, LLC
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
+ * Licensed under the Apache License, Version 2.0 (the "License")
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
@@ -20,6 +20,7 @@
 
 #include "ED25519PublicKey.h"
 
+#include "PrivateKey.h"
 #include "helper/HexConverter.h"
 #include "openssl/x509.h"
 
@@ -86,4 +87,12 @@ bool ED25519PublicKey::verifySignature(const std::vector<unsigned char>& signatu
 
   return verificationResult == 1;
 }
+
+//-----
+std::shared_ptr<PrivateKey> ED25519PublicKey::getPrivateKey() const
+{
+  // TODO: implement stub
+  return std::make_shared<PrivateKey>();
 }
+
+} // namespace Hedera

--- a/sdk/main/src/Executable.cc
+++ b/sdk/main/src/Executable.cc
@@ -58,7 +58,7 @@ SdkResponseType Executable<SdkRequestType, ProtoRequestType, ProtoResponseType, 
 {
   for (std::shared_ptr<Node> node : client.getNetwork()->getNodesWithAccountIds(mNodeAccountIds))
   {
-    std::pair<ProtoResponseType, grpc::Status> response = node->submitRequest(makeRequest(), duration);
+    std::pair<ProtoResponseType, grpc::Status> response = node->submitRequest(makeRequest(client), duration);
     if (response.second.ok())
     {
       return mapResponse(response.first);

--- a/sdk/main/src/PublicKey.cc
+++ b/sdk/main/src/PublicKey.cc
@@ -24,8 +24,6 @@
 
 #include <proto/basic_types.pb.h>
 
-#include <algorithm>
-
 namespace Hedera
 {
 std::shared_ptr<PublicKey> PublicKey::fromProtobuf(const proto::Key& key)

--- a/sdk/main/src/PublicKey.cc
+++ b/sdk/main/src/PublicKey.cc
@@ -4,7 +4,7 @@
  *
  * Copyright (C) 2020 - 2022 Hedera Hashgraph, LLC
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
+ * Licensed under the Apache License, Version 2.0 (the "License")
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
@@ -24,38 +24,35 @@
 
 #include <proto/basic_types.pb.h>
 
+#include <algorithm>
+
 namespace Hedera
 {
-PublicKey::PublicKey() = default;
-
 std::shared_ptr<PublicKey> PublicKey::fromProtobuf(const proto::Key& key)
 {
+  switch (key.key_case())
   {
-    switch (key.key_case())
+    case proto::Key::KeyCase::kEd25519:
     {
-      case proto::Key::KeyCase::kEd25519:
-      {
-        std::string keyString = key.ed25519();
-        std::vector<unsigned char> rawKeyBytes(keyString.size());
-        std::copy(keyString.begin(), keyString.end(), &rawKeyBytes.front());
+      std::string keyString = key.ed25519();
+      std::vector<unsigned char> rawKeyBytes(keyString.size());
+      std::copy(keyString.begin(), keyString.end(), &rawKeyBytes.front());
 
-        return std::make_shared<ED25519PublicKey>(ED25519PublicKey(rawKeyBytes));
-      }
-      default:
-      {
-        // TODO throw
-        break;
-      }
+      return std::make_shared<ED25519PublicKey>(ED25519PublicKey(rawKeyBytes));
+    }
+    default:
+    {
+      // TODO throw
+      return std::shared_ptr<PublicKey>();
     }
   }
 }
 
-std::shared_ptr<PublicKey> PublicKey::fromAliasBytes(const std::string& bytes)
+std::shared_ptr<PublicKey> PublicKey::fromAliasBytes(const std::string&)
 {
-  {
-    // TODO this implementation is meaningless, only acts as a stub
-    std::vector<unsigned char> rawKeyBytes(32);
-    return std::make_shared<ED25519PublicKey>(ED25519PublicKey(rawKeyBytes));
-  }
+  // TODO this implementation is meaningless, only acts as a stub
+  std::vector<unsigned char> rawKeyBytes(32);
+  return std::make_shared<ED25519PublicKey>(ED25519PublicKey(rawKeyBytes));
 }
-}
+
+} // namespace Hedera

--- a/sdk/main/src/Transaction.cc
+++ b/sdk/main/src/Transaction.cc
@@ -85,12 +85,12 @@ proto::Transaction Transaction<SdkRequestType>::signTransaction(const proto::Tra
       mTransactionId.getAccountId().has_value() && mTransactionId.getAccountId() == client.getOperatorAccountId())
   {
     // Generate a signature from the TransactionBody
-    std::string* transactionBodySerialized = new std::string(transaction.SerializeAsString());
-    const std::vector<unsigned char> signature = client.getOperatorPublicKey()->getPrivateKey()->sign(
-      { transactionBodySerialized->cbegin(), transactionBodySerialized->cend() });
+    auto transactionBodySerialized = new std::string(transaction.SerializeAsString());
+    const std::vector<unsigned char> signature =
+      client.getOperatorPrivateKey()->sign({ transactionBodySerialized->cbegin(), transactionBodySerialized->cend() });
 
     // Generate a protobuf SignaturePair from a protobuf SignatureMap
-    proto::SignatureMap* signatureMap = new proto::SignatureMap();
+    auto signatureMap = new proto::SignatureMap();
     signatureMap->add_sigpair()->set_allocated_ed25519(new std::string{ signature.cbegin(), signature.cend() });
 
     // Create a protobuf SignedTransaction from the TransactionBody and SignatureMap

--- a/sdk/main/src/Transaction.cc
+++ b/sdk/main/src/Transaction.cc
@@ -4,7 +4,7 @@
  *
  * Copyright (C) 2020 - 2022 Hedera Hashgraph, LLC
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
+ * Licensed under the Apache License, Version 2.0 (the "License")
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
@@ -20,8 +20,18 @@
 #include "Transaction.h"
 
 #include "AccountCreateTransaction.h"
+#include "Client.h"
+#include "PrivateKey.h"
+#include "TransactionId.h"
 #include "TransactionResponse.h"
 #include "TransferTransaction.h"
+
+#include <proto/basic_types.pb.h>
+#include <proto/transaction.pb.h>
+#include <proto/transaction_body.pb.h>
+#include <proto/transaction_contents.pb.h>
+
+#include <vector>
 
 namespace Hedera
 {
@@ -62,6 +72,41 @@ template<typename SdkRequestType>
 TransactionResponse Transaction<SdkRequestType>::mapResponse(const proto::TransactionResponse& response) const
 {
   return TransactionResponse::fromProtobuf(response).setTransactionId(mTransactionId);
+}
+
+//-----
+template<typename SdkRequestType>
+proto::Transaction Transaction<SdkRequestType>::signTransaction(const proto::TransactionBody& transaction,
+                                                                const Client& client) const
+{
+  // Make sure the operator key and account ID are valid, and make sure the account ID for this transaction matches
+  // the operator's account ID.
+  if (client.getOperatorPublicKey() && client.getOperatorAccountId().has_value() &&
+      mTransactionId.getAccountId().has_value() && mTransactionId.getAccountId() == client.getOperatorAccountId())
+  {
+    // Generate a signature from the TransactionBody
+    auto transactionBodySerialized = std::make_shared<std::string>(transaction.SerializeAsString());
+    const std::vector<unsigned char> signature = client.getOperatorPublicKey()->getPrivateKey()->sign(
+      { transactionBodySerialized->cbegin(), transactionBodySerialized->cend() });
+
+    // Generate a protobuf SignaturePair from a protobuf SignatureMap
+    auto signatureMap = std::make_shared<proto::SignatureMap>();
+    signatureMap->add_sigpair()->set_allocated_ed25519(new std::string{ signature.cbegin(), signature.cend() });
+
+    // Create a protobuf SignedTransaction from the TransactionBody and SignatureMap
+    proto::SignedTransaction signedTransaction;
+    signedTransaction.set_allocated_bodybytes(transactionBodySerialized.get());
+    signedTransaction.set_allocated_sigmap(signatureMap.get());
+
+    // Serialize the protobuf SignedTransaction to a protobuf Transaction
+    proto::Transaction transactionToReturn;
+    transactionToReturn.set_allocated_signedtransactionbytes(new std::string(signedTransaction.SerializeAsString()));
+
+    return transactionToReturn;
+  }
+
+  // TODO: throw?
+  return proto::Transaction();
 }
 
 /**

--- a/sdk/main/src/Transaction.cc
+++ b/sdk/main/src/Transaction.cc
@@ -85,18 +85,18 @@ proto::Transaction Transaction<SdkRequestType>::signTransaction(const proto::Tra
       mTransactionId.getAccountId().has_value() && mTransactionId.getAccountId() == client.getOperatorAccountId())
   {
     // Generate a signature from the TransactionBody
-    auto transactionBodySerialized = std::make_shared<std::string>(transaction.SerializeAsString());
+    std::string* transactionBodySerialized = new std::string(transaction.SerializeAsString());
     const std::vector<unsigned char> signature = client.getOperatorPublicKey()->getPrivateKey()->sign(
       { transactionBodySerialized->cbegin(), transactionBodySerialized->cend() });
 
     // Generate a protobuf SignaturePair from a protobuf SignatureMap
-    auto signatureMap = std::make_shared<proto::SignatureMap>();
+    proto::SignatureMap* signatureMap = new proto::SignatureMap();
     signatureMap->add_sigpair()->set_allocated_ed25519(new std::string{ signature.cbegin(), signature.cend() });
 
     // Create a protobuf SignedTransaction from the TransactionBody and SignatureMap
     proto::SignedTransaction signedTransaction;
-    signedTransaction.set_allocated_bodybytes(transactionBodySerialized.get());
-    signedTransaction.set_allocated_sigmap(signatureMap.get());
+    signedTransaction.set_allocated_bodybytes(transactionBodySerialized);
+    signedTransaction.set_allocated_sigmap(signatureMap);
 
     // Serialize the protobuf SignedTransaction to a protobuf Transaction
     proto::Transaction transactionToReturn;

--- a/sdk/main/src/TransactionReceiptQuery.cc
+++ b/sdk/main/src/TransactionReceiptQuery.cc
@@ -4,7 +4,7 @@
  *
  * Copyright (C) 2020 - 2022 Hedera Hashgraph, LLC
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
+ * Licensed under the Apache License, Version 2.0 (the "License")
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
@@ -19,6 +19,7 @@
  */
 #include "TransactionReceiptQuery.h"
 
+#include "Client.h"
 #include "TransactionReceipt.h"
 
 #include <proto/query.pb.h>
@@ -28,7 +29,7 @@
 namespace Hedera
 {
 //-----
-proto::Query TransactionReceiptQuery::makeRequest() const
+proto::Query TransactionReceiptQuery::makeRequest(const Client&) const
 {
   proto::Query query;
   proto::TransactionGetReceiptQuery* getTransactionReceiptQuery = query.mutable_transactiongetreceipt();

--- a/sdk/main/src/TransactionRecordQuery.cc
+++ b/sdk/main/src/TransactionRecordQuery.cc
@@ -19,6 +19,7 @@
  */
 #include "TransactionRecordQuery.h"
 
+#include "Client.h"
 #include "TransactionRecord.h"
 
 #include <proto/query.pb.h>
@@ -35,7 +36,7 @@ TransactionRecordQuery& TransactionRecordQuery::setTransactionId(const Transacti
 }
 
 //-----
-proto::Query TransactionRecordQuery::makeRequest() const
+proto::Query TransactionRecordQuery::makeRequest(const Client&) const
 {
   proto::Query query;
   proto::TransactionGetRecordQuery* getTransactionRecordQuery = query.mutable_transactiongetrecord();

--- a/sdk/main/src/TransferTransaction.cc
+++ b/sdk/main/src/TransferTransaction.cc
@@ -4,7 +4,7 @@
  *
  * Copyright (C) 2020 - 2022 Hedera Hashgraph, LLC
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
+ * Licensed under the Apache License, Version 2.0 (the "License")
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
@@ -19,6 +19,7 @@
  */
 #include "TransferTransaction.h"
 
+#include "Client.h"
 #include "TransactionResponse.h"
 
 #include <proto/crypto_transfer.pb.h>
@@ -41,15 +42,12 @@ TransferTransaction& TransferTransaction::addUnapprovedHbarTransfer(const Accoun
 }
 
 //-----
-proto::Transaction TransferTransaction::makeRequest() const
+proto::Transaction TransferTransaction::makeRequest(const Client& client) const
 {
-  proto::Transaction transaction;
-  proto::TransactionBody* body = transaction.mutable_body();
-  body->set_allocated_cryptotransfer(build().get());
+  proto::TransactionBody body;
+  body.set_allocated_cryptotransfer(build().get());
 
-  // TODO: sign here?
-
-  return transaction;
+  return signTransaction(body, client);
 }
 
 //-----


### PR DESCRIPTION
This PR uses the `openssl` to sign transactions when they are being executed/sent. Main functionality is contained in `Transfer::signTransaction()`.

There are a couple other changes to suppress SonarLint warnings.

**Related issue(s)**:

Fixes #56
