### PR TITLE
Use `std::unique_ptr` to manage OpenSSL memory allocations when able

### DIFF
--- a/sdk/main/include/ECDSAsecp256k1PrivateKey.h
+++ b/sdk/main/include/ECDSAsecp256k1PrivateKey.h
@@ -23,6 +23,7 @@
 #include "ECDSAsecp256k1PublicKey.h"
 #include "MnemonicBIP39.h"
 #include "PrivateKey.h"
+#include "impl/OpenSSLObjectWrapper.h"
 
 #include <memory>
 #include <openssl/crypto.h>
@@ -144,29 +145,27 @@ public:
 
 private:
   /**
-   * Create an OpenSSL key object from a byte vector representing an ECDSAsecp256k1PrivateKey.
+   * Create a wrapped OpenSSL key object from a byte vector representing an ECDSAsecp256k1PrivateKey.
    *
    * @param keyBytes The bytes representing a ECDSAsecp256k1PrivateKey.
-   * @return A pointer to a newly created OpenSSL keypair object.
+   * @return The newly created wrapped OpenSSL keypair object.
    */
-  static std::unique_ptr<EVP_PKEY, void (*)(EVP_PKEY*)> bytesToPKEY(const std::vector<unsigned char>& keyBytes);
+  static internal::OpenSSL_EVP_PKEY bytesToPKEY(const std::vector<unsigned char>& keyBytes);
 
   /**
-   * Construct from an OpenSSL keypair object.
+   * Construct from a wrapped OpenSSL keypair object.
    *
-   * @param keypair A pointer to the underlying OpenSSL keypair object from which to construct this
-   *                ECDSAsecp256k1PrivateKey.
+   * @param keypair The wrapped OpenSSL keypair object from which to construct this ECDSAsecp256k1PrivateKey.
    */
-  explicit ECDSAsecp256k1PrivateKey(std::unique_ptr<EVP_PKEY, void (*)(EVP_PKEY*)>&& keypair);
+  explicit ECDSAsecp256k1PrivateKey(internal::OpenSSL_EVP_PKEY&& keypair);
 
   /**
-   * Construct from an OpenSSL keypair object and a chaincode.
+   * Construct from a wrapped OpenSSL keypair object and a chaincode.
    *
-   * @param keypair   A pointer to the underlying OpenSSL keypair.
+   * @param keypair   The wrapped OpenSSL keypair.
    * @param chainCode The new ECDSAsecp256k1PrivateKey's chain code.
    */
-  ECDSAsecp256k1PrivateKey(std::unique_ptr<EVP_PKEY, void (*)(EVP_PKEY*)>&& keypair,
-                           std::vector<unsigned char> chainCode);
+  ECDSAsecp256k1PrivateKey(internal::OpenSSL_EVP_PKEY&& keypair, std::vector<unsigned char> chainCode);
 
   /**
    * Get the byte representation of the ECDSAsecp256k1PublicKey that corresponds to this ECDSAsecp256k1PrivateKey.
@@ -176,9 +175,9 @@ private:
   [[nodiscard]] std::vector<unsigned char> getPublicKeyBytes() const;
 
   /**
-   * A pointer to the underlying OpenSSL keypair.
+   * The wrapped OpenSSL keypair.
    */
-  std::unique_ptr<EVP_PKEY, void (*)(EVP_PKEY*)> mKeypair = { nullptr, &EVP_PKEY_free };
+  internal::OpenSSL_EVP_PKEY mKeypair;
 
   /**
    * A pointer to the ECDSAsecp256k1PublicKey object that corresponds to this ECDSAsecp256k1PrivateKey.

--- a/sdk/main/include/ECDSAsecp256k1PublicKey.h
+++ b/sdk/main/include/ECDSAsecp256k1PublicKey.h
@@ -23,6 +23,7 @@
 #include "PublicKey.h"
 
 #include <openssl/crypto.h>
+#include <openssl/evp.h>
 #include <vector>
 
 namespace Hedera
@@ -40,13 +41,9 @@ public:
   ECDSAsecp256k1PublicKey() = delete;
 
   /**
-   * Destructor
-   */
-  ~ECDSAsecp256k1PublicKey() override;
-
-  /**
    * Copy constructor and copy assignment operator can throw std::runtime_error if OpenSSL serialization fails.
    */
+  ~ECDSAsecp256k1PublicKey() override = default;
   ECDSAsecp256k1PublicKey(const ECDSAsecp256k1PublicKey& other);
   ECDSAsecp256k1PublicKey& operator=(const ECDSAsecp256k1PublicKey& other);
   ECDSAsecp256k1PublicKey(ECDSAsecp256k1PublicKey&& other) noexcept;
@@ -135,19 +132,19 @@ private:
    * @param inputKeyBytes The bytes representing a ECDSAsecp256k1PublicKey.
    * @return A pointer to a newly created OpenSSL keypair object.
    */
-  static EVP_PKEY* bytesToPKEY(const std::vector<unsigned char>& inputKeyBytes);
+  static std::unique_ptr<EVP_PKEY, void (*)(EVP_PKEY*)> bytesToPKEY(const std::vector<unsigned char>& inputKeyBytes);
 
   /**
    * Construct from an OpenSSL key object.
    *
    * @param keypair The underlying OpenSSL keypair object from which to construct this ECDSAsecp256k1PublicKey.
    */
