### PR TITLE
Conform differences in `verifySignature` for `ECDSAsecp256k1PublicKey` and `ED25519PublicKey`

### DIFF
--- a/sdk/main/include/ECDSAsecp256k1PublicKey.h
+++ b/sdk/main/include/ECDSAsecp256k1PublicKey.h
@@ -96,7 +96,7 @@ public:
    *
    * @param signatureBytes The byte vector representing the signature.
    * @param signedBytes    The bytes which were purportedly signed to create the signature.
-   * @return \c TRUE if the signature is valid, otherwise \c FALSE.
+   * @return \c TRUE if the signature is valid for this ECDSAsecp256k1PublicKey's private key, otherwise \c FALSE.
    * @throws std::runtime_error If OpenSSL signature verification experiences an error.
    */
   [[nodiscard]] bool verifySignature(const std::vector<unsigned char>& signatureBytes,

--- a/sdk/main/include/ED25519PublicKey.h
+++ b/sdk/main/include/ED25519PublicKey.h
@@ -79,8 +79,8 @@ public:
    *
    * @param signatureBytes The byte vector representing the signature.
    * @param signedBytes    The bytes which were purportedly signed to create the signature.
-   * @return \c TRUE if the signature is valid, otherwise \c FALSE.
-   * @throws std::runtime_error If OpenSSL signature verification fails.
+   * @return \c TRUE if the signature is valid for this ED25519PublicKey's private key, otherwise \c FALSE.
+   * @throws std::runtime_error If OpenSSL signature verification experiences an error.
    */
   [[nodiscard]] bool verifySignature(const std::vector<unsigned char>& signatureBytes,
                                      const std::vector<unsigned char>& signedBytes) const override;

--- a/sdk/main/src/ED25519PublicKey.cc
+++ b/sdk/main/src/ED25519PublicKey.cc
@@ -19,6 +19,7 @@
  */
 #include "ED25519PublicKey.h"
 #include "impl/HexConverter.h"
+#include "impl/OpenSSLHasher.h"
 
 #include <iostream>
 #include <openssl/err.h>
@@ -102,10 +103,11 @@ bool ED25519PublicKey::verifySignature(const std::vector<unsigned char>& signatu
                                                   signatureBytes.size(),
                                                   (!signedBytes.empty()) ? &signedBytes.front() : nullptr,
                                                   signedBytes.size());
-  if (verificationResult <= 0)
+
+  // any value other than 0 or 1 means an error occurred
+  if (verificationResult != 0 && verificationResult != 1)
   {
-    std::string message = "Failed to verify signature with code [" + std::to_string(verificationResult) + ']';
-    throw std::runtime_error(message.c_str());
+    throw std::runtime_error(internal::OpenSSLHasher::getOpenSSLErrorMessage("EVP_DigestVerify"));
   }
 
   return verificationResult == 1;

--- a/sdk/tests/ED25519PublicKeyTest.cc
+++ b/sdk/tests/ED25519PublicKeyTest.cc
@@ -122,9 +122,9 @@ TEST_F(ED25519PublicKeyTest, VerifySignatureAgainstModifiedBytes)
   const std::vector<unsigned char> signature = getTestPrivateKey()->sign({ 0x1, 0x2, 0x3 });
   const std::vector<unsigned char> modifiedBytes = { 0x1, 0x2, 0x3, 0x4 };
 
-  EXPECT_THROW(getTestPublicKeyFromPrivate()->verifySignature(signature, modifiedBytes), std::runtime_error);
-  EXPECT_THROW(getTestPublicKeyFromString()->verifySignature(signature, modifiedBytes), std::runtime_error);
-  EXPECT_THROW(getTestPublicKeyFromProtobuf()->verifySignature(signature, modifiedBytes), std::runtime_error);
+  EXPECT_FALSE(getTestPublicKeyFromPrivate()->verifySignature(signature, modifiedBytes));
+  EXPECT_FALSE(getTestPublicKeyFromString()->verifySignature(signature, modifiedBytes));
+  EXPECT_FALSE(getTestPublicKeyFromProtobuf()->verifySignature(signature, modifiedBytes));
 }
 
 TEST_F(ED25519PublicKeyTest, VerifyArbitrarySignature)
