### PR TITLE
Conform to SDK standard for generating `PrivateKey`s from `Mnemonic`

### DIFF
--- a/sdk/examples/GeneratePrivateKeyFromMnemonic.cc
+++ b/sdk/examples/GeneratePrivateKeyFromMnemonic.cc
@@ -42,7 +42,7 @@ int main(int argc, char** argv)
   // Generate and print a ED25519PrivateKey and ECDSAsecp256k1PrivateKey from the mnemonic with no passphrase
   std::unique_ptr<ED25519PrivateKey> ed25519PrivateKey = mnemonicBip39.toStandardEd25519PrivateKey();
   std::unique_ptr<ECDSAsecp256k1PrivateKey> ecdsaSecp256k1PrivateKey =
-    mnemonicBip39.toStandardEcdsaSecp256k1PrivateKey();
+    mnemonicBip39.toStandardECDSAsecp256k1PrivateKey();
   std::cout << "Generated ED25519PrivateKey from mnemonic with no passphrase: " << ed25519PrivateKey->toString()
             << std::endl;
   std::cout << "Generated ECDSAsecp256k1PrivateKey from mnemonic with no passphrase: "
@@ -50,7 +50,7 @@ int main(int argc, char** argv)
 
   // Generate and print a ED25519PrivateKey and ECDSAsecp256k1PrivateKey from the mnemonic with a passphrase
   ed25519PrivateKey = mnemonicBip39.toStandardEd25519PrivateKey(passphrase);
-  ecdsaSecp256k1PrivateKey = mnemonicBip39.toStandardEcdsaSecp256k1PrivateKey(passphrase);
+  ecdsaSecp256k1PrivateKey = mnemonicBip39.toStandardECDSAsecp256k1PrivateKey(passphrase);
   std::cout << "Generated ED25519PrivateKey from mnemonic with passphrase '" << passphrase
             << "': " << ed25519PrivateKey->toString() << std::endl;
   std::cout << "Generated ECDSAsecp256k1PrivateKey from mnemonic with passphrase '" << passphrase
@@ -65,7 +65,7 @@ int main(int argc, char** argv)
 
   // Generate and print a ED25519PrivateKey and ECDSAsecp256k1PrivateKey from the mnemonic with no passphrase
   ed25519PrivateKey = mnemonicBip39.toStandardEd25519PrivateKey();
-  ecdsaSecp256k1PrivateKey = mnemonicBip39.toStandardEcdsaSecp256k1PrivateKey();
+  ecdsaSecp256k1PrivateKey = mnemonicBip39.toStandardECDSAsecp256k1PrivateKey();
   std::cout << "Generated ED25519PrivateKey from mnemonic with no passphrase: " << ed25519PrivateKey->toString()
             << std::endl;
   std::cout << "Generated ECDSAsecp256k1PrivateKey from mnemonic with no passphrase: "
@@ -73,7 +73,7 @@ int main(int argc, char** argv)
 
   // Generate and print a ED25519PrivateKey and ECDSAsecp256k1PrivateKey from the mnemonic with a passphrase
   ed25519PrivateKey = mnemonicBip39.toStandardEd25519PrivateKey(passphrase);
-  ecdsaSecp256k1PrivateKey = mnemonicBip39.toStandardEcdsaSecp256k1PrivateKey(passphrase);
+  ecdsaSecp256k1PrivateKey = mnemonicBip39.toStandardECDSAsecp256k1PrivateKey(passphrase);
   std::cout << "Generated ED25519PrivateKey from mnemonic with passphrase '" << passphrase
             << "': " << ed25519PrivateKey->toString() << std::endl;
   std::cout << "Generated ECDSAsecp256k1PrivateKey from mnemonic with passphrase '" << passphrase