-  explicit ECDSAsecp256k1PublicKey(EVP_PKEY* publicKey);
+  explicit ECDSAsecp256k1PublicKey(std::unique_ptr<EVP_PKEY, void (*)(EVP_PKEY*)>&& publicKey);
 
   /**
    * A pointer to the underlying OpenSSL keypair.
    */
-  EVP_PKEY* mPublicKey = nullptr;
+  std::unique_ptr<EVP_PKEY, void (*)(EVP_PKEY*)> mPublicKey = { nullptr, &EVP_PKEY_free };
 };
 
 } // namespace Hedera

--- a/sdk/main/include/ECDSAsecp256k1PublicKey.h
+++ b/sdk/main/include/ECDSAsecp256k1PublicKey.h
@@ -21,6 +21,7 @@
 #define HEDERA_SDK_CPP_ECDSA_SECP256K1_PUBLIC_KEY_H_
 
 #include "PublicKey.h"
+#include "impl/OpenSSLObjectWrapper.h"
 
 #include <openssl/crypto.h>
 #include <openssl/evp.h>
@@ -127,24 +128,24 @@ public:
 
 private:
   /**
-   * Create an OpenSSL keypair object from a byte vector representing an ECDSAsecp256k1PublicKey.
+   * Create a wrapped OpenSSL keypair object from a byte vector representing an ECDSAsecp256k1PublicKey.
    *
    * @param inputKeyBytes The bytes representing a ECDSAsecp256k1PublicKey.
-   * @return A pointer to a newly created OpenSSL keypair object.
+   * @return The newly created wrapped OpenSSL keypair object.
    */
-  static std::unique_ptr<EVP_PKEY, void (*)(EVP_PKEY*)> bytesToPKEY(const std::vector<unsigned char>& inputKeyBytes);
+  static internal::OpenSSL_EVP_PKEY bytesToPKEY(const std::vector<unsigned char>& inputKeyBytes);
 
   /**
-   * Construct from an OpenSSL key object.
+   * Construct from a wrapped OpenSSL keypair object.
    *
-   * @param keypair The underlying OpenSSL keypair object from which to construct this ECDSAsecp256k1PublicKey.
+   * @param keypair The wrapped OpenSSL keypair object from which to construct this ECDSAsecp256k1PublicKey.
    */
-  explicit ECDSAsecp256k1PublicKey(std::unique_ptr<EVP_PKEY, void (*)(EVP_PKEY*)>&& publicKey);
+  explicit ECDSAsecp256k1PublicKey(internal::OpenSSL_EVP_PKEY&& publicKey);
 
   /**
-   * A pointer to the underlying OpenSSL keypair.
+   * The wrapped OpenSSL keypair object.
    */
-  std::unique_ptr<EVP_PKEY, void (*)(EVP_PKEY*)> mPublicKey = { nullptr, &EVP_PKEY_free };
+  internal::OpenSSL_EVP_PKEY mPublicKey;
 };
 
 } // namespace Hedera

--- a/sdk/main/include/ED25519PrivateKey.h
+++ b/sdk/main/include/ED25519PrivateKey.h
@@ -23,6 +23,7 @@
 #include "ED25519PublicKey.h"
 #include "MnemonicBIP39.h"
 #include "PrivateKey.h"
+#include "impl/OpenSSLObjectWrapper.h"
 
 #include <memory>
 #include <openssl/crypto.h>
@@ -144,12 +145,12 @@ public:
 
 private:
   /**
-   * Create an OpenSSL keypair object from a byte vector representing an ED25519PrivateKey.
+   * Create a wrapped OpenSSL keypair object from a byte vector representing an ED25519PrivateKey.
    *
    * @param keyBytes The bytes representing a ED25519PrivateKey.
-   * @return A pointer to a newly created OpenSSL keypair object.
+   * @return The newly created wrapped OpenSSL keypair object.
    */
-  static std::unique_ptr<EVP_PKEY, void (*)(EVP_PKEY*)> bytesToPKEY(const std::vector<unsigned char>& keyBytes);
+  static internal::OpenSSL_EVP_PKEY bytesToPKEY(const std::vector<unsigned char>& keyBytes);
 
   /**
    * Prepend an ED25519PrivateKey's algorithm identifier to an array of serialized ED25519PrivateKey bytes.
@@ -169,19 +170,19 @@ private:
   static std::unique_ptr<ED25519PrivateKey> fromHMACOutput(const std::vector<unsigned char>& hmacOutput);
 
   /**
-   * Construct from an OpenSSL keypair object.
+   * Construct from a wrapped OpenSSL keypair object.
    *
-   * @param keypair A pointer to the underlying OpenSSL keypair object from which to construct this ED25519PrivateKey.
+   * @param keypair The wrapped OpenSSL keypair object from which to construct this ED25519PrivateKey.
    */
