### PR TITLE
Implement `Transaction::fromBytes()`

### DIFF
--- a/sdk/main/include/AccountCreateTransaction.h
+++ b/sdk/main/include/AccountCreateTransaction.h
@@ -67,8 +67,18 @@ namespace Hedera
 class AccountCreateTransaction : public Transaction<AccountCreateTransaction>
 {
 public:
+  /**
+   * Default constructor. Sets the maximum transaction fee to 5 Hbars.
+   */
   AccountCreateTransaction();
-  ~AccountCreateTransaction() override = default;
+
+  /**
+   * Construct from a TransactionBody protobuf object.
+   *
+   * @param transactionBody The TransactionBody protobuf object from which to construct.
+   * @throws std::invalid_argument If the input TransactionBody does not represent a CryptoCreateAccount transaction.
+   */
+  explicit AccountCreateTransaction(const proto::TransactionBody& transactionBody);
 
   /**
    * Derived from Executable. Create a clone of this AccountCreateTransaction.

--- a/sdk/main/include/Transaction.h
+++ b/sdk/main/include/Transaction.h
@@ -65,8 +65,8 @@ public:
    * this return type would look like the following:
    *
    * std::vector<unsigned char> bytes;
-   *                                                 The Transaction type here doesn't matter and is an unfortunate,
-   *                        vvvvvvvvvvvvvvvvvvvvvvvv ugly byproduct of this approach.
+   *                                                              The Transaction type here doesn't matter and is an
+   *                                     vvvvvvvvvvvvvvvvvvvvvvvv unfortunate, ugly byproduct of this approach.
    * auto [index, variant] = Transaction<AccountCreateTransaction>::fromBytes(bytes);
    *
    * switch (index)

--- a/sdk/main/include/Transaction.h
+++ b/sdk/main/include/Transaction.h
@@ -67,19 +67,19 @@ public:
    * std::vector<unsigned char> bytes;
    *                                                 The Transaction type here doesn't matter and is an unfortunate,
    *                        vvvvvvvvvvvvvvvvvvvvvvvv ugly byproduct of this approach.
-   * auto ret = Transaction<AccountCreateTransaction>::fromBytes(bytes);
+   * auto [index, variant] = Transaction<AccountCreateTransaction>::fromBytes(bytes);
    *
-   * switch (ret.first)
+   * switch (index)
    * {
    *    case 0:
    *    {
-   *        AccountCreateTransaction tx = std::get<0>(ret.second);
+   *        AccountCreateTransaction tx = std::get<0>(variant);
    *        ** do stuff with tx here **
    *        break;
    *    }
    *    case 1:
    *    {
-   *        TransferTransaction tx = std::get<1>(ret.second);
+   *        TransferTransaction tx = std::get<1>(variant);
    *        ** do stuff with tx here **
    *        break;
    *    }

--- a/sdk/main/include/Transaction.h
+++ b/sdk/main/include/Transaction.h
@@ -28,10 +28,14 @@
 #include <chrono>
 #include <memory>
 #include <string>
+#include <variant>
+#include <vector>
 
 namespace Hedera
 {
+class AccountCreateTransaction;
 class TransactionResponse;
+class TransferTransaction;
 }
 
 namespace proto
@@ -53,7 +57,15 @@ class Transaction
   : public Executable<SdkRequestType, proto::Transaction, proto::TransactionResponse, TransactionResponse>
 {
 public:
-  ~Transaction() override = default;
+  /**
+   * Construct a Transaction derived class from a byte array. The bytes can be a protobuf encoded TransactionBody,
+   * Transaction, or SignedTransaction.
+   *
+   * @param bytes The bytes from which to construct a Transaction.
+   * @return A variant from which to get the constructed Transaction.
+   * @throws std::invalid_argument If unable to construct a Transaction from the input bytes.
+   */
+  static std::variant<AccountCreateTransaction, TransferTransaction> fromBytes(const std::vector<unsigned char>& bytes);
 
   /**
    * Set the length of time that this Transaction will remain valid.
@@ -147,6 +159,13 @@ protected:
   Transaction& operator=(const Transaction&) = default;
   Transaction(Transaction&&) noexcept = default;
   Transaction& operator=(Transaction&&) noexcept = default;
+
+  /**
+   * Construct from a TransactionBody protobuf object.
+   *
+   * @param transactionBody The TransactionBody protobuf object from which to construct.
+   */
+  explicit Transaction(const proto::TransactionBody& transactionBody);
 
   /**
    * Derived from Executable. Perform any needed actions for this Transaction when a Node has been selected to which to

--- a/sdk/main/include/TransferTransaction.h
+++ b/sdk/main/include/TransferTransaction.h
@@ -52,6 +52,16 @@ namespace Hedera
 class TransferTransaction : public Transaction<TransferTransaction>
 {
 public:
+  TransferTransaction() = default;
+
+  /**
+   * Construct from a TransactionBody protobuf object.
+   *
+   * @param transactionBody The TransactionBody protobuf object from which to construct.
+   * @throws std::invalid_argument If the input TransactionBody does not represent a CryptoTransfer transaction.
+   */
+  explicit TransferTransaction(const proto::TransactionBody& transactionBody);
+
   /**
    * Derived from Executable. Create a clone of this TransferTransaction.
    *

--- a/sdk/main/src/AccountCreateTransaction.cc
+++ b/sdk/main/src/AccountCreateTransaction.cc
@@ -53,7 +53,7 @@ AccountCreateTransaction::AccountCreateTransaction(const proto::TransactionBody&
     mKey = PublicKey::fromProtobuf(body.key());
   }
 
-  mInitialBalance = Hbar(static_cast<int64_t>(body.initialbalance()));
+  mInitialBalance = Hbar(static_cast<int64_t>(body.initialbalance()), HbarUnit::TINYBAR());
   mReceiverSignatureRequired = body.receiversigrequired();
 
   if (body.has_autorenewperiod())

--- a/sdk/main/src/AccountCreateTransaction.cc
+++ b/sdk/main/src/AccountCreateTransaction.cc
@@ -38,6 +38,56 @@ AccountCreateTransaction::AccountCreateTransaction()
 }
 
 //-----
+AccountCreateTransaction::AccountCreateTransaction(const proto::TransactionBody& transactionBody)
+  : Transaction<AccountCreateTransaction>(transactionBody)
+{
+  if (!transactionBody.has_cryptocreateaccount())
+  {
+    throw std::invalid_argument("Transaction body doesn't contain CryptoCreateAccount data");
+  }
+
+  const proto::CryptoCreateTransactionBody& body = transactionBody.cryptocreateaccount();
+
+  if (body.has_key())
+  {
+    mKey = PublicKey::fromProtobuf(body.key());
+  }
+
+  mInitialBalance = Hbar(static_cast<int64_t>(body.initialbalance()));
+  mReceiverSignatureRequired = body.receiversigrequired();
+
+  if (body.has_autorenewperiod())
+  {
+    mAutoRenewPeriod = internal::DurationConverter::fromProtobuf(body.autorenewperiod());
+  }
+
+  mAccountMemo = body.memo();
+  mMaxAutomaticTokenAssociations = static_cast<uint32_t>(body.max_automatic_token_associations());
+
+  if (body.has_staked_account_id())
+  {
+    mStakedAccountId = AccountId::fromProtobuf(body.staked_account_id());
+  }
+
+  if (body.has_staked_node_id())
+  {
+    mStakedNodeId = body.staked_node_id();
+  }
+
+  mDeclineStakingReward = body.decline_reward();
+
+  if (!body.alias().empty())
+  {
+    mAlias = PublicKey::fromBytes({ body.alias().cbegin(), body.alias().cend() });
+  }
+
+  if (!body.evm_address().empty())
+  {
+    mEvmAddress = EvmAddress::fromBytes({ body.evm_address().cbegin(), body.evm_address().cend() });
+  }
+}
+
+//-----
 std::unique_ptr<
   Executable<AccountCreateTransaction, proto::Transaction, proto::TransactionResponse, TransactionResponse>>
 AccountCreateTransaction::clone() const

--- a/sdk/main/src/AccountCreateTransaction.cc
+++ b/sdk/main/src/AccountCreateTransaction.cc
@@ -71,7 +71,7 @@ AccountCreateTransaction::AccountCreateTransaction(const proto::TransactionBody&
 
   if (body.has_staked_node_id())
   {
-    mStakedNodeId = body.staked_node_id();
+    mStakedNodeId = static_cast<uint64_t>(body.staked_node_id());
   }
 
   mDeclineStakingReward = body.decline_reward();

--- a/sdk/main/src/Transaction.cc
+++ b/sdk/main/src/Transaction.cc
@@ -41,19 +41,25 @@ template<typename SdkRequestType>
 std::pair<int, std::variant<AccountCreateTransaction, TransferTransaction>> Transaction<SdkRequestType>::fromBytes(
   const std::vector<unsigned char>& bytes)
 {
-  proto::Transaction tx;
   proto::TransactionBody txBody;
-  proto::SignedTransaction signedTx;
 
-  if (tx.ParseFromArray(bytes.data(), static_cast<int>(bytes.size())) && !tx.signedtransactionbytes().empty())
+  // Transaction protobuf object
+  if (proto::Transaction tx;
+      tx.ParseFromArray(bytes.data(), static_cast<int>(bytes.size())) && !tx.signedtransactionbytes().empty())
   {
+    proto::SignedTransaction signedTx;
     signedTx.ParseFromArray(tx.signedtransactionbytes().data(), static_cast<int>(tx.signedtransactionbytes().size()));
     txBody.ParseFromArray(signedTx.bodybytes().data(), static_cast<int>(signedTx.bodybytes().size()));
   }
-  else if (signedTx.ParseFromArray(bytes.data(), static_cast<int>(bytes.size())) && !signedTx.bodybytes().empty())
+
+  // SignedTransaction protobuf object
+  else if (proto::SignedTransaction signedTx;
+           signedTx.ParseFromArray(bytes.data(), static_cast<int>(bytes.size())) && !signedTx.bodybytes().empty())
   {
     txBody.ParseFromArray(signedTx.bodybytes().data(), static_cast<int>(signedTx.bodybytes().size()));
   }
+
+  // If not TransactionBody protobuf object, throw
   else if (!txBody.ParseFromArray(bytes.data(), static_cast<int>(bytes.size())) ||
            txBody.data_case() == proto::TransactionBody::DataCase::DATA_NOT_SET)
   {

--- a/sdk/main/src/Transaction.cc
+++ b/sdk/main/src/Transaction.cc
@@ -38,7 +38,7 @@ namespace Hedera
 {
 //-----
 template<typename SdkRequestType>
-std::variant<AccountCreateTransaction, TransferTransaction> Transaction<SdkRequestType>::fromBytes(
+std::pair<int, std::variant<AccountCreateTransaction, TransferTransaction>> Transaction<SdkRequestType>::fromBytes(
   const std::vector<unsigned char>& bytes)
 {
   proto::Transaction tx;
@@ -63,9 +63,9 @@ std::variant<AccountCreateTransaction, TransferTransaction> Transaction<SdkReque
   switch (txBody.data_case())
   {
     case proto::TransactionBody::kCryptoCreateAccount:
-      return AccountCreateTransaction(txBody);
+      return { 0, AccountCreateTransaction(txBody) };
     case proto::TransactionBody::kCryptoTransfer:
-      return TransferTransaction(txBody);
+      return { 1, TransferTransaction(txBody) };
     default:
       throw std::invalid_argument("Type of transaction cannot be determined from input bytes");
   }

--- a/sdk/main/src/TransferTransaction.cc
+++ b/sdk/main/src/TransferTransaction.cc
@@ -272,7 +272,7 @@ proto::CryptoTransferTransactionBody* TransferTransaction::build() const
 
     if (!list)
     {
-      list = body->mutable_tokentransfers()->Add();
+      list = body->add_tokentransfers();
     }
 
     list->set_allocated_token(transfer.getTokenId().toProtobuf().release());
@@ -301,7 +301,7 @@ proto::CryptoTransferTransactionBody* TransferTransaction::build() const
 
     if (!list)
     {
-      list = body->mutable_tokentransfers()->Add();
+      list = body->add_tokentransfers();
     }
 
     proto::NftTransfer* nft = list->add_nfttransfers();

--- a/sdk/main/src/TransferTransaction.cc
+++ b/sdk/main/src/TransferTransaction.cc
@@ -27,6 +27,55 @@
 
 namespace Hedera
 {
+
+//-----
+TransferTransaction::TransferTransaction(const proto::TransactionBody& transactionBody)
+  : Transaction<TransferTransaction>(transactionBody)
+{
+  if (!transactionBody.has_cryptotransfer())
+  {
+    throw std::invalid_argument("Transaction body doesn't contain CryptoTransfer data");
+  }
+
+  const proto::CryptoTransferTransactionBody& body = transactionBody.cryptotransfer();
+
+  for (int i = 0; i < body.transfers().accountamounts_size(); ++i)
+  {
+    const proto::AccountAmount& accountAmount = body.transfers().accountamounts(i);
+    mHbarTransfers.push_back(HbarTransfer()
+                               .setAccountId(AccountId::fromProtobuf(accountAmount.accountid()))
+                               .setAmount(Hbar(accountAmount.amount(), HbarUnit::TINYBAR()))
+                               .setApproved(accountAmount.is_approval()));
+  }
+
+  for (int i = 0; i < body.tokentransfers_size(); ++i)
+  {
+    const proto::TokenTransferList& transfer = body.tokentransfers(i);
+    const TokenId tokenId = TokenId::fromProtobuf(transfer.token());
+
+    for (int j = 0; j < transfer.transfers_size(); ++j)
+    {
+      const proto::AccountAmount& accountAmount = transfer.transfers(j);
+      mTokenTransfers.push_back(TokenTransfer()
+                                  .setTokenId(tokenId)
+                                  .setAccountId(AccountId::fromProtobuf(accountAmount.accountid()))
+                                  .setAmount(accountAmount.amount())
+                                  .setApproval(accountAmount.is_approval())
+                                  .setExpectedDecimals(transfer.expected_decimals().value()));
+    }
+
+    for (int j = 0; j < transfer.nfttransfers_size(); ++j)
+    {
+      const proto::NftTransfer& nftTransfer = transfer.nfttransfers(j);
+      mNftTransfers.push_back(TokenNftTransfer()
+                                .setNftId(NftId(tokenId, static_cast<uint64_t>(nftTransfer.serialnumber())))
+                                .setSenderAccountId(AccountId::fromProtobuf(nftTransfer.senderaccountid()))
+                                .setReceiverAccountId(AccountId::fromProtobuf(nftTransfer.receiveraccountid()))
+                                .setApproval(nftTransfer.is_approval()));
+    }
+  }
+}
+
 //-----
 std::unique_ptr<Executable<TransferTransaction, proto::Transaction, proto::TransactionResponse, TransactionResponse>>
 TransferTransaction::clone() const

--- a/sdk/tests/AccountCreateTransactionTest.cc
+++ b/sdk/tests/AccountCreateTransactionTest.cc
@@ -104,11 +104,12 @@ TEST_F(AccountCreateTransactionTest, ConstructAccountCreateTransactionFromTransa
   EXPECT_EQ(accountCreateTransaction.getAutoRenewPeriod(), getTestAutoRenewPeriod());
   EXPECT_EQ(accountCreateTransaction.getAccountMemo(), getTestAccountMemo());
   EXPECT_EQ(accountCreateTransaction.getMaxAutomaticTokenAssociations(), getTestMaximumTokenAssociations());
-  EXPECT_TRUE(accountCreateTransaction.getStakedAccountId().has_value());
-  EXPECT_FALSE(accountCreateTransaction.getStakedNodeId().has_value());
+  ASSERT_TRUE(accountCreateTransaction.getStakedAccountId().has_value());
   EXPECT_EQ(accountCreateTransaction.getStakedAccountId(), getTestAccountId());
+  EXPECT_FALSE(accountCreateTransaction.getStakedNodeId().has_value());
   EXPECT_EQ(accountCreateTransaction.getDeclineStakingReward(), getTestDeclineStakingReward());
   EXPECT_EQ(accountCreateTransaction.getAlias()->toBytes(), testPublicKeyBytes);
+  ASSERT_TRUE(accountCreateTransaction.getEvmAddress().has_value());
   EXPECT_EQ(accountCreateTransaction.getEvmAddress()->toBytes(), testEvmAddressBytes);
 }
 

--- a/sdk/tests/CMakeLists.txt
+++ b/sdk/tests/CMakeLists.txt
@@ -38,6 +38,7 @@ add_executable(${TEST_PROJECT_NAME}
         TransactionRecordQueryTest.cc
         TransactionRecordTest.cc
         TransactionResponseTest.cc
+        TransactionTest.cc
         TransferTest.cc
         TransferTransactionTest.cc
 

--- a/sdk/tests/TransactionTest.cc
+++ b/sdk/tests/TransactionTest.cc
@@ -1,0 +1,375 @@
+/*-
+ *
+ * Hedera C++ SDK
+ *
+ * Copyright (C) 2020 - 2022 Hedera Hashgraph, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+#include "Transaction.h"
+#include "AccountCreateTransaction.h"
+#include "ECDSAsecp256k1PrivateKey.h"
+#include "TransferTransaction.h"
+#include "impl/DurationConverter.h"
+
+#include <gtest/gtest.h>
+#include <proto/transaction.pb.h>
+#include <proto/transaction_body.pb.h>
+#include <proto/transaction_contents.pb.h>
+
+using namespace Hedera;
+
+class TransactionTest : public ::testing::Test
+{
+protected:
+  void SetUp() override
+  {
+    // Initialize the CryptoCreate unique_ptr
+    mCryptoCreateTransactionBody->set_allocated_key(mPublicKey->toProtobuf().release());
+    mCryptoCreateTransactionBody->set_initialbalance(static_cast<uint64_t>(mInitialBalance.toTinybars()));
+    mCryptoCreateTransactionBody->set_receiversigrequired(mReceiverSignatureRequired);
+    mCryptoCreateTransactionBody->set_allocated_autorenewperiod(
+      internal::DurationConverter::toProtobuf(mAutoRenewPeriod));
+    mCryptoCreateTransactionBody->set_allocated_memo(new std::string{ mAccountMemo.cbegin(), mAccountMemo.cend() });
+    mCryptoCreateTransactionBody->set_max_automatic_token_associations(static_cast<int32_t>(mMaxTokenAssociations));
+    mCryptoCreateTransactionBody->set_allocated_staked_account_id(mAccountId.toProtobuf().release());
+    mCryptoCreateTransactionBody->set_decline_reward(mDeclineStakingReward);
+
+    const std::vector<unsigned char> testPublicKeyBytes = mPublicKey->toBytes();
+    const std::vector<unsigned char> testEvmAddressBytes = mEvmAddress.toBytes();
+    mCryptoCreateTransactionBody->set_allocated_alias(
+      new std::string{ testPublicKeyBytes.cbegin(), testPublicKeyBytes.cend() });
+    mCryptoCreateTransactionBody->set_allocated_evm_address(
+      new std::string{ testEvmAddressBytes.cbegin(), testEvmAddressBytes.cend() });
+
+    // Initialize the CryptoTransfer unique_ptr
+    proto::AccountAmount* amount = mCryptoTransferTransactionBody->mutable_transfers()->add_accountamounts();
+    amount->set_allocated_accountid(getTestAccountId().toProtobuf().release());
+    amount->set_amount(getTestAmount().toTinybars());
+    amount->set_is_approval(getTestApproval());
+
+    proto::TokenTransferList* list = mCryptoTransferTransactionBody->add_tokentransfers();
+    list->set_allocated_token(getTestTokenId().toProtobuf().release());
+    list->mutable_expected_decimals()->set_value(getTestExpectedDecimals());
+
+    amount = list->add_transfers();
+    amount->set_allocated_accountid(getTestAccountId().toProtobuf().release());
+    amount->set_amount(getTestAmount().toTinybars());
+    amount->set_is_approval(getTestApproval());
+
+    list = mCryptoTransferTransactionBody->add_tokentransfers();
+    list->set_allocated_token(getTestNftId().getTokenId().toProtobuf().release());
+
+    proto::NftTransfer* nft = list->add_nfttransfers();
+    nft->set_allocated_senderaccountid(getTestAccountId().toProtobuf().release());
+    nft->set_allocated_receiveraccountid(getTestAccountId().toProtobuf().release());
+    nft->set_serialnumber(static_cast<int64_t>(getTestNftId().getSerialNum()));
+    nft->set_is_approval(getTestApproval());
+  }
+
+  [[nodiscard]] inline const std::unique_ptr<proto::CryptoCreateTransactionBody>& getTestCryptoCreateTransactionBody()
+    const
+  {
+    return mCryptoCreateTransactionBody;
+  }
+  [[nodiscard]] inline const std::unique_ptr<proto::CryptoTransferTransactionBody>&
+  getTestCryptoTransferTransactionBody() const
+  {
+    return mCryptoTransferTransactionBody;
+  }
+  [[nodiscard]] inline const std::shared_ptr<PublicKey>& getTestPublicKey() const { return mPublicKey; }
+  [[nodiscard]] inline const Hbar& getTestInitialBalance() const { return mInitialBalance; }
+  [[nodiscard]] inline bool getTestReceiverSignatureRequired() const { return mReceiverSignatureRequired; }
+  [[nodiscard]] inline const std::chrono::duration<double>& getTestAutoRenewPeriod() const { return mAutoRenewPeriod; }
+  [[nodiscard]] inline const std::string& getTestAccountMemo() const { return mAccountMemo; }
+  [[nodiscard]] inline uint32_t getTestMaximumTokenAssociations() const { return mMaxTokenAssociations; }
+  [[nodiscard]] inline const AccountId& getTestAccountId() const { return mAccountId; }
+  [[nodiscard]] inline const uint64_t& getTestNodeId() const { return mNodeId; }
+  [[nodiscard]] inline bool getTestDeclineStakingReward() const { return mDeclineStakingReward; }
+  [[nodiscard]] inline const EvmAddress& getTestEvmAddress() const { return mEvmAddress; }
+  [[nodiscard]] inline const TokenId& getTestTokenId() const { return mTokenId; }
+  [[nodiscard]] inline const NftId& getTestNftId() const { return mNftId; }
+  [[nodiscard]] inline const Hbar& getTestAmount() const { return mAmount; }
+  [[nodiscard]] inline uint32_t getTestExpectedDecimals() const { return mExpectedDecimals; }
+  [[nodiscard]] inline bool getTestApproval() const { return mApproval; }
+
+private:
+  std::unique_ptr<proto::CryptoCreateTransactionBody> mCryptoCreateTransactionBody =
+    std::make_unique<proto::CryptoCreateTransactionBody>();
+  std::unique_ptr<proto::CryptoTransferTransactionBody> mCryptoTransferTransactionBody =
+    std::make_unique<proto::CryptoTransferTransactionBody>();
+
+  const std::shared_ptr<PublicKey> mPublicKey = ECDSAsecp256k1PrivateKey::generatePrivateKey()->getPublicKey();
+  const Hbar mInitialBalance = Hbar(1LL);
+  const bool mReceiverSignatureRequired = true;
+  const std::chrono::duration<double> mAutoRenewPeriod = std::chrono::hours(2);
+  const std::string mAccountMemo = "test account memo";
+  const uint32_t mMaxTokenAssociations = 3U;
+  const AccountId mAccountId = AccountId(4ULL);
+  const uint64_t mNodeId = 5ULL;
+  const bool mDeclineStakingReward = true;
+  const EvmAddress mEvmAddress = EvmAddress::fromString("303132333435363738396162636465666768696a");
+  const TokenId mTokenId = TokenId(6ULL);
+  const NftId mNftId = NftId(mTokenId, 7ULL);
+  const Hbar mAmount = Hbar(8ULL);
+  const uint32_t mExpectedDecimals = 9U;
+  const bool mApproval = true;
+};
+
+//-----
+TEST_F(TransactionTest, AccountCreateTransactionFromTransactionBodyBytes)
+{
+  // Given
+  proto::TransactionBody txBody;
+  txBody.set_allocated_cryptocreateaccount(
+    std::make_unique<proto::CryptoCreateTransactionBody>(*getTestCryptoCreateTransactionBody()).release());
+
+  const std::string serialized = txBody.SerializeAsString();
+
+  // When
+  const auto [index, txVariant] =
+    Transaction<AccountCreateTransaction>::fromBytes({ serialized.cbegin(), serialized.cend() });
+
+  // Then
+  ASSERT_EQ(index, 0);
+
+  AccountCreateTransaction accountCreateTransaction = std::get<0>(txVariant);
+  EXPECT_EQ(accountCreateTransaction.getKey()->toString(), getTestPublicKey()->toString());
+  EXPECT_EQ(accountCreateTransaction.getInitialBalance(), getTestInitialBalance());
+  EXPECT_EQ(accountCreateTransaction.getReceiverSignatureRequired(), getTestReceiverSignatureRequired());
+  EXPECT_EQ(accountCreateTransaction.getAutoRenewPeriod(), getTestAutoRenewPeriod());
+  EXPECT_EQ(accountCreateTransaction.getAccountMemo(), getTestAccountMemo());
+  EXPECT_EQ(accountCreateTransaction.getMaxAutomaticTokenAssociations(), getTestMaximumTokenAssociations());
+  ASSERT_TRUE(accountCreateTransaction.getStakedAccountId().has_value());
+  EXPECT_EQ(*accountCreateTransaction.getStakedAccountId(), getTestAccountId());
+  EXPECT_FALSE(accountCreateTransaction.getStakedNodeId().has_value());
+  EXPECT_EQ(accountCreateTransaction.getDeclineStakingReward(), getTestDeclineStakingReward());
+  EXPECT_EQ(accountCreateTransaction.getAlias()->toBytes(), getTestPublicKey()->toBytes());
+  ASSERT_TRUE(accountCreateTransaction.getEvmAddress().has_value());
+  EXPECT_EQ(accountCreateTransaction.getEvmAddress()->toBytes(), getTestEvmAddress().toBytes());
+}
+
+//-----
+TEST_F(TransactionTest, AccountCreateTransactionFromSignedTransactionBytes)
+{
+  // Given
+  proto::TransactionBody txBody;
+  txBody.set_allocated_cryptocreateaccount(
+    std::make_unique<proto::CryptoCreateTransactionBody>(*getTestCryptoCreateTransactionBody()).release());
+
+  proto::SignedTransaction signedTx;
+  signedTx.set_allocated_bodybytes(new std::string(txBody.SerializeAsString()));
+  // SignatureMap not required
+
+  const std::string serialized = signedTx.SerializeAsString();
+
+  // When
+  const auto [index, txVariant] =
+    Transaction<AccountCreateTransaction>::fromBytes({ serialized.cbegin(), serialized.cend() });
+
+  // Then
+  ASSERT_EQ(index, 0);
+
+  AccountCreateTransaction accountCreateTransaction = std::get<0>(txVariant);
+  EXPECT_EQ(accountCreateTransaction.getKey()->toString(), getTestPublicKey()->toString());
+  EXPECT_EQ(accountCreateTransaction.getInitialBalance(), getTestInitialBalance());
+  EXPECT_EQ(accountCreateTransaction.getReceiverSignatureRequired(), getTestReceiverSignatureRequired());
+  EXPECT_EQ(accountCreateTransaction.getAutoRenewPeriod(), getTestAutoRenewPeriod());
+  EXPECT_EQ(accountCreateTransaction.getAccountMemo(), getTestAccountMemo());
+  EXPECT_EQ(accountCreateTransaction.getMaxAutomaticTokenAssociations(), getTestMaximumTokenAssociations());
+  ASSERT_TRUE(accountCreateTransaction.getStakedAccountId().has_value());
+  EXPECT_EQ(*accountCreateTransaction.getStakedAccountId(), getTestAccountId());
+  EXPECT_FALSE(accountCreateTransaction.getStakedNodeId().has_value());
+  EXPECT_EQ(accountCreateTransaction.getDeclineStakingReward(), getTestDeclineStakingReward());
+  EXPECT_EQ(accountCreateTransaction.getAlias()->toBytes(), getTestPublicKey()->toBytes());
+  ASSERT_TRUE(accountCreateTransaction.getEvmAddress().has_value());
+  EXPECT_EQ(accountCreateTransaction.getEvmAddress()->toBytes(), getTestEvmAddress().toBytes());
+}
+
+//-----
+TEST_F(TransactionTest, AccountCreateTransactionFromTransactionBytes)
+{
+  // Given
+  proto::TransactionBody txBody;
+  txBody.set_allocated_cryptocreateaccount(
+    std::make_unique<proto::CryptoCreateTransactionBody>(*getTestCryptoCreateTransactionBody()).release());
+
+  proto::SignedTransaction signedTx;
+  signedTx.set_allocated_bodybytes(new std::string(txBody.SerializeAsString()));
+  // SignatureMap not required
+
+  proto::Transaction tx;
+  tx.set_allocated_signedtransactionbytes(new std::string(signedTx.SerializeAsString()));
+
+  const std::string serialized = tx.SerializeAsString();
+
+  // When
+  const auto [index, txVariant] =
+    Transaction<AccountCreateTransaction>::fromBytes({ serialized.cbegin(), serialized.cend() });
+
+  // Then
+  ASSERT_EQ(index, 0);
+
+  AccountCreateTransaction accountCreateTransaction = std::get<0>(txVariant);
+  EXPECT_EQ(accountCreateTransaction.getKey()->toString(), getTestPublicKey()->toString());
+  EXPECT_EQ(accountCreateTransaction.getInitialBalance(), getTestInitialBalance());
+  EXPECT_EQ(accountCreateTransaction.getReceiverSignatureRequired(), getTestReceiverSignatureRequired());
+  EXPECT_EQ(accountCreateTransaction.getAutoRenewPeriod(), getTestAutoRenewPeriod());
+  EXPECT_EQ(accountCreateTransaction.getAccountMemo(), getTestAccountMemo());
+  EXPECT_EQ(accountCreateTransaction.getMaxAutomaticTokenAssociations(), getTestMaximumTokenAssociations());
+  ASSERT_TRUE(accountCreateTransaction.getStakedAccountId().has_value());
+  EXPECT_EQ(*accountCreateTransaction.getStakedAccountId(), getTestAccountId());
+  EXPECT_FALSE(accountCreateTransaction.getStakedNodeId().has_value());
+  EXPECT_EQ(accountCreateTransaction.getDeclineStakingReward(), getTestDeclineStakingReward());
+  EXPECT_EQ(accountCreateTransaction.getAlias()->toBytes(), getTestPublicKey()->toBytes());
+  ASSERT_TRUE(accountCreateTransaction.getEvmAddress().has_value());
+  EXPECT_EQ(accountCreateTransaction.getEvmAddress()->toBytes(), getTestEvmAddress().toBytes());
+}
+
+//-----
+TEST_F(TransactionTest, TransferTransactionFromTransactionBodyBytes)
+{
+  // Given
+  proto::TransactionBody txBody;
+  txBody.set_allocated_cryptotransfer(
+    std::make_unique<proto::CryptoTransferTransactionBody>(*getTestCryptoTransferTransactionBody()).release());
+
+  const std::string serialized = txBody.SerializeAsString();
+
+  // When
+  const auto [index, txVariant] =
+    Transaction<AccountCreateTransaction>::fromBytes({ serialized.cbegin(), serialized.cend() });
+
+  // Then
+  ASSERT_EQ(index, 1);
+
+  TransferTransaction transferTransaction = std::get<1>(txVariant);
+  const std::unordered_map<AccountId, Hbar> hbarTransfers = transferTransaction.getHbarTransfers();
+  const std::unordered_map<TokenId, std::unordered_map<AccountId, int64_t>> tokenTransfers =
+    transferTransaction.getTokenTransfers();
+  const std::unordered_map<TokenId, std::vector<TokenNftTransfer>> nftTransfers = transferTransaction.getNftTransfers();
+  const std::unordered_map<TokenId, uint32_t> tokenDecimals = transferTransaction.getTokenIdDecimals();
+
+  ASSERT_EQ(hbarTransfers.size(), 1);
+  EXPECT_EQ(hbarTransfers.cbegin()->first, getTestAccountId());
+  EXPECT_EQ(hbarTransfers.cbegin()->second, getTestAmount());
+
+  ASSERT_EQ(tokenTransfers.size(), 1);
+  EXPECT_EQ(tokenTransfers.cbegin()->first, getTestTokenId());
+  EXPECT_EQ(tokenTransfers.cbegin()->second.cbegin()->first, getTestAccountId());
+  EXPECT_EQ(tokenTransfers.cbegin()->second.cbegin()->second, getTestAmount().toTinybars());
+
+  ASSERT_EQ(nftTransfers.size(), 1);
+  EXPECT_EQ(nftTransfers.cbegin()->first, getTestNftId().getTokenId());
+  ASSERT_EQ(nftTransfers.cbegin()->second.size(), 1);
+  EXPECT_EQ(nftTransfers.cbegin()->second.cbegin()->getNftId(), getTestNftId());
+  EXPECT_EQ(nftTransfers.cbegin()->second.cbegin()->getSenderAccountId(), getTestAccountId());
+  EXPECT_EQ(nftTransfers.cbegin()->second.cbegin()->getReceiverAccountId(), getTestAccountId());
+  EXPECT_EQ(nftTransfers.cbegin()->second.cbegin()->getApproval(), getTestApproval());
+}
+
+//-----
+TEST_F(TransactionTest, TransferTransactionFromSignedTransactionBytes)
+{
+  // Given
+  proto::TransactionBody txBody;
+  txBody.set_allocated_cryptotransfer(
+    std::make_unique<proto::CryptoTransferTransactionBody>(*getTestCryptoTransferTransactionBody()).release());
+
+  proto::SignedTransaction signedTx;
+  signedTx.set_allocated_bodybytes(new std::string(txBody.SerializeAsString()));
+  // SignatureMap not required
+
+  const std::string serialized = signedTx.SerializeAsString();
+
+  // When
+  const auto [index, txVariant] =
+    Transaction<AccountCreateTransaction>::fromBytes({ serialized.cbegin(), serialized.cend() });
+
+  // Then
+  ASSERT_EQ(index, 1);
+
+  TransferTransaction transferTransaction = std::get<1>(txVariant);
+  const std::unordered_map<AccountId, Hbar> hbarTransfers = transferTransaction.getHbarTransfers();
+  const std::unordered_map<TokenId, std::unordered_map<AccountId, int64_t>> tokenTransfers =
+    transferTransaction.getTokenTransfers();
+  const std::unordered_map<TokenId, std::vector<TokenNftTransfer>> nftTransfers = transferTransaction.getNftTransfers();
+  const std::unordered_map<TokenId, uint32_t> tokenDecimals = transferTransaction.getTokenIdDecimals();
+
+  ASSERT_EQ(hbarTransfers.size(), 1);
+  EXPECT_EQ(hbarTransfers.cbegin()->first, getTestAccountId());
+  EXPECT_EQ(hbarTransfers.cbegin()->second, getTestAmount());
+
+  ASSERT_EQ(tokenTransfers.size(), 1);
+  EXPECT_EQ(tokenTransfers.cbegin()->first, getTestTokenId());
+  EXPECT_EQ(tokenTransfers.cbegin()->second.cbegin()->first, getTestAccountId());
+  EXPECT_EQ(tokenTransfers.cbegin()->second.cbegin()->second, getTestAmount().toTinybars());
+
+  ASSERT_EQ(nftTransfers.size(), 1);
+  EXPECT_EQ(nftTransfers.cbegin()->first, getTestNftId().getTokenId());
+  ASSERT_EQ(nftTransfers.cbegin()->second.size(), 1);
+  EXPECT_EQ(nftTransfers.cbegin()->second.cbegin()->getNftId(), getTestNftId());
+  EXPECT_EQ(nftTransfers.cbegin()->second.cbegin()->getSenderAccountId(), getTestAccountId());
+  EXPECT_EQ(nftTransfers.cbegin()->second.cbegin()->getReceiverAccountId(), getTestAccountId());
+  EXPECT_EQ(nftTransfers.cbegin()->second.cbegin()->getApproval(), getTestApproval());
+}
+
+//-----
+TEST_F(TransactionTest, TransferTransactionFromTransactionBytes)
+{
+  // Given
+  proto::TransactionBody txBody;
+  txBody.set_allocated_cryptotransfer(
+    std::make_unique<proto::CryptoTransferTransactionBody>(*getTestCryptoTransferTransactionBody()).release());
+
+  proto::SignedTransaction signedTx;
+  signedTx.set_allocated_bodybytes(new std::string(txBody.SerializeAsString()));
+  // SignatureMap not required
+
+  proto::Transaction tx;
+  tx.set_allocated_signedtransactionbytes(new std::string(signedTx.SerializeAsString()));
+
+  const std::string serialized = tx.SerializeAsString();
+
+  // When
+  const auto [index, txVariant] =
+    Transaction<AccountCreateTransaction>::fromBytes({ serialized.cbegin(), serialized.cend() });
+
+  // Then
+  ASSERT_EQ(index, 1);
+
+  TransferTransaction transferTransaction = std::get<1>(txVariant);
+  const std::unordered_map<AccountId, Hbar> hbarTransfers = transferTransaction.getHbarTransfers();
+  const std::unordered_map<TokenId, std::unordered_map<AccountId, int64_t>> tokenTransfers =
+    transferTransaction.getTokenTransfers();
+  const std::unordered_map<TokenId, std::vector<TokenNftTransfer>> nftTransfers = transferTransaction.getNftTransfers();
+  const std::unordered_map<TokenId, uint32_t> tokenDecimals = transferTransaction.getTokenIdDecimals();
+
+  ASSERT_EQ(hbarTransfers.size(), 1);
+  EXPECT_EQ(hbarTransfers.cbegin()->first, getTestAccountId());
+  EXPECT_EQ(hbarTransfers.cbegin()->second, getTestAmount());
+
+  ASSERT_EQ(tokenTransfers.size(), 1);
+  EXPECT_EQ(tokenTransfers.cbegin()->first, getTestTokenId());
+  EXPECT_EQ(tokenTransfers.cbegin()->second.cbegin()->first, getTestAccountId());
+  EXPECT_EQ(tokenTransfers.cbegin()->second.cbegin()->second, getTestAmount().toTinybars());
+
+  ASSERT_EQ(nftTransfers.size(), 1);
+  EXPECT_EQ(nftTransfers.cbegin()->first, getTestNftId().getTokenId());
+  ASSERT_EQ(nftTransfers.cbegin()->second.size(), 1);
+  EXPECT_EQ(nftTransfers.cbegin()->second.cbegin()->getNftId(), getTestNftId());
+  EXPECT_EQ(nftTransfers.cbegin()->second.cbegin()->getSenderAccountId(), getTestAccountId());
+  EXPECT_EQ(nftTransfers.cbegin()->second.cbegin()->getReceiverAccountId(), getTestAccountId());
+  EXPECT_EQ(nftTransfers.cbegin()->second.cbegin()->getApproval(), getTestApproval());
+}

--- a/sdk/tests/TransferTransactionTest.cc
+++ b/sdk/tests/TransferTransactionTest.cc
@@ -92,23 +92,24 @@ TEST_F(TransferTransactionTest, ConstructTransferTransactionFromTransactionBodyP
 
   // When
   TransferTransaction transferTransaction(txBody);
+
+  // Then
   const std::unordered_map<AccountId, Hbar> hbarTransfers = transferTransaction.getHbarTransfers();
   const std::unordered_map<TokenId, std::unordered_map<AccountId, int64_t>> tokenTransfers =
     transferTransaction.getTokenTransfers();
   const std::unordered_map<TokenId, std::vector<TokenNftTransfer>> nftTransfers = transferTransaction.getNftTransfers();
   const std::unordered_map<TokenId, uint32_t> tokenDecimals = transferTransaction.getTokenIdDecimals();
 
-  // Then
-  EXPECT_EQ(hbarTransfers.size(), 1);
+  ASSERT_EQ(hbarTransfers.size(), 1);
   EXPECT_EQ(hbarTransfers.cbegin()->first, getTestAccountId1());
   EXPECT_EQ(hbarTransfers.cbegin()->second, getTestAmount());
 
-  EXPECT_EQ(tokenTransfers.size(), 1);
+  ASSERT_EQ(tokenTransfers.size(), 1);
   EXPECT_EQ(tokenTransfers.cbegin()->first, getTestTokenId());
   EXPECT_EQ(tokenTransfers.cbegin()->second.cbegin()->first, getTestAccountId2());
   EXPECT_EQ(tokenTransfers.cbegin()->second.cbegin()->second, getTestAmount().toTinybars());
 
-  EXPECT_EQ(nftTransfers.size(), 1);
+  ASSERT_EQ(nftTransfers.size(), 1);
   EXPECT_EQ(nftTransfers.cbegin()->first, getTestNftId().getTokenId());
   EXPECT_EQ(nftTransfers.cbegin()->second.size(), 1);
   EXPECT_EQ(nftTransfers.cbegin()->second.cbegin()->getNftId(), getTestNftId());

--- a/sdk/tests/TransferTransactionTest.cc
+++ b/sdk/tests/TransferTransactionTest.cc
@@ -23,6 +23,7 @@
 #include "TokenId.h"
 
 #include <gtest/gtest.h>
+#include <proto/transaction_body.pb.h>
 
 using namespace Hedera;
 
@@ -32,19 +33,19 @@ protected:
   [[nodiscard]] inline const AccountId& getTestAccountId1() const { return mAccountId1; }
   [[nodiscard]] inline const AccountId& getTestAccountId2() const { return mAccountId2; }
   [[nodiscard]] inline const TokenId& getTestTokenId() const { return mTokenId; }
-  [[nodiscard]] inline const uint64_t& getTestNftSerialNumber() const { return mSerialNumber; }
   [[nodiscard]] inline const NftId& getTestNftId() const { return mNftId; }
   [[nodiscard]] inline const Hbar& getTestAmount() const { return mAmount; }
   [[nodiscard]] inline uint32_t getTestExpectedDecimals() const { return mExpectedDecimals; }
+  [[nodiscard]] inline bool getTestApproval() const { return mApproval; }
 
 private:
   const AccountId mAccountId1 = AccountId(10ULL);
   const AccountId mAccountId2 = AccountId(20ULL);
   const TokenId mTokenId = TokenId(30ULL);
-  const uint64_t mSerialNumber = 40ULL;
-  const NftId mNftId = NftId(mTokenId, mSerialNumber);
+  const NftId mNftId = NftId(mTokenId, 40ULL);
   const Hbar mAmount = Hbar(50ULL);
   const uint32_t mExpectedDecimals = 6U;
+  const bool mApproval = true;
 };
 
 //-----
@@ -55,6 +56,65 @@ TEST_F(TransferTransactionTest, ConstructTransferTransaction)
   EXPECT_TRUE(transaction.getTokenTransfers().empty());
   EXPECT_TRUE(transaction.getNftTransfers().empty());
   EXPECT_TRUE(transaction.getTokenIdDecimals().empty());
+}
+
+//-----
+TEST_F(TransferTransactionTest, ConstructTransferTransactionFromTransactionBodyProtobuf)
+{
+  // Given
+  auto body = std::make_unique<proto::CryptoTransferTransactionBody>();
+
+  proto::AccountAmount* amount = body->mutable_transfers()->add_accountamounts();
+  amount->set_allocated_accountid(getTestAccountId1().toProtobuf().release());
+  amount->set_amount(getTestAmount().toTinybars());
+  amount->set_is_approval(getTestApproval());
+
+  proto::TokenTransferList* list = body->add_tokentransfers();
+  list->set_allocated_token(getTestTokenId().toProtobuf().release());
+  list->mutable_expected_decimals()->set_value(getTestExpectedDecimals());
+
+  amount = list->add_transfers();
+  amount->set_allocated_accountid(getTestAccountId2().toProtobuf().release());
+  amount->set_amount(getTestAmount().toTinybars());
+  amount->set_is_approval(getTestApproval());
+
+  list = body->add_tokentransfers();
+  list->set_allocated_token(getTestNftId().getTokenId().toProtobuf().release());
+
+  proto::NftTransfer* nft = list->add_nfttransfers();
+  nft->set_allocated_senderaccountid(getTestAccountId1().toProtobuf().release());
+  nft->set_allocated_receiveraccountid(getTestAccountId2().toProtobuf().release());
+  nft->set_serialnumber(static_cast<int64_t>(getTestNftId().getSerialNum()));
+  nft->set_is_approval(getTestApproval());
+
+  proto::TransactionBody txBody;
+  txBody.set_allocated_cryptotransfer(body.release());
+
+  // When
+  TransferTransaction transferTransaction(txBody);
+  const std::unordered_map<AccountId, Hbar> hbarTransfers = transferTransaction.getHbarTransfers();
+  const std::unordered_map<TokenId, std::unordered_map<AccountId, int64_t>> tokenTransfers =
+    transferTransaction.getTokenTransfers();
+  const std::unordered_map<TokenId, std::vector<TokenNftTransfer>> nftTransfers = transferTransaction.getNftTransfers();
+  const std::unordered_map<TokenId, uint32_t> tokenDecimals = transferTransaction.getTokenIdDecimals();
+
+  // Then
+  EXPECT_EQ(hbarTransfers.size(), 1);
+  EXPECT_EQ(hbarTransfers.cbegin()->first, getTestAccountId1());
+  EXPECT_EQ(hbarTransfers.cbegin()->second, getTestAmount());
+
+  EXPECT_EQ(tokenTransfers.size(), 1);
+  EXPECT_EQ(tokenTransfers.cbegin()->first, getTestTokenId());
+  EXPECT_EQ(tokenTransfers.cbegin()->second.cbegin()->first, getTestAccountId2());
+  EXPECT_EQ(tokenTransfers.cbegin()->second.cbegin()->second, getTestAmount().toTinybars());
+
+  EXPECT_EQ(nftTransfers.size(), 1);
+  EXPECT_EQ(nftTransfers.cbegin()->first, getTestNftId().getTokenId());
+  EXPECT_EQ(nftTransfers.cbegin()->second.size(), 1);
+  EXPECT_EQ(nftTransfers.cbegin()->second.cbegin()->getNftId(), getTestNftId());
+  EXPECT_EQ(nftTransfers.cbegin()->second.cbegin()->getSenderAccountId(), getTestAccountId1());
+  EXPECT_EQ(nftTransfers.cbegin()->second.cbegin()->getReceiverAccountId(), getTestAccountId2());
+  EXPECT_EQ(nftTransfers.cbegin()->second.cbegin()->getApproval(), getTestApproval());
 }
 
 //-----
@@ -133,7 +193,7 @@ TEST_F(TransferTransactionTest, AddNftTransfer)
   EXPECT_EQ(transaction.getNftTransfers().cbegin()->second.cbegin()->getSenderAccountId(), getTestAccountId1());
   EXPECT_EQ(transaction.getNftTransfers().cbegin()->second.cbegin()->getReceiverAccountId(), getTestAccountId2());
   EXPECT_EQ(transaction.getNftTransfers().cbegin()->second.cbegin()->getNftId().getSerialNum(),
-            getTestNftSerialNumber());
+            getTestNftId().getSerialNum());
 
   transaction.addNftTransfer(getTestNftId(), getTestAccountId2(), getTestAccountId1());
   EXPECT_TRUE(transaction.getNftTransfers().empty());


### PR DESCRIPTION
**Description**:
This PR adds a `Transaction::fromBytes()` function. Unlike what is stated in the [Hedera SDK Reference](https://github.com/hashgraph/hedera-sdk-reference/blob/main/reference/core/Transaction.md#frombytes--data--bytes--transaction) for this function, a clean return of a `Transaction` object is not possible since the return type _must_ be known at compile time. `Transaction` is unable to be returned because it is a template and the template parameter is the created derived class (see [Curiously Recurring Template Pattern](https://en.wikipedia.org/wiki/Curiously_recurring_template_pattern)).

To avert this problem, a `std::pair` is returned, which contains a `std::variant` and an `index` into the `std::variant`. While a `switch` statement will be necessary to determine and create the actual derived `Transaction` type, it is the only way to get around the language constricting issue of needing to know the return type at compile time.

**Related issue(s)**:

Fixes #205 

**Checklist**

- [x] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
