### PR TITLE
Create unit tests for `AccountBalanceQuery`

### DIFF
--- a/sdk/main/include/AccountBalance.h
+++ b/sdk/main/include/AccountBalance.h
@@ -20,10 +20,7 @@
 #ifndef ACCOUNT_BALANCE_H_
 #define ACCOUNT_BALANCE_H_
 
-#include "AccountId.h"
 #include "Hbar.h"
-
-#include <optional>
 
 namespace proto
 {
@@ -33,7 +30,7 @@ class CryptoGetAccountBalanceResponse;
 namespace Hedera
 {
 /**
- * This class represents the account balance object.
+ * Response when the client sends a node an AccountBalanceQuery.
  */
 class AccountBalance
 {
@@ -53,23 +50,11 @@ public:
    */
   inline Hbar getBalance() const { return mBalance; }
 
-  /**
-   * Extract the account ID.
-   *
-   * @return The account ID.
-   */
-  inline std::optional<AccountId> getAccountId() const { return mAccountId; }
-
 private:
   /**
    * The account balance.
    */
   Hbar mBalance;
-
-  /**
-   * The account ID of the account.
-   */
-  std::optional<AccountId> mAccountId;
 };
 
 } // namespace Hedera

--- a/sdk/main/include/AccountBalanceQuery.h
+++ b/sdk/main/include/AccountBalanceQuery.h
@@ -24,7 +24,7 @@
 #include "ContractId.h"
 #include "Query.h"
 
-#include <optional>
+#include <memory>
 
 namespace Hedera
 {
@@ -82,14 +82,20 @@ public:
    *
    * @return The account ID of the query.
    */
-  inline std::optional<AccountId> getAccountId() { return mAccountId; }
+  inline std::unique_ptr<AccountId> getAccountId()
+  {
+    return mAccountId ? std::make_unique<AccountId>(*mAccountId) : std::unique_ptr<AccountId>();
+  }
 
   /**
    * Extract the contract ID of the contract for which this query is meant.
    *
    * @return The contract ID of the contract for which this query is meant.
    */
-  inline std::optional<ContractId> getContractId() { return mContractId; }
+  inline std::unique_ptr<ContractId> getContractId()
+  {
+    return mContractId ? std::make_unique<ContractId>(*mContractId) : std::unique_ptr<ContractId>();
+  }
 
 protected:
   /**
@@ -120,12 +126,12 @@ private:
   /**
    * The account ID of the account for which this query is meant.
    */
-  std::optional<AccountId> mAccountId;
+  std::unique_ptr<AccountId> mAccountId;
 
   /**
    * The contract ID with which this request is associated.
    */
-  std::optional<ContractId> mContractId;
+  std::unique_ptr<ContractId> mContractId;
 };
 
 } // namespace Hedera