--- a/sdk/examples/GeneratePrivateKeyFromMnemonic.cc
+++ b/sdk/examples/GeneratePrivateKeyFromMnemonic.cc
@@ -40,17 +40,17 @@ int main(int argc, char** argv)
   std::cout << "Generated 12-word MnemonicBIP39: " << mnemonicBip39.toString() << std::endl;
 
   // Generate and print a ED25519PrivateKey and ECDSAsecp256k1PrivateKey from the mnemonic with no passphrase
-  std::unique_ptr<ED25519PrivateKey> ed25519PrivateKey = ED25519PrivateKey::fromBIP39Mnemonic(mnemonicBip39, "");
+  std::unique_ptr<ED25519PrivateKey> ed25519PrivateKey = mnemonicBip39.toStandardEd25519PrivateKey();
   std::unique_ptr<ECDSAsecp256k1PrivateKey> ecdsaSecp256k1PrivateKey =
-    ECDSAsecp256k1PrivateKey::fromBIP39Mnemonic(mnemonicBip39, "");
+    mnemonicBip39.toStandardEcdsaSecp256k1PrivateKey();
   std::cout << "Generated ED25519PrivateKey from mnemonic with no passphrase: " << ed25519PrivateKey->toString()
             << std::endl;
   std::cout << "Generated ECDSAsecp256k1PrivateKey from mnemonic with no passphrase: "
             << ecdsaSecp256k1PrivateKey->toString() << std::endl;
 
   // Generate and print a ED25519PrivateKey and ECDSAsecp256k1PrivateKey from the mnemonic with a passphrase
-  ed25519PrivateKey = ED25519PrivateKey::fromBIP39Mnemonic(mnemonicBip39, passphrase);
-  ecdsaSecp256k1PrivateKey = ECDSAsecp256k1PrivateKey::fromBIP39Mnemonic(mnemonicBip39, passphrase);
+  ed25519PrivateKey = mnemonicBip39.toStandardEd25519PrivateKey(passphrase);
+  ecdsaSecp256k1PrivateKey = mnemonicBip39.toStandardEcdsaSecp256k1PrivateKey(passphrase);
   std::cout << "Generated ED25519PrivateKey from mnemonic with passphrase '" << passphrase
             << "': " << ed25519PrivateKey->toString() << std::endl;
   std::cout << "Generated ECDSAsecp256k1PrivateKey from mnemonic with passphrase '" << passphrase
@@ -64,16 +64,16 @@ int main(int argc, char** argv)
   std::cout << "Generated 24-word MnemonicBIP39: " << mnemonicBip39.toString() << std::endl;
 
   // Generate and print a ED25519PrivateKey and ECDSAsecp256k1PrivateKey from the mnemonic with no passphrase
-  ed25519PrivateKey = ED25519PrivateKey::fromBIP39Mnemonic(mnemonicBip39, "");
-  ecdsaSecp256k1PrivateKey = ECDSAsecp256k1PrivateKey::fromBIP39Mnemonic(mnemonicBip39, "");
+  ed25519PrivateKey = mnemonicBip39.toStandardEd25519PrivateKey();
+  ecdsaSecp256k1PrivateKey = mnemonicBip39.toStandardEcdsaSecp256k1PrivateKey();
   std::cout << "Generated ED25519PrivateKey from mnemonic with no passphrase: " << ed25519PrivateKey->toString()
             << std::endl;
   std::cout << "Generated ECDSAsecp256k1PrivateKey from mnemonic with no passphrase: "
             << ecdsaSecp256k1PrivateKey->toString() << std::endl;
 
   // Generate and print a ED25519PrivateKey and ECDSAsecp256k1PrivateKey from the mnemonic with a passphrase
-  ed25519PrivateKey = ED25519PrivateKey::fromBIP39Mnemonic(mnemonicBip39, passphrase);
-  ecdsaSecp256k1PrivateKey = ECDSAsecp256k1PrivateKey::fromBIP39Mnemonic(mnemonicBip39, passphrase);
+  ed25519PrivateKey = mnemonicBip39.toStandardEd25519PrivateKey(passphrase);
+  ecdsaSecp256k1PrivateKey = mnemonicBip39.toStandardEcdsaSecp256k1PrivateKey(passphrase);
   std::cout << "Generated ED25519PrivateKey from mnemonic with passphrase '" << passphrase
             << "': " << ed25519PrivateKey->toString() << std::endl;
   std::cout << "Generated ECDSAsecp256k1PrivateKey from mnemonic with passphrase '" << passphrase

