### PR TITLE
Create unit tests for `AccountCreateTransaction`

### DIFF
--- a/sdk/main/include/Hbar.h
+++ b/sdk/main/include/Hbar.h
@@ -62,6 +62,14 @@ public:
   }
 
   /**
+   * Default comparator operator.
+   *
+   * @param other The other Hbar against which to compare value.
+   * @return \c TRUE if this Hbar has the same value as other, otherwise \c FALSE
+   */
+  bool operator==(const Hbar& other) const = default;
+
+  /**
    * Convert this Hbar value to tinybars.
    *
    * @return The amount this Hbar object represents in tinybars.

--- a/sdk/main/src/AccountCreateTransaction.cc
+++ b/sdk/main/src/AccountCreateTransaction.cc
@@ -42,7 +42,7 @@ AccountCreateTransaction::AccountCreateTransaction()
 //-----
 AccountCreateTransaction& AccountCreateTransaction::setKey(const std::shared_ptr<PublicKey>& key)
 {
-  mPublicKey = key;
+  mKey = key;
   return *this;
 }
 
@@ -76,32 +76,32 @@ AccountCreateTransaction& AccountCreateTransaction::setAccountMemo(std::string_v
 }
 
 //-----
-AccountCreateTransaction& AccountCreateTransaction::setMaxAutomaticTokenAssociations(int32_t associations)
+AccountCreateTransaction& AccountCreateTransaction::setMaxAutomaticTokenAssociations(uint32_t associations)
 {
-  mMaxAutomaticTokenAssociations = associations;
+  mMaxAutomaticTokenAssociations = associations > 1000U ? 1000U : associations;
   return *this;
 }
 
 //-----
 AccountCreateTransaction& AccountCreateTransaction::setStakedAccountId(const AccountId& stakedAccountId)
 {
-  mStakedAccountId = stakedAccountId;
+  mStakedAccountId = std::make_unique<AccountId>(stakedAccountId);
   mStakedNodeId.reset();
   return *this;
 }
 
 //-----
-AccountCreateTransaction& AccountCreateTransaction::setStakedNodeId(const int64_t& stakedNodeId)
+AccountCreateTransaction& AccountCreateTransaction::setStakedNodeId(const uint64_t& stakedNodeId)
 {
-  mStakedNodeId = stakedNodeId;
+  mStakedNodeId = std::make_unique<uint64_t>(stakedNodeId);
   mStakedAccountId.reset();
   return *this;
 }
 
 //-----
-AccountCreateTransaction& AccountCreateTransaction::setDeclineStakingReward(bool declineStakingReward)
+AccountCreateTransaction& AccountCreateTransaction::setDeclineStakingReward(bool declineReward)
 {
-  mDeclineStakingReward = declineStakingReward;
+  mDeclineStakingReward = declineReward;
   return *this;
 }
 
@@ -131,11 +131,11 @@ AccountCreateTransaction::getGrpcMethod(const std::shared_ptr<Node>& node) const
 //-----
 proto::CryptoCreateTransactionBody* AccountCreateTransaction::build() const
 {
-  auto body = new proto::CryptoCreateTransactionBody;
+  auto body = std::make_unique<proto::CryptoCreateTransactionBody>();
 
-  if (mPublicKey)
+  if (mKey)
   {
-    body->set_allocated_key(mPublicKey->toProtobuf());
+    body->set_allocated_key(mKey->toProtobuf());
   }
 
   body->set_initialbalance(mInitialBalance.toTinybars());
@@ -143,16 +143,16 @@ proto::CryptoCreateTransactionBody* AccountCreateTransaction::build() const
   body->set_allocated_autorenewperiod(
     DurationConverter::toProtobuf(std::chrono::duration_cast<std::chrono::seconds>(mAutoRenewPeriod)));
   body->set_memo(mAccountMemo);
-  body->set_max_automatic_token_associations(mMaxAutomaticTokenAssociations);
+  body->set_max_automatic_token_associations(static_cast<int32_t>(mMaxAutomaticTokenAssociations));
 
-  if (mStakedAccountId.has_value())
+  if (mStakedAccountId)
   {
-    body->set_allocated_staked_account_id(mStakedAccountId.value().toProtobuf());
+    body->set_allocated_staked_account_id(mStakedAccountId->toProtobuf());
   }
 
-  if (mStakedNodeId.has_value())
+  if (mStakedNodeId)
   {
-    body->set_staked_node_id(mStakedNodeId.value());
+    body->set_staked_node_id(static_cast<int64_t>(*mStakedNodeId));
   }
 
   body->set_decline_reward(mDeclineStakingReward);
@@ -162,7 +162,7 @@ proto::CryptoCreateTransactionBody* AccountCreateTransaction::build() const
     body->set_allocated_alias(new std::string(mAlias->toString()));
   }
 
-  return body;
+  return body.release();
 }
 
 } // namespace Hedera

--- a/sdk/tests/AccountCreateTransactionTest.cc
+++ b/sdk/tests/AccountCreateTransactionTest.cc
@@ -1,0 +1,147 @@
+/*-
+ *
+ * Hedera C++ SDK
+ *
+ * Copyright (C) 2020 - 2022 Hedera Hashgraph, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+#include "AccountCreateTransaction.h"
+#include "ED25519PrivateKey.h"
+#include "Hbar.h"
+#include "PublicKey.h"
+
+#include <gtest/gtest.h>
+
+using namespace Hedera;
+
+class AccountCreateTransactionTest : public ::testing::Test
+{
+protected:
+  [[nodiscard]] inline const std::shared_ptr<PublicKey>& getTestPublicKey() const { return mPublicKey; }
+  [[nodiscard]] inline const AccountId& getTestAccountId() const { return mAccountId; }
+  [[nodiscard]] inline const uint64_t& getTestNodeId() const { return mNodeId; }
+
+private:
+  const std::shared_ptr<PublicKey> mPublicKey = ED25519PrivateKey::generatePrivateKey()->getPublicKey();
+  const AccountId mAccountId = AccountId(0ULL, 0ULL, 10ULL);
+  const uint64_t mNodeId = 10ULL;
+};
+
+TEST_F(AccountCreateTransactionTest, ConstructAccountCreateTransaction)
+{
+  AccountCreateTransaction transaction;
+  EXPECT_EQ(transaction.getKey(), nullptr);
+  EXPECT_EQ(transaction.getInitialBalance(), Hbar(0ULL));
+  EXPECT_FALSE(transaction.getReceiverSignatureRequired());
+  EXPECT_EQ(transaction.getAutoRenewPeriod(), std::chrono::months(3));
+  EXPECT_EQ(transaction.getTransactionMemo(), std::string());
+  EXPECT_EQ(transaction.getMaxAutomaticTokenAssociations(), 0U);
+  EXPECT_EQ(transaction.getStakedAccountId(), nullptr);
+  EXPECT_EQ(transaction.getStakedNodeId(), nullptr);
+  EXPECT_FALSE(transaction.getDeclineStakingReward());
+  EXPECT_EQ(transaction.getAlias(), nullptr);
+}
+
+TEST_F(AccountCreateTransactionTest, SetKey)
+{
+  AccountCreateTransaction transaction;
+  transaction.setKey(getTestPublicKey());
+  EXPECT_EQ(transaction.getKey()->toString(), getTestPublicKey()->toString());
+}
+
+TEST_F(AccountCreateTransactionTest, SetInitialBalance)
+{
+  AccountCreateTransaction transaction;
+  const auto initialBalance = Hbar(3ULL);
+  transaction.setInitialBalance(initialBalance);
+
+  EXPECT_EQ(transaction.getInitialBalance(), initialBalance);
+}
+
+TEST_F(AccountCreateTransactionTest, SetReceiverSignatureRequired)
+{
+  AccountCreateTransaction transaction;
+  transaction.setReceiverSignatureRequired(true);
+  EXPECT_TRUE(transaction.getReceiverSignatureRequired());
+}
+
+TEST_F(AccountCreateTransactionTest, SetAutoRenewPeriod)
+{
+  AccountCreateTransaction transaction;
+  const std::chrono::duration<double> duration = std::chrono::days(10);
+  transaction.setAutoRenewPeriod(duration);
+
+  EXPECT_EQ(transaction.getAutoRenewPeriod(), duration);
+}
+
+TEST_F(AccountCreateTransactionTest, SetAccountMemo)
+{
+  AccountCreateTransaction transaction;
+  const std::string memo = "transaction test";
+  transaction.setAccountMemo(memo);
+
+  EXPECT_EQ(transaction.getAccountMemo(), memo);
+}
+
+TEST_F(AccountCreateTransactionTest, SetMaxAutomaticTokenAssociations)
+{
+  AccountCreateTransaction transaction;
+  transaction.setMaxAutomaticTokenAssociations(5);
+  EXPECT_EQ(transaction.getMaxAutomaticTokenAssociations(), 5);
+
+  // Cap at 1000
+  transaction.setMaxAutomaticTokenAssociations(2000U);
+  EXPECT_EQ(transaction.getMaxAutomaticTokenAssociations(), 1000U);
+}
+
+TEST_F(AccountCreateTransactionTest, SetStakedAccountId)
+{
+  AccountCreateTransaction transaction;
+  transaction.setStakedAccountId(getTestAccountId());
+  EXPECT_EQ(*transaction.getStakedAccountId(), getTestAccountId());
+}
+
+TEST_F(AccountCreateTransactionTest, SetStakedNodeId)
+{
+  AccountCreateTransaction transaction;
+  transaction.setStakedNodeId(getTestNodeId());
+  EXPECT_EQ(*transaction.getStakedNodeId(), getTestNodeId());
+}
+
+TEST_F(AccountCreateTransactionTest, SetStakingRewardPolicy)
+{
+  AccountCreateTransaction transaction;
+  transaction.setDeclineStakingReward(true);
+  EXPECT_TRUE(transaction.getDeclineStakingReward());
+}
+
+TEST_F(AccountCreateTransactionTest, SetAlias)
+{
+  AccountCreateTransaction transaction;
+  transaction.setAlias(getTestPublicKey());
+  EXPECT_EQ(transaction.getAlias()->toString(), getTestPublicKey()->toString());
+}
+
+TEST_F(AccountCreateTransactionTest, ResetMutuallyExclusiveIds)
+{
+  AccountCreateTransaction transaction;
+  transaction.setStakedAccountId(getTestAccountId());
+  transaction.setStakedNodeId(getTestNodeId());
+
+  EXPECT_EQ(transaction.getStakedAccountId(), nullptr);
+
+  transaction.setStakedAccountId(getTestAccountId());
+  EXPECT_EQ(transaction.getStakedNodeId(), nullptr);
+}

--- a/sdk/tests/CMakeLists.txt
+++ b/sdk/tests/CMakeLists.txt
@@ -6,6 +6,7 @@ FetchContent_Declare(googletest
 FetchContent_MakeAvailable(googletest)
 
 set(TestSources
+        AccountCreateTransactionTest.cc
         ED25519PrivateKeyTest.cc
         ED25519PublicKeyTest.cc
         HbarTest.cc


### PR DESCRIPTION
**Description**:
 - Add unit tests for `AccountCreateTransaction`.
 - Switch over to use `std::unique_ptr` instead of `std::optional` for the mutually exclusive `AccountCreateTransaction` fields.
 - Use `unsigned` types for fields that can't/shouldn't be negative.
 - Enforce rule that an account can have no more than `1000` token associations.
 - Add default comparison to `Hbar` in order to test.
 - Update `AccountCreateTransaction` doxygen comments.

**Related issue(s)**:

Fixes #76 

**Checklist**

- [X] Documented (Code comments, README, etc.)
- [X] Tested (unit, integration, etc.)