@@ -132,9 +132,9 @@ TEST_F(ED25519PublicKeyTest, VerifyArbitrarySignature)
   const std::vector<unsigned char> bytesToSign = { 0x1, 0x2, 0x3 };
   const std::vector<unsigned char> arbitrarySignature = { 0x1, 0x2, 0x3, 0x4 };
 
-  EXPECT_THROW(getTestPublicKeyFromPrivate()->verifySignature(arbitrarySignature, bytesToSign), std::runtime_error);
-  EXPECT_THROW(getTestPublicKeyFromString()->verifySignature(arbitrarySignature, bytesToSign), std::runtime_error);
-  EXPECT_THROW(getTestPublicKeyFromProtobuf()->verifySignature(arbitrarySignature, bytesToSign), std::runtime_error);
+  EXPECT_FALSE(getTestPublicKeyFromPrivate()->verifySignature(arbitrarySignature, bytesToSign));
+  EXPECT_FALSE(getTestPublicKeyFromString()->verifySignature(arbitrarySignature, bytesToSign));
+  EXPECT_FALSE(getTestPublicKeyFromProtobuf()->verifySignature(arbitrarySignature, bytesToSign));
 }
 
 TEST_F(ED25519PublicKeyTest, VerifyEmptySignature)
@@ -142,9 +142,9 @@ TEST_F(ED25519PublicKeyTest, VerifyEmptySignature)
   const std::vector<unsigned char> bytesToSign = { 0x1, 0x2, 0x3 };
   const std::vector<unsigned char> emptySignature;
 
-  EXPECT_THROW(getTestPublicKeyFromPrivate()->verifySignature(emptySignature, bytesToSign), std::runtime_error);
-  EXPECT_THROW(getTestPublicKeyFromString()->verifySignature(emptySignature, bytesToSign), std::runtime_error);
-  EXPECT_THROW(getTestPublicKeyFromProtobuf()->verifySignature(emptySignature, bytesToSign), std::runtime_error);
+  EXPECT_FALSE(getTestPublicKeyFromPrivate()->verifySignature(emptySignature, bytesToSign));
+  EXPECT_FALSE(getTestPublicKeyFromString()->verifySignature(emptySignature, bytesToSign));
+  EXPECT_FALSE(getTestPublicKeyFromProtobuf()->verifySignature(emptySignature, bytesToSign));
 }
 
 TEST_F(ED25519PublicKeyTest, VerifyEmptyMessage)
@@ -152,9 +152,9 @@ TEST_F(ED25519PublicKeyTest, VerifyEmptyMessage)
   const std::vector<unsigned char> signature = getTestPrivateKey()->sign({ 0x1, 0x2, 0x3 });
   const std::vector<unsigned char> emptyMessage;
 
-  EXPECT_THROW(getTestPublicKeyFromPrivate()->verifySignature(signature, emptyMessage), std::runtime_error);
-  EXPECT_THROW(getTestPublicKeyFromString()->verifySignature(signature, emptyMessage), std::runtime_error);
-  EXPECT_THROW(getTestPublicKeyFromProtobuf()->verifySignature(signature, emptyMessage), std::runtime_error);
+  EXPECT_FALSE(getTestPublicKeyFromPrivate()->verifySignature(signature, emptyMessage));
+  EXPECT_FALSE(getTestPublicKeyFromString()->verifySignature(signature, emptyMessage));
+  EXPECT_FALSE(getTestPublicKeyFromProtobuf()->verifySignature(signature, emptyMessage));
 }
 
 TEST_F(ED25519PublicKeyTest, FromString)


### PR DESCRIPTION
**Description**:
This PR fixes a difference in the `verifySignature` function for our derived `PublicKey` classes, where `false` should be returned if the signature was verified to not be correct, as opposed to throwing an error. Tests were updated to reflect this error as well.

**Related issue(s)**:

Fixes #193 

- [X] Documented (Code comments, README, etc.)
- [X] Tested (unit, integration, etc.)