--- a/sdk/main/include/ContractId.h
+++ b/sdk/main/include/ContractId.h
@@ -58,6 +58,14 @@ public:
   explicit ContractId(const uint64_t& shard, const uint64_t& realm, const uint64_t& num);
 
   /**
+   * Default comparator operator.
+   *
+   * @param other The other ContractId to compare.
+   * @return \c TRUE if the input ContractId is the same as this one, otherwise \c FALSE
+   */
+  bool operator==(const ContractId& other) const = default;
+
+  /**
    * Retrieve the contract ID from a protobuf ContractID.
    *
    * @param proto The ContractID protobuf object.

--- a/sdk/main/src/AccountBalance.cc
+++ b/sdk/main/src/AccountBalance.cc
@@ -27,14 +27,7 @@ namespace Hedera
 AccountBalance AccountBalance::fromProtobuf(const proto::CryptoGetAccountBalanceResponse& proto)
 {
   AccountBalance balance;
-
-  if (proto.has_accountid())
-  {
-    balance.mAccountId = AccountId::fromProtobuf(proto.accountid());
-  }
-
   balance.mBalance = Hbar(proto.balance(), HbarUnit::TINYBAR());
-
   return balance;
 }
 

--- a/sdk/main/src/AccountBalanceQuery.cc
+++ b/sdk/main/src/AccountBalanceQuery.cc
@@ -32,7 +32,7 @@ namespace Hedera
 //-----
 AccountBalanceQuery& AccountBalanceQuery::setAccountId(const AccountId& accountId)
 {
-  mAccountId = accountId;
+  mAccountId = std::make_unique<AccountId>(accountId);
   mContractId.reset();
 
   return *this;
@@ -41,7 +41,7 @@ AccountBalanceQuery& AccountBalanceQuery::setAccountId(const AccountId& accountI
 //-----
 AccountBalanceQuery& AccountBalanceQuery::setContractId(const ContractId& contractId)
 {
-  mContractId = contractId;
+  mContractId = std::make_unique<ContractId>(contractId);
   mAccountId.reset();
 
   return *this;

--- a/sdk/tests/AccountBalanceQueryTest.cc
+++ b/sdk/tests/AccountBalanceQueryTest.cc
@@ -1,0 +1,72 @@
+/*-
+ *
+ * Hedera C++ SDK
+ *
+ * Copyright (C) 2020 - 2022 Hedera Hashgraph, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+#include "AccountBalanceQuery.h"
+#include "AccountId.h"
+
+#include <gtest/gtest.h>
+
+using namespace Hedera;
+
+class AccountBalanceQueryTest : public ::testing::Test
+{
+protected:
+  [[nodiscard]] inline const AccountId& getTestAccountId() const { return mTestAccountId; }
+  [[nodiscard]] inline const ContractId& getTestContractId() const { return mTestContractId; }
+
+private:
+  const AccountId mTestAccountId = AccountId(0ULL, 0ULL, 3ULL);
+  const ContractId mTestContractId = ContractId(0ULL, 0ULL, 3ULL);
+};
+
+TEST_F(AccountBalanceQueryTest, ConstructAccountBalanceQuery)
+{
+  AccountBalanceQuery query;
+  EXPECT_EQ(query.getAccountId(), nullptr);
+  EXPECT_EQ(query.getContractId(), nullptr);
+}
+
+TEST_F(AccountBalanceQueryTest, SetAccountId)
+{
+  AccountBalanceQuery query;
+  query.setAccountId(getTestAccountId());
+
+  EXPECT_EQ(*query.getAccountId(), getTestAccountId());
+}
+
+TEST_F(AccountBalanceQueryTest, SetContractId)
+{
+  AccountBalanceQuery query;
+  query.setContractId(getTestContractId());
+
+  EXPECT_EQ(*query.getContractId(), getTestContractId());
+}
+
+TEST_F(AccountBalanceQueryTest, ResetMutuallyExclusiveIds)
+{
+  AccountBalanceQuery query;
+  query.setAccountId(getTestAccountId());
+  query.setContractId(getTestContractId());
+
+  EXPECT_EQ(query.getAccountId(), nullptr);
+
+  query.setAccountId(getTestAccountId());
+
+  EXPECT_EQ(query.getContractId(), nullptr);
+}

--- a/sdk/tests/CMakeLists.txt
+++ b/sdk/tests/CMakeLists.txt
@@ -6,6 +6,7 @@ FetchContent_Declare(googletest
 FetchContent_MakeAvailable(googletest)
 
 set(TestSources
+        AccountBalanceQueryTest.cc
         ED25519PrivateKeyTest.cc
         ED25519PublicKeyTest.cc
         HbarTest.cc


### PR DESCRIPTION
**Description**:
- Add unit tests for `AccountBalanceQuery`.
- Switch over to use `std::unique_ptr` instead of `std::optional` for the `AccountBalanceQuery` fields.
- Remove `AccountId` field from `AccountBalance` as its not implemented yet.
- Add default comparison to `ContractId` in order to test.

**Related issue(s)**:

Fixes #75 

**Checklist**

- [X] Documented (Code comments, README, etc.)
- [X] Tested (unit, integration, etc.)