-  explicit ED25519PrivateKey(std::unique_ptr<EVP_PKEY, void (*)(EVP_PKEY*)>&& keypair);
+  explicit ED25519PrivateKey(internal::OpenSSL_EVP_PKEY&& keypair);
 
   /**
-   * Construct from an OpenSSL keypair object and a chaincode.
+   * Construct from a wrapped OpenSSL keypair object and a chaincode.
    *
-   * @param keypair   A pointer to the underlying OpenSSL keypair.
+   * @param keypair   The wrapped OpenSSL keypair object.
    * @param chainCode The new ED25519PrivateKey's chain code.
    */
-  ED25519PrivateKey(std::unique_ptr<EVP_PKEY, void (*)(EVP_PKEY*)>&& keypair, std::vector<unsigned char> chainCode);
+  ED25519PrivateKey(internal::OpenSSL_EVP_PKEY&& keypair, std::vector<unsigned char> chainCode);
 
   /**
    * Get the byte representation of the ED25519PublicKey that corresponds to this ED25519PrivateKey.
@@ -191,9 +192,9 @@ private:
   [[nodiscard]] std::vector<unsigned char> getPublicKeyBytes() const;
 
   /**
-   * A pointer to the underlying OpenSSL keypair.
+   * The wrapped OpenSSL keypair object.
    */
-  std::unique_ptr<EVP_PKEY, void (*)(EVP_PKEY*)> mKeypair = { nullptr, &EVP_PKEY_free };
+  internal::OpenSSL_EVP_PKEY mKeypair;
 
   /**
    * A pointer to the ED25519PublicKey object that corresponds to this ED25519PrivateKey.

--- a/sdk/main/include/ED25519PublicKey.h
+++ b/sdk/main/include/ED25519PublicKey.h
@@ -21,6 +21,7 @@
 #define HEDERA_SDK_CPP_ED25519_PUBLIC_KEY_H_
 
 #include "PublicKey.h"
+#include "impl/OpenSSLObjectWrapper.h"
 
 #include <openssl/crypto.h>
 #include <openssl/evp.h>
@@ -109,12 +110,12 @@ public:
 
 private:
   /**
-   * Create an OpenSSL keypair object from a byte vector representing an ED25519PublicKey.
+   * Create a wrapped OpenSSL keypair object from a byte vector representing an ED25519PublicKey.
    *
    * @param keyBytes The bytes representing a ED25519PublicKey.
-   * @return A pointer to a newly created OpenSSL keypair object.
+   * @return The newly created wrapped OpenSSL keypair object.
    */
-  static std::unique_ptr<EVP_PKEY, void (*)(EVP_PKEY*)> bytesToPKEY(const std::vector<unsigned char>& keyBytes);
+  static internal::OpenSSL_EVP_PKEY bytesToPKEY(const std::vector<unsigned char>& keyBytes);
 
   /**
    * Prepend an ED25519PublicKey's algorithm identifier to an array of serialized ED25519PublicKey bytes.
@@ -126,16 +127,16 @@ private:
   static std::vector<unsigned char> prependAlgorithmIdentifier(const std::vector<unsigned char>& keyBytes);
 
   /**
-   * Construct from an OpenSSL key object.
+   * Construct from a wrapped OpenSSL key object.
    *
-   * @param keypair The underlying OpenSSL keypair object from which to construct this ED25519PublicKey.
+   * @param keypair The wrapped OpenSSL keypair object from which to construct this ED25519PublicKey.
    */
-  explicit ED25519PublicKey(std::unique_ptr<EVP_PKEY, void (*)(EVP_PKEY*)>&& publicKey);
+  explicit ED25519PublicKey(internal::OpenSSL_EVP_PKEY&& publicKey);
 
   /**
-   * A pointer to the underlying OpenSSL keypair.
+   * The wrapped OpenSSL keypair object.
    */
-  std::unique_ptr<EVP_PKEY, void (*)(EVP_PKEY*)> mPublicKey = { nullptr, &EVP_PKEY_free };
+  internal::OpenSSL_EVP_PKEY mPublicKey;
 };
 
 } // namespace Hedera

--- a/sdk/main/include/ED25519PublicKey.h
+++ b/sdk/main/include/ED25519PublicKey.h
@@ -23,6 +23,7 @@
 #include "PublicKey.h"
 
 #include <openssl/crypto.h>
+#include <openssl/evp.h>
 #include <vector>
 
 namespace Hedera
@@ -42,7 +43,7 @@ public:
   /**
    * Copy constructor and copy assignment operator can throw std::runtime_error if OpenSSL serialization fails.
    */
-  ~ED25519PublicKey() override;
+  ~ED25519PublicKey() override = default;
   ED25519PublicKey(const ED25519PublicKey& other);
   ED25519PublicKey& operator=(const ED25519PublicKey& other);
   ED25519PublicKey(ED25519PublicKey&& other) noexcept;
@@ -113,7 +114,7 @@ private:
    * @param keyBytes The bytes representing a ED25519PublicKey.
    * @return A pointer to a newly created OpenSSL keypair object.
    */