--- a/sdk/main/include/ECDSAsecp256k1PrivateKey.h
+++ b/sdk/main/include/ECDSAsecp256k1PrivateKey.h
@@ -72,16 +72,6 @@ public:
   static std::unique_ptr<ECDSAsecp256k1PrivateKey> fromString(const std::string& keyString);
 
   /**
-   * Recover an ECDSAsecp256k1PrivateKey from a BIP39 mnemonic phrase and passphrase.
-   *
-   * @param mnemonic   The mnemonic phrase from which to recover the ECDSAsecp256k1PrivateKey.
-   * @param passphrase The passphrase from which to recover the ECDSAsecp256k1PrivateKey.
-   * @return A pointer to the recovered ECDSAsecp256k1PrivateKey.
-   */
-  static std::unique_ptr<ECDSAsecp256k1PrivateKey> fromBIP39Mnemonic(const MnemonicBIP39& mnemonic,
-                                                                     const std::string& passphrase);
-
-  /**
    * Derive an ECDSAsecp256k1PrivateKey from a seed array.
    *
    * @param seed The array seed from which to derive the ECDSAsecp256k1PrivateKey.

--- a/sdk/main/include/ED25519PrivateKey.h
+++ b/sdk/main/include/ED25519PrivateKey.h
@@ -72,16 +72,6 @@ public:
   static std::unique_ptr<ED25519PrivateKey> fromString(const std::string& keyString);
 
   /**
-   * Recover an ED25519PrivateKey from a BIP39 mnemonic phrase and passphrase.
-   *
-   * @param mnemonic   The mnemonic phrase from which to recover the ED25519PrivateKey.
-   * @param passphrase The passphrase from which to recover the ED25519PrivateKey.
-   * @return A pointer to the recovered ED25519PrivateKey.
-   */
-  static std::unique_ptr<ED25519PrivateKey> fromBIP39Mnemonic(const MnemonicBIP39& mnemonic,
-                                                              const std::string& passphrase);
-
-  /**
    * Derive an ED25519PrivateKey from a seed array.
    *
    * @param seed The array seed from which to derive the ED25519PrivateKey.

--- a/sdk/main/include/MnemonicBIP39.h
+++ b/sdk/main/include/MnemonicBIP39.h
@@ -22,6 +22,7 @@
 
 #include "Mnemonic.h"
 
+#include <memory>
 #include <string>
 #include <vector>
 

--- a/sdk/main/include/MnemonicBIP39.h
+++ b/sdk/main/include/MnemonicBIP39.h
@@ -83,8 +83,9 @@ public:
    * Generate an ED25519PrivateKey from this Mnemonic using the input passphrase at the specified index.
    *
    * @param passphrase The passphrase to use to generate the ED25519PrivateKey.
-   * @param index      The index in the derivation path from which to derive the ED25519PrivateKey.
+   * @param index      The unhardened index in the derivation path from which to derive the ED25519PrivateKey.
    * @return A pointer to the derived ED25519PrivateKey.
+   * @throws std::runtime_error If the index is already hardened.
    */
   [[nodiscard]] std::unique_ptr<ED25519PrivateKey> toStandardEd25519PrivateKey(const std::string& passphrase = "",
                                                                                int index = 0) const;
@@ -96,7 +97,7 @@ public:
    * @param index      The index in the derivation path from which to derive the ECDSAsecp256k1PrivateKey.
    * @return A pointer to the derived ECDSAsecp256k1PrivateKey.
    */
