### PR TITLE
Make the maximum number of token associations for an account 5000 instead of 1000

### DIFF
--- a/sdk/main/include/AccountCreateTransaction.h
+++ b/sdk/main/include/AccountCreateTransaction.h
@@ -127,7 +127,7 @@ public:
    * @param associations The desired maximum amount of token associations for the new account.
    * @return A reference to this AccountCreateTransaction object with the newly-set maximum automatic token
    *         associations.
-   * @throws std::invalid_argument If the desired maximum number of associations is over 1000.
+   * @throws std::invalid_argument If the desired maximum number of associations is over 5000.
    */
   AccountCreateTransaction& setMaxAutomaticTokenAssociations(uint32_t associations);
 
@@ -310,7 +310,7 @@ private:
 
   /**
    * The maximum number of tokens with which the new account can be implicitly associated. Only allows values up to a
-   * maximum value of 1000.
+   * maximum value of 5000.
    */
   uint32_t mMaxAutomaticTokenAssociations = 0U;
 

--- a/sdk/main/src/AccountCreateTransaction.cc
+++ b/sdk/main/src/AccountCreateTransaction.cc
@@ -22,10 +22,10 @@
 #include "impl/DurationConverter.h"
 #include "impl/Node.h"
 
+#include <grpcpp/client_context.h>
 #include <proto/crypto_create.pb.h>
 #include <proto/transaction.pb.h>
 #include <proto/transaction_response.pb.h>
-#include <grpcpp/client_context.h>
 #include <stdexcept>
 
 namespace Hedera
@@ -89,9 +89,9 @@ AccountCreateTransaction& AccountCreateTransaction::setAccountMemo(std::string_v
 //-----
 AccountCreateTransaction& AccountCreateTransaction::setMaxAutomaticTokenAssociations(uint32_t associations)
 {
-  if (associations > 1000)
+  if (associations > 5000U)
   {
-    throw std::invalid_argument("Too many maximum number of token associations. Maximum can't be over 1000");
+    throw std::invalid_argument("Too many maximum number of token associations. Maximum can't be over 5000");
   }
 
   mMaxAutomaticTokenAssociations = associations;

--- a/sdk/tests/AccountCreateTransactionTest.cc
+++ b/sdk/tests/AccountCreateTransactionTest.cc
@@ -123,11 +123,16 @@ TEST_F(AccountCreateTransactionTest, SetAccountMemo)
 TEST_F(AccountCreateTransactionTest, SetMaxAutomaticTokenAssociations)
 {
   AccountCreateTransaction transaction;
-  transaction.setMaxAutomaticTokenAssociations(5);
+  const uint32_t associations = 5U;
+  transaction.setMaxAutomaticTokenAssociations(associations);
 
-  EXPECT_EQ(transaction.getMaxAutomaticTokenAssociations(), 5);
-  // Throw if over 1000
-  EXPECT_ANY_THROW(transaction.setMaxAutomaticTokenAssociations(2000U));
+  EXPECT_EQ(transaction.getMaxAutomaticTokenAssociations(), associations);
+  
+  // Throw if over 5000
+  EXPECT_NO_THROW(transaction.setMaxAutomaticTokenAssociations(5000U));
+  EXPECT_THROW(transaction.setMaxAutomaticTokenAssociations(5001U), std::invalid_argument);
+  EXPECT_THROW(transaction.setMaxAutomaticTokenAssociations(std::numeric_limits<uint32_t>::max()),
+               std::invalid_argument);
 }
 
 TEST_F(AccountCreateTransactionTest, SetStakedAccountId)


### PR DESCRIPTION
**Description**:
This PR fixes a small issue where the number of maximum token associations was improperly set to 1,000 when it should be 5,000 (according to https://github.com/hashgraph/hedera-protobufs/pull/247).

**Related issue(s)**:

Fixes #161 

**Checklist**

- [X] Documented (Code comments, README, etc.)
- [X] Tested (unit, integration, etc.)