-  static EVP_PKEY* bytesToPKEY(const std::vector<unsigned char>& keyBytes);
+  static std::unique_ptr<EVP_PKEY, void (*)(EVP_PKEY*)> bytesToPKEY(const std::vector<unsigned char>& keyBytes);
 
   /**
    * Prepend an ED25519PublicKey's algorithm identifier to an array of serialized ED25519PublicKey bytes.
@@ -129,12 +130,12 @@ private:
    *
    * @param keypair The underlying OpenSSL keypair object from which to construct this ED25519PublicKey.
    */
-  explicit ED25519PublicKey(EVP_PKEY* publicKey);
+  explicit ED25519PublicKey(std::unique_ptr<EVP_PKEY, void (*)(EVP_PKEY*)>&& publicKey);
 
   /**
    * A pointer to the underlying OpenSSL keypair.
    */
-  EVP_PKEY* mPublicKey = nullptr;
+  std::unique_ptr<EVP_PKEY, void (*)(EVP_PKEY*)> mPublicKey = { nullptr, &EVP_PKEY_free };
 };
 
 } // namespace Hedera

--- a/sdk/main/include/impl/OpenSSLObjectWrapper.h
+++ b/sdk/main/include/impl/OpenSSLObjectWrapper.h
@@ -17,8 +17,8 @@
  * limitations under the License.
  *
  */
-#ifndef HEDERA_SDK_CPP_OPENSSL_OBJECT_WRAPPER_H_
-#define HEDERA_SDK_CPP_OPENSSL_OBJECT_WRAPPER_H_
+#ifndef HEDERA_SDK_CPP_IMPL_OPENSSL_OBJECT_WRAPPER_H_
+#define HEDERA_SDK_CPP_IMPL_OPENSSL_OBJECT_WRAPPER_H_
 
 #include <memory>
 #include <openssl/decoder.h>
@@ -247,4 +247,4 @@ public:
 
 } // namespace Hedera::internal
 
-#endif // HEDERA_SDK_CPP_OPENSSL_OBJECT_WRAPPER_H_
+#endif // HEDERA_SDK_CPP_IMPL_OPENSSL_OBJECT_WRAPPER_H_