-  [[nodiscard]] std::unique_ptr<ECDSAsecp256k1PrivateKey> toStandardEcdsaSecp256k1PrivateKey(
+  [[nodiscard]] std::unique_ptr<ECDSAsecp256k1PrivateKey> toStandardECDSAsecp256k1PrivateKey(
     const std::string& passphrase = "",
     int index = 0) const;
 

--- a/sdk/main/include/MnemonicBIP39.h
+++ b/sdk/main/include/MnemonicBIP39.h
@@ -27,6 +27,12 @@
 
 namespace Hedera
 {
+class ECDSAsecp256k1PrivateKey;
+class ED25519PrivateKey;
+}
+
+namespace Hedera
+{
 /**
  * A standard BIP39 mnemonic.
  */
@@ -72,6 +78,27 @@ public:
    * @return The newly-generated MnemonicBIP39.
    */
   static MnemonicBIP39 generate24WordBIP39Mnemonic();
+
+  /**
+   * Generate an ED25519PrivateKey from this Mnemonic using the input passphrase at the specified index.
+   *
+   * @param passphrase The passphrase to use to generate the ED25519PrivateKey.
+   * @param index      The index in the derivation path from which to derive the ED25519PrivateKey.
+   * @return A pointer to the derived ED25519PrivateKey.
+   */
+  [[nodiscard]] std::unique_ptr<ED25519PrivateKey> toStandardEd25519PrivateKey(const std::string& passphrase = "",
+                                                                               int index = 0) const;
+
+  /**
+   * Generate an ECDSAsecp256k1PrivateKey from this Mnemonic using the input passphrase at the specified index.
+   *
+   * @param passphrase The passphrase to use to generate the ECDSAsecp256k1PrivateKey.
+   * @param index      The index in the derivation path from which to derive the ECDSAsecp256k1PrivateKey.
+   * @return A pointer to the derived ECDSAsecp256k1PrivateKey.
+   */
+  [[nodiscard]] std::unique_ptr<ECDSAsecp256k1PrivateKey> toStandardEcdsaSecp256k1PrivateKey(
+    const std::string& passphrase = "",
+    int index = 0) const;
 
   /**
    * Compute a seed that results from this MnemonicBIP39.

--- a/sdk/main/src/ECDSAsecp256k1PrivateKey.cc
+++ b/sdk/main/src/ECDSAsecp256k1PrivateKey.cc
@@ -95,13 +95,6 @@ std::unique_ptr<ECDSAsecp256k1PrivateKey> ECDSAsecp256k1PrivateKey::fromString(c
 }
 
 //-----
-std::unique_ptr<ECDSAsecp256k1PrivateKey> ECDSAsecp256k1PrivateKey::fromBIP39Mnemonic(const MnemonicBIP39& mnemonic,
-                                                                                      const std::string& passphrase)
-{
-  return fromSeed(mnemonic.toSeed(passphrase));
-}
-
-//-----
 std::unique_ptr<ECDSAsecp256k1PrivateKey> ECDSAsecp256k1PrivateKey::fromSeed(const std::vector<unsigned char>& seed)
 {
   static const std::string keyString = "Bitcoin seed"; // as defined by BIP 32

--- a/sdk/main/src/MnemonicBIP39.cc
+++ b/sdk/main/src/MnemonicBIP39.cc
@@ -18,6 +18,9 @@
  *
  */
 #include "MnemonicBIP39.h"
+#include "ECDSAsecp256k1PrivateKey.h"
+#include "ED25519PrivateKey.h"
+#include "impl/DerivationPathUtils.h"
 #include "impl/OpenSSLHasher.h"
 #include "impl/OpenSSLRandom.h"
 
@@ -80,6 +83,26 @@ MnemonicBIP39 MnemonicBIP39::generate24WordBIP39Mnemonic()
 {
   // BIP39 dictates 32 bytes of entropy for 24 words
   return initializeBIP39Mnemonic(entropyToWordIndices(internal::OpenSSLRandom::getRandomBytes(32)));
+}
+
+//-----
+std::unique_ptr<ED25519PrivateKey> MnemonicBIP39::toStandardEd25519PrivateKey(const std::string& passphrase,
+                                                                              int index) const
+{
+  return ED25519PrivateKey::fromSeed(toSeed(passphrase))->derive(40)->derive(3030)->derive(0)->derive(0)->derive(index);
+}
+
+//-----
+std::unique_ptr<ECDSAsecp256k1PrivateKey> MnemonicBIP39::toStandardEcdsaSecp256k1PrivateKey(
+  const std::string& passphrase,
+  int index) const
+{
+  return ECDSAsecp256k1PrivateKey::fromSeed(toSeed(passphrase))
+    ->derive(internal::DerivationPathUtils::getHardenedIndex(40))
+    ->derive(internal::DerivationPathUtils::getHardenedIndex(3030))
+    ->derive(internal::DerivationPathUtils::getHardenedIndex(0))
+    ->derive(0)
+    ->derive(index);
 }
 
 //-----

--- a/sdk/main/src/MnemonicBIP39.cc
+++ b/sdk/main/src/MnemonicBIP39.cc
@@ -93,7 +93,7 @@ std::unique_ptr<ED25519PrivateKey> MnemonicBIP39::toStandardEd25519PrivateKey(co
 }
 
 //-----
-std::unique_ptr<ECDSAsecp256k1PrivateKey> MnemonicBIP39::toStandardEcdsaSecp256k1PrivateKey(
+std::unique_ptr<ECDSAsecp256k1PrivateKey> MnemonicBIP39::toStandardECDSAsecp256k1PrivateKey(
   const std::string& passphrase,
   int index) const
 {

--- a/sdk/tests/ED25519PrivateKeyTest.cc
+++ b/sdk/tests/ED25519PrivateKeyTest.cc
@@ -136,7 +136,7 @@ TEST_F(ED25519PrivateKeyTest, SLIP10TestVector1)
   EXPECT_EQ(privateKey->toBytes(), internal::HexConverter::hexToBase64(expectedPrivate));
   EXPECT_EQ(privateKey->getPublicKey()->toBytes(), internal::HexConverter::hexToBase64(expectedPublic));
 
-  privateKey = privateKey->derive(internal::DerivationPathUtils::getHardenedIndex(0));
+  privateKey = privateKey->derive(0);
   expectedChainCode = "8b59aa11380b624e81507a27fedda59fea6d0b779a778918a2fd3590e16e9c69";
   expectedPrivate = "68e0fe46dfb67e368c75379acec591dad19df3cde26e63b93a8e704f1dade7a3";
   expectedPublic = "8c8a13df77a28f3445213a0f432fde644acaa215fc72dcdf300d5efaa85d350c";
@@ -144,7 +144,7 @@ TEST_F(ED25519PrivateKeyTest, SLIP10TestVector1)
   EXPECT_EQ(privateKey->toBytes(), internal::HexConverter::hexToBase64(expectedPrivate));
   EXPECT_EQ(privateKey->getPublicKey()->toBytes(), internal::HexConverter::hexToBase64(expectedPublic));
 
-  privateKey = privateKey->derive(internal::DerivationPathUtils::getHardenedIndex(1));
+  privateKey = privateKey->derive(1);
   expectedChainCode = "a320425f77d1b5c2505a6b1b27382b37368ee640e3557c315416801243552f14";
   expectedPrivate = "b1d0bad404bf35da785a64ca1ac54b2617211d2777696fbffaf208f746ae84f2";
   expectedPublic = "1932a5270f335bed617d5b935c80aedb1a35bd9fc1e31acafd5372c30f5c1187";
@@ -152,7 +152,7 @@ TEST_F(ED25519PrivateKeyTest, SLIP10TestVector1)
   EXPECT_EQ(privateKey->toBytes(), internal::HexConverter::hexToBase64(expectedPrivate));
   EXPECT_EQ(privateKey->getPublicKey()->toBytes(), internal::HexConverter::hexToBase64(expectedPublic));
 
-  privateKey = privateKey->derive(internal::DerivationPathUtils::getHardenedIndex(2));
+  privateKey = privateKey->derive(2);
   expectedChainCode = "2e69929e00b5ab250f49c3fb1c12f252de4fed2c1db88387094a0f8c4c9ccd6c";
   expectedPrivate = "92a5b23c0b8a99e37d07df3fb9966917f5d06e02ddbd909c7e184371463e9fc9";
   expectedPublic = "ae98736566d30ed0e9d2f4486a64bc95740d89c7db33f52121f8ea8f76ff0fc1";
@@ -160,7 +160,7 @@ TEST_F(ED25519PrivateKeyTest, SLIP10TestVector1)
   EXPECT_EQ(privateKey->toBytes(), internal::HexConverter::hexToBase64(expectedPrivate));
   EXPECT_EQ(privateKey->getPublicKey()->toBytes(), internal::HexConverter::hexToBase64(expectedPublic));
 
-  privateKey = privateKey->derive(internal::DerivationPathUtils::getHardenedIndex(2));
+  privateKey = privateKey->derive(2);
   expectedChainCode = "8f6d87f93d750e0efccda017d662a1b31a266e4a6f5993b15f5c1f07f74dd5cc";
   expectedPrivate = "30d1dc7e5fc04c31219ab25a27ae00b50f6fd66622f6e9c913253d6511d1e662";
   expectedPublic = "8abae2d66361c879b900d204ad2cc4984fa2aa344dd7ddc46007329ac76c429c";
@@ -168,7 +168,7 @@ TEST_F(ED25519PrivateKeyTest, SLIP10TestVector1)
   EXPECT_EQ(privateKey->toBytes(), internal::HexConverter::hexToBase64(expectedPrivate));
   EXPECT_EQ(privateKey->getPublicKey()->toBytes(), internal::HexConverter::hexToBase64(expectedPublic));
 
-  privateKey = privateKey->derive(internal::DerivationPathUtils::getHardenedIndex(1000000000));
+  privateKey = privateKey->derive(1000000000);
   expectedChainCode = "68789923a0cac2cd5a29172a475fe9e0fb14cd6adb5ad98a3fa70333e7afa230";
   expectedPrivate = "8f94d394a8e8fd6b1bc2f3f49f5c47e385281d5c17e65324b0f62483e37e8793";
   expectedPublic = "3c24da049451555d51a7014a37337aa4e12d41e485abccfa46b47dfb2af54b7a";
@@ -192,7 +192,7 @@ TEST_F(ED25519PrivateKeyTest, SLIP10TestVector2)
   EXPECT_EQ(privateKey->toBytes(), internal::HexConverter::hexToBase64(expectedPrivate));
   EXPECT_EQ(privateKey->getPublicKey()->toBytes(), internal::HexConverter::hexToBase64(expectedPublic));
 
-  privateKey = privateKey->derive(internal::DerivationPathUtils::getHardenedIndex(0));
+  privateKey = privateKey->derive(0);
   expectedChainCode = "0b78a3226f915c082bf118f83618a618ab6dec793752624cbeb622acb562862d";
   expectedPrivate = "1559eb2bbec5790b0c65d8693e4d0875b1747f4970ae8b650486ed7470845635";
   expectedPublic = "86fab68dcb57aa196c77c5f264f215a112c22a912c10d123b0d03c3c28ef1037";
@@ -200,7 +200,7 @@ TEST_F(ED25519PrivateKeyTest, SLIP10TestVector2)
   EXPECT_EQ(privateKey->toBytes(), internal::HexConverter::hexToBase64(expectedPrivate));
   EXPECT_EQ(privateKey->getPublicKey()->toBytes(), internal::HexConverter::hexToBase64(expectedPublic));
 
-  privateKey = privateKey->derive(internal::DerivationPathUtils::getHardenedIndex(2147483647));
+  privateKey = privateKey->derive(2147483647);
   expectedChainCode = "138f0b2551bcafeca6ff2aa88ba8ed0ed8de070841f0c4ef0165df8181eaad7f";
   expectedPrivate = "ea4f5bfe8694d8bb74b7b59404632fd5968b774ed545e810de9c32a4fb4192f4";
   expectedPublic = "5ba3b9ac6e90e83effcd25ac4e58a1365a9e35a3d3ae5eb07b9e4d90bcf7506d";
@@ -208,7 +208,7 @@ TEST_F(ED25519PrivateKeyTest, SLIP10TestVector2)
   EXPECT_EQ(privateKey->toBytes(), internal::HexConverter::hexToBase64(expectedPrivate));
   EXPECT_EQ(privateKey->getPublicKey()->toBytes(), internal::HexConverter::hexToBase64(expectedPublic));
 
-  privateKey = privateKey->derive(internal::DerivationPathUtils::getHardenedIndex(1));
+  privateKey = privateKey->derive(1);
   expectedChainCode = "73bd9fff1cfbde33a1b846c27085f711c0fe2d66fd32e139d3ebc28e5a4a6b90";
   expectedPrivate = "3757c7577170179c7868353ada796c839135b3d30554bbb74a4b1e4a5a58505c";
   expectedPublic = "2e66aa57069c86cc18249aecf5cb5a9cebbfd6fadeab056254763874a9352b45";
@@ -216,7 +216,7 @@ TEST_F(ED25519PrivateKeyTest, SLIP10TestVector2)
   EXPECT_EQ(privateKey->toBytes(), internal::HexConverter::hexToBase64(expectedPrivate));
   EXPECT_EQ(privateKey->getPublicKey()->toBytes(), internal::HexConverter::hexToBase64(expectedPublic));
 
-  privateKey = privateKey->derive(internal::DerivationPathUtils::getHardenedIndex(2147483646));
+  privateKey = privateKey->derive(2147483646);
   expectedChainCode = "0902fe8a29f9140480a00ef244bd183e8a13288e4412d8389d140aac1794825a";
   expectedPrivate = "5837736c89570de861ebc173b1086da4f505d4adb387c6a1b1342d5e4ac9ec72";
   expectedPublic = "e33c0f7d81d843c572275f287498e8d408654fdf0d1e065b84e2e6f157aab09b";
@@ -224,7 +224,7 @@ TEST_F(ED25519PrivateKeyTest, SLIP10TestVector2)
   EXPECT_EQ(privateKey->toBytes(), internal::HexConverter::hexToBase64(expectedPrivate));
   EXPECT_EQ(privateKey->getPublicKey()->toBytes(), internal::HexConverter::hexToBase64(expectedPublic));
 
-  privateKey = privateKey->derive(internal::DerivationPathUtils::getHardenedIndex(2));
+  privateKey = privateKey->derive(2);
   expectedChainCode = "5d70af781f3a37b829f0d060924d5e960bdc02e85423494afc0b1a41bbe196d4";
   expectedPrivate = "551d333177df541ad876a60ea71f00447931c0a9da16f227c11ea080d7391b8d";
   expectedPublic = "47150c75db263559a70d5778bf36abbab30fb061ad69f69ece61a72b0cfa4fc0";


### PR DESCRIPTION
**Description**:
This PR adjusts the processing for generating `PrivateKey`s from a `Mnemonic`. Users should now use the `toStandard[Ed25519|Ecdsa]PrivateKey()` functions now to derive their `PrivateKey` from a `Mnemonic`, as this conforms to the established SDK standard defined in https://github.com/hashgraph/hedera-sdk-reference/issues/73.

**Related issue(s)**:

Fixes #149 

**Checklist**

- [X] Documented (Code comments, README, etc.)
- [X] Tested (unit, integration, etc.)
