### PR TITLE
Remove clone() for `Executable` and all derived classes

### DIFF
--- a/sdk/main/include/AccountBalanceQuery.h
+++ b/sdk/main/include/AccountBalanceQuery.h
@@ -40,13 +40,6 @@ public:
   ~AccountBalanceQuery() override = default;
 
   /**
-   * Derived from Executable. Create a clone of this AccountBalanceQuery.
-   *
-   * @return A pointer to the created clone.
-   */
-  [[nodiscard]] std::unique_ptr<Executable> clone() const override;
-
-  /**
    * Set the ID of the account of which to request the balance. This is mutually exclusive with setContractId() and will
    * clear the contract ID if one is already set.
    *

--- a/sdk/main/include/AccountCreateTransaction.h
+++ b/sdk/main/include/AccountCreateTransaction.h
@@ -81,13 +81,6 @@ public:
   explicit AccountCreateTransaction(const proto::TransactionBody& transactionBody);
 
   /**
-   * Derived from Executable. Create a clone of this AccountCreateTransaction.
-   *
-   * @return A pointer to the created clone.
-   */
-  [[nodiscard]] std::unique_ptr<Executable> clone() const override;
-
-  /**
    * Set the public key for the new account. The key that must sign each transfer out of the account. If
    * mReceiverSignatureRequired is true, then it must also sign any transfer into the account.
    *

--- a/sdk/main/include/Executable.h
+++ b/sdk/main/include/Executable.h
@@ -61,13 +61,6 @@ public:
   virtual ~Executable() = default;
 
   /**
-   * Create a clone of this Executable object.
-   *
-   * @return A pointer to the created clone of this Executable.
-   */
-  virtual std::unique_ptr<Executable> clone() const = 0;
-
-  /**
    * Submit this Executable to a Hedera network.
    *
    * @param client The Client to use to submit this Executable.

--- a/sdk/main/include/TransactionReceiptQuery.h
+++ b/sdk/main/include/TransactionReceiptQuery.h
@@ -39,13 +39,6 @@ public:
   ~TransactionReceiptQuery() override = default;
 
   /**
-   * Derived from Executable. Create a clone of this TransactionReceiptQuery.
-   *
-   * @return A pointer to the created clone.
-   */
-  [[nodiscard]] std::unique_ptr<Executable> clone() const override;
-
-  /**
    * Set the ID of the transaction of which to request the receipt.
    *
    * @param transactionId The ID of the desired transaction of which to request the receipt.

--- a/sdk/main/include/TransactionRecordQuery.h
+++ b/sdk/main/include/TransactionRecordQuery.h
@@ -39,14 +39,7 @@ class TransactionRecordQuery : public Query<TransactionRecordQuery, TransactionR
 {
 public:
   ~TransactionRecordQuery() override = default;
-
-  /**
-   * Derived from Executable. Create a clone of this TransactionRecordQuery.
-   *
-   * @return A pointer to the created clone.
-   */
-  [[nodiscard]] std::unique_ptr<Executable> clone() const override;
-
+  
   /**
    * Set the ID of the transaction of which to request the record.
    *

--- a/sdk/main/include/TransferTransaction.h
+++ b/sdk/main/include/TransferTransaction.h
@@ -63,13 +63,6 @@ public:
   explicit TransferTransaction(const proto::TransactionBody& transactionBody);
 
   /**
-   * Derived from Executable. Create a clone of this TransferTransaction.
-   *
-   * @return A pointer to the created clone.
-   */
-  [[nodiscard]] std::unique_ptr<Executable> clone() const override;
-
-  /**
    * Add an Hbar transfer to be submitted as part of this TransferTransaction.
    *
    * @param accountId The ID of the account associated with this transfer.

--- a/sdk/main/src/AccountBalanceQuery.cc
+++ b/sdk/main/src/AccountBalanceQuery.cc
@@ -30,13 +30,6 @@
 namespace Hedera
 {
 //-----
-std::unique_ptr<Executable<AccountBalanceQuery, proto::Query, proto::Response, AccountBalance>>
-AccountBalanceQuery::clone() const
-{
-  return std::make_unique<AccountBalanceQuery>(*this);
-}
-
-//-----
 AccountBalanceQuery& AccountBalanceQuery::setAccountId(const AccountId& accountId)
 {
   mAccountId = accountId;

--- a/sdk/main/src/AccountCreateTransaction.cc
+++ b/sdk/main/src/AccountCreateTransaction.cc
@@ -88,14 +88,6 @@ AccountCreateTransaction::AccountCreateTransaction(const proto::TransactionBody&
 }
 
 //-----
-std::unique_ptr<
-  Executable<AccountCreateTransaction, proto::Transaction, proto::TransactionResponse, TransactionResponse>>
-AccountCreateTransaction::clone() const
-{
-  return std::make_unique<AccountCreateTransaction>(*this);
-}
-
-//-----
 AccountCreateTransaction& AccountCreateTransaction::setKey(const std::shared_ptr<PublicKey>& key)
 {
   mKey = key;

--- a/sdk/main/src/TransactionReceiptQuery.cc
+++ b/sdk/main/src/TransactionReceiptQuery.cc
@@ -30,13 +30,6 @@
 namespace Hedera
 {
 //-----
-std::unique_ptr<Executable<TransactionReceiptQuery, proto::Query, proto::Response, TransactionReceipt>>
-TransactionReceiptQuery::clone() const
-{
-  return std::make_unique<TransactionReceiptQuery>(*this);
-}
-
-//-----
 TransactionReceiptQuery& TransactionReceiptQuery::setTransactionId(const TransactionId& transactionId)
 {
   mTransactionId = transactionId;

--- a/sdk/main/src/TransactionRecordQuery.cc
+++ b/sdk/main/src/TransactionRecordQuery.cc
@@ -34,13 +34,6 @@
 namespace Hedera
 {
 //-----
-std::unique_ptr<Executable<TransactionRecordQuery, proto::Query, proto::Response, TransactionRecord>>
-TransactionRecordQuery::clone() const
-{
-  return std::make_unique<TransactionRecordQuery>(*this);
-}
-
-//-----
 TransactionRecordQuery& TransactionRecordQuery::setTransactionId(const TransactionId& transactionId)
 {
   mTransactionId = transactionId;

--- a/sdk/main/src/TransferTransaction.cc
+++ b/sdk/main/src/TransferTransaction.cc
@@ -77,13 +77,6 @@ TransferTransaction::TransferTransaction(const proto::TransactionBody& transacti
 }
 
 //-----
-std::unique_ptr<Executable<TransferTransaction, proto::Transaction, proto::TransactionResponse, TransactionResponse>>
-TransferTransaction::clone() const
-{
-  return std::make_unique<TransferTransaction>(*this);
-}
-
-//-----
 TransferTransaction& TransferTransaction::addHbarTransfer(const AccountId& accountId, const Hbar& amount)
 {
   doHbarTransfer(HbarTransfer().setAccountId(accountId).setAmount(amount).setApproved(false));

--- a/sdk/tests/AccountBalanceQueryTest.cc
+++ b/sdk/tests/AccountBalanceQueryTest.cc
@@ -42,23 +42,6 @@ TEST_F(AccountBalanceQueryTest, ConstructAccountBalanceQuery)
   EXPECT_FALSE(query.getContractId());
 }
 
-TEST_F(AccountBalanceQueryTest, CloneAccountBalanceQuery)
-{
-  AccountBalanceQuery accountBalanceQuery;
-  accountBalanceQuery.setNodeAccountIds({ getTestAccountId() });
-  accountBalanceQuery.setAccountId(getTestAccountId());
-
-  auto clonedExecutablePtr = accountBalanceQuery.clone();
-  EXPECT_EQ(clonedExecutablePtr->getNodeAccountIds().size(), accountBalanceQuery.getNodeAccountIds().size());
-  EXPECT_EQ(clonedExecutablePtr->getNodeAccountIds().at(0), getTestAccountId());
-
-  // TODO: get and test Query derived class members when they're added
-
-  auto clonedAccountBalanceQueryPtr = dynamic_cast<AccountBalanceQuery*>(clonedExecutablePtr.get());
-  EXPECT_TRUE(clonedAccountBalanceQueryPtr->getAccountId());
-  EXPECT_EQ(*clonedAccountBalanceQueryPtr->getAccountId(), getTestAccountId());
-}
-
 TEST_F(AccountBalanceQueryTest, SetAccountId)
 {
   AccountBalanceQuery query;

--- a/sdk/tests/AccountCreateTransactionTest.cc
+++ b/sdk/tests/AccountCreateTransactionTest.cc
@@ -114,30 +114,6 @@ TEST_F(AccountCreateTransactionTest, ConstructAccountCreateTransactionFromTransa
 }
 
 //-----
-TEST_F(AccountCreateTransactionTest, CloneAccountCreateTransaction)
-{
-  AccountCreateTransaction transaction;
-  const std::string memo = "this is a test memo";
-  transaction.setNodeAccountIds({ getTestAccountId() });
-  transaction.setTransactionMemo(memo);
-  transaction.setStakedAccountId(getTestAccountId());
-
-  auto clonedExecutableTransactionPtr = transaction.clone();
-  EXPECT_EQ(clonedExecutableTransactionPtr->getNodeAccountIds().size(), transaction.getNodeAccountIds().size());
-  EXPECT_EQ(clonedExecutableTransactionPtr->getNodeAccountIds().at(0), getTestAccountId());
-
-  auto clonedTransactionPtr =
-    dynamic_cast<Transaction<AccountCreateTransaction>*>(clonedExecutableTransactionPtr.get());
-  EXPECT_NE(clonedTransactionPtr, nullptr);
-  EXPECT_EQ(clonedTransactionPtr->getTransactionMemo(), memo);
-
-  auto clonedAccountCreateTransactionPtr = dynamic_cast<AccountCreateTransaction*>(clonedTransactionPtr);
-  EXPECT_NE(clonedAccountCreateTransactionPtr, nullptr);
-  EXPECT_TRUE(clonedAccountCreateTransactionPtr->getStakedAccountId());
-  EXPECT_EQ(*clonedAccountCreateTransactionPtr->getStakedAccountId(), getTestAccountId());
-}
-
-//-----
 TEST_F(AccountCreateTransactionTest, SetKey)
 {
   AccountCreateTransaction transaction;

--- a/sdk/tests/TransactionReceiptQueryTest.cc
+++ b/sdk/tests/TransactionReceiptQueryTest.cc
@@ -35,23 +35,6 @@ private:
   const TransactionId mTestTransactionId = TransactionId::generate(mTestAccountId);
 };
 
-TEST_F(TransactionReceiptQueryTest, CloneTransactionReceiptQuery)
-{
-  TransactionReceiptQuery transactionReceiptQuery;
-  transactionReceiptQuery.setNodeAccountIds({ getTestAccountId() });
-  transactionReceiptQuery.setTransactionId(getTestTransactionId());
-
-  auto clonedExecutablePtr = transactionReceiptQuery.clone();
-  EXPECT_EQ(clonedExecutablePtr->getNodeAccountIds().size(), transactionReceiptQuery.getNodeAccountIds().size());
-  EXPECT_EQ(clonedExecutablePtr->getNodeAccountIds().at(0), getTestAccountId());
-
-  // TODO: get and test Query derived class members when they're added
-
-  auto clonedTransactionReceiptQueryPtr = dynamic_cast<TransactionReceiptQuery*>(clonedExecutablePtr.get());
-  EXPECT_TRUE(clonedTransactionReceiptQueryPtr->getTransactionId());
-  EXPECT_EQ(*clonedTransactionReceiptQueryPtr->getTransactionId(), getTestTransactionId());
-}
-
 TEST_F(TransactionReceiptQueryTest, SetTransactionId)
 {
   TransactionReceiptQuery query;

--- a/sdk/tests/TransactionRecordQueryTest.cc
+++ b/sdk/tests/TransactionRecordQueryTest.cc
@@ -35,23 +35,6 @@ private:
   const TransactionId mTestTransactionId = TransactionId::generate(mTestAccountId);
 };
 
-TEST_F(TransactionRecordQueryTest, CloneTransactionReceiptQuery)
-{
-  TransactionRecordQuery transactionRecordQuery;
-  transactionRecordQuery.setNodeAccountIds({ getTestAccountId() });
-  transactionRecordQuery.setTransactionId(getTestTransactionId());
-
-  auto clonedExecutablePtr = transactionRecordQuery.clone();
-  EXPECT_EQ(clonedExecutablePtr->getNodeAccountIds().size(), transactionRecordQuery.getNodeAccountIds().size());
-  EXPECT_EQ(clonedExecutablePtr->getNodeAccountIds().at(0), getTestAccountId());
-
-  // TODO: get and test Query derived class members when they're added
-
-  auto clonedTransactionReceiptQueryPtr = dynamic_cast<TransactionRecordQuery*>(clonedExecutablePtr.get());
-  EXPECT_TRUE(clonedTransactionReceiptQueryPtr->getTransactionId());
-  EXPECT_EQ(*clonedTransactionReceiptQueryPtr->getTransactionId(), getTestTransactionId());
-}
-
 TEST_F(TransactionRecordQueryTest, SetTransactionId)
 {
   TransactionRecordQuery query;

--- a/sdk/tests/TransferTransactionTest.cc
+++ b/sdk/tests/TransferTransactionTest.cc
@@ -119,30 +119,6 @@ TEST_F(TransferTransactionTest, ConstructTransferTransactionFromTransactionBodyP
 }
 
 //-----
-TEST_F(TransferTransactionTest, CloneTransferTransaction)
-{
-  TransferTransaction transaction;
-  const std::string memo = "this is a test memo";
-  transaction.setNodeAccountIds({ getTestAccountId1() });
-  transaction.setTransactionMemo(memo);
-  transaction.addHbarTransfer(getTestAccountId1(), getTestAmount());
-
-  auto clonedExecutableTransactionPtr = transaction.clone();
-  EXPECT_EQ(clonedExecutableTransactionPtr->getNodeAccountIds().size(), transaction.getNodeAccountIds().size());
-  EXPECT_EQ(clonedExecutableTransactionPtr->getNodeAccountIds().at(0), getTestAccountId1());
-
-  auto clonedTransactionPtr = dynamic_cast<Transaction<TransferTransaction>*>(clonedExecutableTransactionPtr.get());
-  EXPECT_NE(clonedTransactionPtr, nullptr);
-  EXPECT_EQ(clonedTransactionPtr->getTransactionMemo(), memo);
-
-  auto clonedAccountCreateTransactionPtr = dynamic_cast<TransferTransaction*>(clonedTransactionPtr);
-  EXPECT_NE(clonedAccountCreateTransactionPtr, nullptr);
-  EXPECT_FALSE(clonedAccountCreateTransactionPtr->getHbarTransfers().empty());
-  EXPECT_EQ(clonedAccountCreateTransactionPtr->getHbarTransfers().begin()->first, getTestAccountId1());
-  EXPECT_EQ(clonedAccountCreateTransactionPtr->getHbarTransfers().begin()->second, getTestAmount());
-}
-
-//-----
 TEST_F(TransferTransactionTest, AddHbarTransfer)
 {
   TransferTransaction transaction;


### PR DESCRIPTION
**Description**:
This PR removes the `clone()` functions for all derived-`Executable` classes (all `Query`s and `Transaction`s). This was initially added as a way to provide safe copying of objects if using a base class pointer. However, since all `Executable`s have their own template structure anyways, this will never happen, thus making the `clone()` functions obsolete. The default, compiler-generated copy and move functions will suffice.

**Related issue(s)**:

Fixes #212 

**Checklist**

- [x] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