--- a/sdk/main/include/impl/OpenSSLObjectWrapper.h
+++ b/sdk/main/include/impl/OpenSSLObjectWrapper.h
@@ -38,9 +38,9 @@ class OpenSSLObjectWrapper
 {
 public:
   /**
-   * Get the pointed-to raw OpenSSL object.
+   * Get the wrapped OpenSSL object.
    *
-   * @return A pointer to the wrapped OpenSSL object.
+   * @return A pointer to the wrapped OpenSSL object, nullptr if no object exists.
    */
   [[nodiscard]] ObjectType* get() const { return mObject.get(); }
 
@@ -55,7 +55,7 @@ protected:
   /**
    * Construct with values for the object and its custom deleter.
    *
-   * @param object  The OpenSSL object to which to point.
+   * @param object  The OpenSSL object to wrap.
    * @param deleter The custom deleter for the OpenSSL object.
    */
   OpenSSLObjectWrapper(ObjectType* object, DeleterType deleter)

--- a/sdk/main/include/impl/OpenSSLObjectWrapper.h
+++ b/sdk/main/include/impl/OpenSSLObjectWrapper.h
@@ -1,0 +1,250 @@
+/*-
+ *
+ * Hedera C++ SDK
+ *
+ * Copyright (C) 2020 - 2022 Hedera Hashgraph, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+#ifndef HEDERA_SDK_CPP_OPENSSL_OBJECT_WRAPPER_H_
+#define HEDERA_SDK_CPP_OPENSSL_OBJECT_WRAPPER_H_
+
+#include <memory>
+#include <openssl/decoder.h>
+#include <openssl/ec.h>
+#include <openssl/evp.h>
+
+namespace Hedera::internal
+{
+/**
+ * Templated base wrapper class to be used for OpenSSL objects that require custom deleter functions.
+ *
+ * @tparam ObjectType  The type of OpenSSL object this class should wrap.
+ * @tparam DeleterType The deleter type for the OpenSSL object.
+ */
+template<typename ObjectType, typename DeleterType>
+class OpenSSLObjectWrapper
+{
+public:
+  /**
+   * Get the pointed-to raw OpenSSL object.
+   *
+   * @return A pointer to the wrapped OpenSSL object.
+   */
+  [[nodiscard]] ObjectType* get() const { return mObject.get(); }
+
+  /**
+   * Determine if this OpenSSLObjectWrapper has a valid OpenSSL object.
+   *
+   * @return \c TRUE if there exists an OpenSSL object, otherwise \c FALSE.
+   */
+  [[nodiscard]] explicit operator bool() const { return mObject != nullptr; }
+
+protected:
+  /**
+   * Construct with values for the object and its custom deleter.
+   *
+   * @param object  The OpenSSL object to which to point.
+   * @param deleter The custom deleter for the OpenSSL object.
+   */
+  OpenSSLObjectWrapper(ObjectType* object, DeleterType deleter)
+    : mObject({ object, deleter })
+  {
+  }
+
+private:
+  /**
+   * Pointer to the OpenSSL object with its associated deleter.
+   */
+  std::unique_ptr<ObjectType, DeleterType> mObject = { nullptr, DeleterType() };
+};
+
+/**
+ * Wrapper class for the OpenSSL ECDSA_SIG object.
+ */
+class OpenSSL_ECDSA_SIG : public OpenSSLObjectWrapper<ECDSA_SIG, decltype(&ECDSA_SIG_free)>
+{
+public:
+  /**
+   * Default constructor sets the ECDSA_SIG_free deleter function.
+   */
+  OpenSSL_ECDSA_SIG()
+    : OpenSSLObjectWrapper(nullptr, &ECDSA_SIG_free)
+  {
+  }
+
+  /**
+   * Construct with the input ECDSA_SIG and its ECDSA_SIG_free deleter function.
+   *
+   * @param evpPkey The ECDSA_SIG OpenSSL object to wrap.
+   */
+  explicit OpenSSL_ECDSA_SIG(ECDSA_SIG* ecdsaSig)
+    : OpenSSLObjectWrapper(ecdsaSig, &ECDSA_SIG_free)
+  {
+  }
+};
+
+/**
+ * Wrapper class for the OpenSSL EVP_MD object.
+ */
+class OpenSSL_EVP_MD : public OpenSSLObjectWrapper<EVP_MD, decltype(&EVP_MD_free)>
+{
+public:
+  /**
+   * Default constructor sets the EVP_MD_free deleter function.
+   */
+  OpenSSL_EVP_MD()
+    : OpenSSLObjectWrapper(nullptr, &EVP_MD_free)
+  {
+  }
+
+  /**
+   * Construct with the input EVP_MD and its EVP_MD_free deleter function.
+   *
+   * @param evpPkey The EVP_MD OpenSSL object to wrap.
+   */
+  explicit OpenSSL_EVP_MD(EVP_MD* evpMd)
+    : OpenSSLObjectWrapper(evpMd, &EVP_MD_free)
+  {
+  }
+};
+
+/**
+ * Wrapper class for the OpenSSL EVP_MD_CTX object.
+ */
+class OpenSSL_EVP_MD_CTX : public OpenSSLObjectWrapper<EVP_MD_CTX, decltype(&EVP_MD_CTX_free)>
+{
+public:
+  /**
+   * Default constructor sets the EVP_MD_CTX_free deleter function.
+   */
+  OpenSSL_EVP_MD_CTX()
+    : OpenSSLObjectWrapper(nullptr, &EVP_MD_CTX_free)
+  {
+  }
+
+  /**
+   * Construct with the input EVP_MD_CTX and its EVP_MD_CTX_free deleter function.
+   *
+   * @param evpPkey The EVP_MD_CTX OpenSSL object to wrap.
+   */
+  explicit OpenSSL_EVP_MD_CTX(EVP_MD_CTX* evpMdCtx)
+    : OpenSSLObjectWrapper(evpMdCtx, &EVP_MD_CTX_free)
+  {
+  }
+};
+
+/**
+ * Wrapper class for the OpenSSL EVP_PKEY object.
+ */
+class OpenSSL_EVP_PKEY : public OpenSSLObjectWrapper<EVP_PKEY, decltype(&EVP_PKEY_free)>
+{
+public:
+  /**
+   * Default constructor sets the EVP_PKEY_free deleter function.
+   */
+  OpenSSL_EVP_PKEY()
+    : OpenSSLObjectWrapper(nullptr, &EVP_PKEY_free)
+  {
+  }
+
+  /**
+   * Construct with the input EVP_PKEY and its EVP_PKEY_free deleter function.
+   *
+   * @param evpPkey The EVP_PKEY OpenSSL object to wrap.
+   */
+  explicit OpenSSL_EVP_PKEY(EVP_PKEY* evpPkey)
+    : OpenSSLObjectWrapper(evpPkey, &EVP_PKEY_free)
+  {
+  }
+};
+
+/**
+ * Wrapper class for the OpenSSL EVP_PKEY_CTX object.
+ */
+class OpenSSL_EVP_PKEY_CTX : public OpenSSLObjectWrapper<EVP_PKEY_CTX, decltype(&EVP_PKEY_CTX_free)>
+{
+public:
+  /**
+   * Default constructor sets the EVP_PKEY_CTX_free deleter function.
+   */
+  OpenSSL_EVP_PKEY_CTX()
+    : OpenSSLObjectWrapper(nullptr, &EVP_PKEY_CTX_free)
+  {
+  }
+
+  /**
+   * Construct with the input EVP_PKEY_CTX and its EVP_PKEY_CTX_free deleter function.
+   *
+   * @param evpPkey The EVP_PKEY_CTX OpenSSL object to wrap.
+   */
+  explicit OpenSSL_EVP_PKEY_CTX(EVP_PKEY_CTX* evpPkeyCtx)
+    : OpenSSLObjectWrapper(evpPkeyCtx, &EVP_PKEY_CTX_free)
+  {
+  }
+};
+
+/**
+ * Wrapper class for the OpenSSL OSSL_LIB_CTX object.
+ */
+class OpenSSL_OSSL_LIB_CTX : public OpenSSLObjectWrapper<OSSL_LIB_CTX, decltype(&OSSL_LIB_CTX_free)>
+{
+public:
+  /**
+   * Default constructor sets the OSSL_LIB_CTX_free deleter function.
+   */
+  OpenSSL_OSSL_LIB_CTX()
+    : OpenSSLObjectWrapper(nullptr, &OSSL_LIB_CTX_free)
+  {
+  }
+
+  /**
+   * Construct with the input OSSL_LIB_CTX and its OSSL_LIB_CTX_free deleter function.
+   *
+   * @param evpPkey The OSSL_LIB_CTX OpenSSL object to wrap.
+   */
+  explicit OpenSSL_OSSL_LIB_CTX(OSSL_LIB_CTX* osslLibCtx)
+    : OpenSSLObjectWrapper(osslLibCtx, &OSSL_LIB_CTX_free)
+  {
+  }
+};
+
+/**
+ * Wrapper class for the OpenSSL OSSL_DECODER_CTX object.
+ */
+class OpenSSL_OSSL_DECODER_CTX : public OpenSSLObjectWrapper<OSSL_DECODER_CTX, decltype(&OSSL_DECODER_CTX_free)>
+{
+public:
+  /**
+   * Default constructor sets the OSSL_DECODER_CTX_free deleter function.
+   */
+  OpenSSL_OSSL_DECODER_CTX()
+    : OpenSSLObjectWrapper(nullptr, &OSSL_DECODER_CTX_free)
+  {
+  }
+
+  /**
+   * Construct with the input OSSL_DECODER_CTX and its OSSL_DECODER_CTX_free deleter function.
+   *
+   * @param evpPkey The OSSL_DECODER_CTX OpenSSL object to wrap.
+   */
+  explicit OpenSSL_OSSL_DECODER_CTX(OSSL_DECODER_CTX* osslDecoderCtx)
+    : OpenSSLObjectWrapper(osslDecoderCtx, &OSSL_DECODER_CTX_free)
+  {
+  }
+};
+
+} // namespace Hedera::internal
+
+#endif // HEDERA_SDK_CPP_OPENSSL_OBJECT_WRAPPER_H_

--- a/sdk/main/include/impl/OpenSSLObjectWrapper.h
+++ b/sdk/main/include/impl/OpenSSLObjectWrapper.h
@@ -77,17 +77,9 @@ class OpenSSL_ECDSA_SIG : public OpenSSLObjectWrapper<ECDSA_SIG, decltype(&ECDSA
 {
 public:
   /**
-   * Default constructor sets the ECDSA_SIG_free deleter function.
-   */
-  OpenSSL_ECDSA_SIG()
-    : OpenSSLObjectWrapper(nullptr, &ECDSA_SIG_free)
-  {
-  }
-
-  /**
    * Construct with the input ECDSA_SIG and its ECDSA_SIG_free deleter function.
    *
-   * @param evpPkey The ECDSA_SIG OpenSSL object to wrap.
+   * @param ecdsaSig The ECDSA_SIG OpenSSL object to wrap.
    */
   explicit OpenSSL_ECDSA_SIG(ECDSA_SIG* ecdsaSig)
     : OpenSSLObjectWrapper(ecdsaSig, &ECDSA_SIG_free)
@@ -102,17 +94,9 @@ class OpenSSL_EVP_MD : public OpenSSLObjectWrapper<EVP_MD, decltype(&EVP_MD_free
 {
 public:
   /**
-   * Default constructor sets the EVP_MD_free deleter function.
-   */
-  OpenSSL_EVP_MD()
-    : OpenSSLObjectWrapper(nullptr, &EVP_MD_free)
-  {
-  }
-
-  /**
    * Construct with the input EVP_MD and its EVP_MD_free deleter function.
    *
-   * @param evpPkey The EVP_MD OpenSSL object to wrap.
+   * @param evpMd The EVP_MD OpenSSL object to wrap.
    */
   explicit OpenSSL_EVP_MD(EVP_MD* evpMd)
     : OpenSSLObjectWrapper(evpMd, &EVP_MD_free)
@@ -127,17 +111,9 @@ class OpenSSL_EVP_MD_CTX : public OpenSSLObjectWrapper<EVP_MD_CTX, decltype(&EVP
 {
 public:
   /**
-   * Default constructor sets the EVP_MD_CTX_free deleter function.
-   */
-  OpenSSL_EVP_MD_CTX()
-    : OpenSSLObjectWrapper(nullptr, &EVP_MD_CTX_free)
-  {
-  }
-
-  /**
    * Construct with the input EVP_MD_CTX and its EVP_MD_CTX_free deleter function.
    *
-   * @param evpPkey The EVP_MD_CTX OpenSSL object to wrap.
+   * @param evpMdCtx The EVP_MD_CTX OpenSSL object to wrap.
    */
   explicit OpenSSL_EVP_MD_CTX(EVP_MD_CTX* evpMdCtx)
     : OpenSSLObjectWrapper(evpMdCtx, &EVP_MD_CTX_free)
@@ -151,14 +127,6 @@ public:
 class OpenSSL_EVP_PKEY : public OpenSSLObjectWrapper<EVP_PKEY, decltype(&EVP_PKEY_free)>
 {
 public:
-  /**
-   * Default constructor sets the EVP_PKEY_free deleter function.
-   */
-  OpenSSL_EVP_PKEY()
-    : OpenSSLObjectWrapper(nullptr, &EVP_PKEY_free)
-  {
-  }
-
   /**
    * Construct with the input EVP_PKEY and its EVP_PKEY_free deleter function.
    *
@@ -177,17 +145,9 @@ class OpenSSL_EVP_PKEY_CTX : public OpenSSLObjectWrapper<EVP_PKEY_CTX, decltype(
 {
 public:
   /**
-   * Default constructor sets the EVP_PKEY_CTX_free deleter function.
-   */
-  OpenSSL_EVP_PKEY_CTX()
-    : OpenSSLObjectWrapper(nullptr, &EVP_PKEY_CTX_free)
-  {
-  }
-
-  /**
    * Construct with the input EVP_PKEY_CTX and its EVP_PKEY_CTX_free deleter function.
    *
-   * @param evpPkey The EVP_PKEY_CTX OpenSSL object to wrap.
+   * @param evpPkeyCtx The EVP_PKEY_CTX OpenSSL object to wrap.
    */
   explicit OpenSSL_EVP_PKEY_CTX(EVP_PKEY_CTX* evpPkeyCtx)
     : OpenSSLObjectWrapper(evpPkeyCtx, &EVP_PKEY_CTX_free)
@@ -202,17 +162,9 @@ class OpenSSL_OSSL_LIB_CTX : public OpenSSLObjectWrapper<OSSL_LIB_CTX, decltype(
 {
 public:
   /**
-   * Default constructor sets the OSSL_LIB_CTX_free deleter function.
-   */
-  OpenSSL_OSSL_LIB_CTX()
-    : OpenSSLObjectWrapper(nullptr, &OSSL_LIB_CTX_free)
-  {
-  }
-
-  /**
    * Construct with the input OSSL_LIB_CTX and its OSSL_LIB_CTX_free deleter function.
    *
-   * @param evpPkey The OSSL_LIB_CTX OpenSSL object to wrap.
+   * @param osslLibCtx The OSSL_LIB_CTX OpenSSL object to wrap.
    */
   explicit OpenSSL_OSSL_LIB_CTX(OSSL_LIB_CTX* osslLibCtx)
     : OpenSSLObjectWrapper(osslLibCtx, &OSSL_LIB_CTX_free)
@@ -227,17 +179,9 @@ class OpenSSL_OSSL_DECODER_CTX : public OpenSSLObjectWrapper<OSSL_DECODER_CTX, d
 {
 public:
   /**
-   * Default constructor sets the OSSL_DECODER_CTX_free deleter function.
-   */
-  OpenSSL_OSSL_DECODER_CTX()
-    : OpenSSLObjectWrapper(nullptr, &OSSL_DECODER_CTX_free)
-  {
-  }
-
-  /**
    * Construct with the input OSSL_DECODER_CTX and its OSSL_DECODER_CTX_free deleter function.
    *
-   * @param evpPkey The OSSL_DECODER_CTX OpenSSL object to wrap.
+   * @param osslDecoderCtx The OSSL_DECODER_CTX OpenSSL object to wrap.
    */
   explicit OpenSSL_OSSL_DECODER_CTX(OSSL_DECODER_CTX* osslDecoderCtx)
     : OpenSSLObjectWrapper(osslDecoderCtx, &OSSL_DECODER_CTX_free)

--- a/sdk/main/src/ED25519PublicKey.cc
+++ b/sdk/main/src/ED25519PublicKey.cc
@@ -34,12 +34,6 @@ const inline std::vector<unsigned char> ALGORITHM_IDENTIFIER_BYTES =
 }
 
 //-----
-ED25519PublicKey::~ED25519PublicKey()
-{
-  EVP_PKEY_free(mPublicKey);
-}
-
-//-----
 ED25519PublicKey::ED25519PublicKey(const ED25519PublicKey& other)
   : mPublicKey(bytesToPKEY(other.toBytes()))
 {
@@ -50,11 +44,6 @@ ED25519PublicKey& ED25519PublicKey::operator=(const ED25519PublicKey& other)
 {
   if (this != &other)
   {
-    if (mPublicKey)
-    {
-      EVP_PKEY_free(mPublicKey);
-    }
-
     mPublicKey = bytesToPKEY(other.toBytes());
   }
 
@@ -63,22 +52,14 @@ ED25519PublicKey& ED25519PublicKey::operator=(const ED25519PublicKey& other)
 
 //-----
 ED25519PublicKey::ED25519PublicKey(ED25519PublicKey&& other) noexcept
-  : mPublicKey(other.mPublicKey)
+  : mPublicKey(std::move(other.mPublicKey))
 {
-  other.mPublicKey = nullptr;
 }
 
 //-----
 ED25519PublicKey& ED25519PublicKey::operator=(ED25519PublicKey&& other) noexcept
 {
-  if (mPublicKey)
-  {
-    EVP_PKEY_free(mPublicKey);
-  }
-
-  mPublicKey = other.mPublicKey;
-  other.mPublicKey = nullptr;
-
+  mPublicKey = std::move(other.mPublicKey);
   return *this;
 }
 
@@ -105,27 +86,23 @@ std::unique_ptr<PublicKey> ED25519PublicKey::clone() const
 bool ED25519PublicKey::verifySignature(const std::vector<unsigned char>& signatureBytes,
                                        const std::vector<unsigned char>& signedBytes) const
 {
-  EVP_MD_CTX* messageDigestContext = EVP_MD_CTX_new();
-
+  const std::unique_ptr<EVP_MD_CTX, void (*)(EVP_MD_CTX*)> messageDigestContext = { EVP_MD_CTX_new(),
+                                                                                    &EVP_MD_CTX_free };
   if (!messageDigestContext)
   {
     throw std::runtime_error("Digest context construction failed");
   }
 
-  if (EVP_DigestVerifyInit(messageDigestContext, nullptr, nullptr, nullptr, mPublicKey) <= 0)
+  if (EVP_DigestVerifyInit(messageDigestContext.get(), nullptr, nullptr, nullptr, mPublicKey.get()) <= 0)
   {
-    EVP_MD_CTX_free(messageDigestContext);
     throw std::runtime_error("Digest verify initialization failed");
   }
 
-  int verificationResult = EVP_DigestVerify(messageDigestContext,
-                                            (!signatureBytes.empty()) ? &signatureBytes.front() : nullptr,
-                                            signatureBytes.size(),
-                                            (!signedBytes.empty()) ? &signedBytes.front() : nullptr,
-                                            signedBytes.size());
-
-  EVP_MD_CTX_free(messageDigestContext);
-
+  const int verificationResult = EVP_DigestVerify(messageDigestContext.get(),
+                                                  (!signatureBytes.empty()) ? &signatureBytes.front() : nullptr,
+                                                  signatureBytes.size(),
+                                                  (!signedBytes.empty()) ? &signedBytes.front() : nullptr,
+                                                  signedBytes.size());
   if (verificationResult <= 0)
   {
     std::string message = "Failed to verify signature with code [" + std::to_string(verificationResult) + ']';
@@ -153,11 +130,11 @@ std::string ED25519PublicKey::toString() const
 //-----
 std::vector<unsigned char> ED25519PublicKey::toBytes() const
 {
-  int bytesLength = i2d_PUBKEY(mPublicKey, nullptr);
+  int bytesLength = i2d_PUBKEY(mPublicKey.get(), nullptr);
 
   std::vector<unsigned char> publicKeyBytes(bytesLength);
 
-  if (unsigned char* rawPublicKeyBytes = &publicKeyBytes.front(); i2d_PUBKEY(mPublicKey, &rawPublicKeyBytes) <= 0)
+  if (unsigned char* rawPublicKeyBytes = &publicKeyBytes.front(); i2d_PUBKEY(mPublicKey.get(), &rawPublicKeyBytes) <= 0)
   {
     throw std::runtime_error("ED25519PublicKey serialization error");
   }
@@ -167,7 +144,7 @@ std::vector<unsigned char> ED25519PublicKey::toBytes() const
 }
 
 //-----
-EVP_PKEY* ED25519PublicKey::bytesToPKEY(const std::vector<unsigned char>& keyBytes)
+std::unique_ptr<EVP_PKEY, void (*)(EVP_PKEY*)> ED25519PublicKey::bytesToPKEY(const std::vector<unsigned char>& keyBytes)
 {
   std::vector<unsigned char> fullKeyBytes;
   // If there are only 32 key bytes, we need to add the algorithm identifier bytes, so that OpenSSL can correctly decode
@@ -186,7 +163,7 @@ EVP_PKEY* ED25519PublicKey::bytesToPKEY(const std::vector<unsigned char>& keyByt
   }
 
   const unsigned char* rawKeyBytes = &fullKeyBytes.front();
-  return d2i_PUBKEY(nullptr, &rawKeyBytes, static_cast<long>(fullKeyBytes.size()));
+  return { d2i_PUBKEY(nullptr, &rawKeyBytes, static_cast<long>(fullKeyBytes.size())), &EVP_PKEY_free };
 }
 
 //-----
@@ -202,8 +179,8 @@ std::vector<unsigned char> ED25519PublicKey::prependAlgorithmIdentifier(const st
 }
 
 //-----
-ED25519PublicKey::ED25519PublicKey(EVP_PKEY* publicKey)
-  : mPublicKey(publicKey)
+ED25519PublicKey::ED25519PublicKey(std::unique_ptr<EVP_PKEY, void (*)(EVP_PKEY*)>&& publicKey)
+  : mPublicKey(std::move(publicKey))
 {
 }
 


### PR DESCRIPTION
**Description**:
This PR consolidates OpenSSL memory management by utilizing `std::unique_ptr` with a custom deleter to automatically handle freeing memory when exiting scope.

**Related issue(s)**:

Fixes #173 

**Checklist**

- [X] Documented (Code comments, README, etc.)
- [X] Tested (unit, integration, etc.)
