### PR TITLE
Complete implementation for NodeAddress (PR)

### DIFF
--- a/sdk/main/include/impl/Endpoint.h
+++ b/sdk/main/include/impl/Endpoint.h
@@ -59,11 +59,18 @@ public:
   [[nodiscard]] std::string toString() const;
 
   /**
+   * Get the IP address of the node.
+   *
+   * @return The IP address (v4) of the node.
+   */
+  [[nodiscard]] inline IPv4Address getAddress() const { return mAddress; }
+
+  /**
    * Get the port of the Endpoint.
    *
    * @return The port of the Endpoint.
    */
-  [[nodiscard]] int getPort() const;
+  [[nodiscard]] inline int getPort() const { return mPort; }
 
 private:
   /**

--- a/sdk/main/include/impl/Endpoint.h
+++ b/sdk/main/include/impl/Endpoint.h
@@ -38,10 +38,10 @@ public:
   /**
    * Construct from an address and a port number.
    *
-   * @param address The IPv4 address of the endpoint.
-   * @param port    The port of the endpoint.
+   * @param ipAddressV4 The IPv4 address of the endpoint.
+   * @param port        The port of the endpoint.
    */
-  Endpoint(const IPv4Address& address, int port);
+  Endpoint(const IPv4Address& ipAddressV4, int port);
 
   /**
    * Create an Endpoint object from a ServiceEndpoint protobuf object.

--- a/sdk/main/include/impl/Node.h
+++ b/sdk/main/include/impl/Node.h
@@ -162,7 +162,7 @@ public:
    *
    * @return The account ID.
    */
-  [[nodiscard]] inline AccountId getAccountId() const { return mAddress->getAccountId(); }
+  [[nodiscard]] inline AccountId getAccountId() const { return mAddress->getNodeAccountId(); }
 
 private:
   /**

--- a/sdk/main/include/impl/NodeAddress.h
+++ b/sdk/main/include/impl/NodeAddress.h
@@ -151,12 +151,9 @@ public:
    *
    * @return An instance of IPv4Address containing the IP address of the node.
    */
-  [[nodiscard]] inline const IPv4Address getDefaultIpAddress() const
-  {
-    return getDefaultEndpoint().get()->getAddress();
-  }
+  [[nodiscard]] inline const IPv4Address getDefaultIpAddress() const { return getDefaultEndpoint()->getAddress(); }
 
-  [[nodiscard]] inline const int getDefaultPort() const { return getDefaultEndpoint().get()->getPort(); }
+  [[nodiscard]] inline const int getDefaultPort() const { return getDefaultEndpoint()->getPort(); }
 
   /**
    * Get the node ID

--- a/sdk/main/include/impl/NodeAddress.h
+++ b/sdk/main/include/impl/NodeAddress.h
@@ -48,6 +48,14 @@ public:
   static NodeAddress fromProtobuf(const proto::NodeAddress& protoNodeAddress);
 
   /**
+   * Create a NodeAddress object from a given string.
+   *
+   * @param addressString The string representation from which to create a new NodeAddress object.
+   * @return The created NodeAddress object.
+   */
+  static NodeAddress fromString(const std::string addressString);
+
+  /**
    * Set a new node ID associated with the node at this address.
    *
    * @param accountId The account ID to be associated with the node

--- a/sdk/main/include/impl/NodeAddress.h
+++ b/sdk/main/include/impl/NodeAddress.h
@@ -188,7 +188,15 @@ public:
    *
    * @return The default node endpoint.
    */
-  [[nodiscard]] inline const std::shared_ptr<Endpoint> getDefaultEndpoint() const { return mEndpoints.front(); }
+  [[nodiscard]] inline const std::shared_ptr<Endpoint> getDefaultEndpoint() const
+  {
+    if (mEndpoints.empty())
+    {
+      return nullptr;
+    }
+
+    return mEndpoints.front();
+  }
 
   /**
    * Get a vector of endpoints associated with the node.

--- a/sdk/main/include/impl/NodeAddress.h
+++ b/sdk/main/include/impl/NodeAddress.h
@@ -39,9 +39,6 @@ namespace Hedera::internal
 class NodeAddress
 {
 public:
-  /**
-   * Default constructor
-   */
   NodeAddress() = default;
 
   /**
@@ -49,9 +46,9 @@ public:
    *
    * @param ipAddressV4 The IPv4 address of the Node with separator and octets.
    * @param port        The port number of the server for the node.
-   * @throws IllegalStateException If the given IP address is incorrect.
+   * @throws IllegalStateException If the given IP address is malformed.
    */
-  NodeAddress(const std::string ipAddressV4, const int port);
+  NodeAddress(const std::string& ipAddressV4, const int port);
 
   /**
    * Create a NodeAddress object from a NodeAddress protobuf object.
@@ -59,7 +56,7 @@ public:
    * @param proto The NodeAddress protobuf object from which to create a NodeAddress object.
    * @return The created NodeAddress object.
    */
-  static NodeAddress fromProtobuf(const proto::NodeAddress& protoNodeAddress);
+  [[nodiscard]] static NodeAddress fromProtobuf(const proto::NodeAddress& protoNodeAddress);
 
   /**
    * Create a NodeAddress object from a given string.
@@ -68,7 +65,7 @@ public:
    * @return The created NodeAddress object.
    * @throws IllegalStateException If the given node address is incorrect.
    */
-  static NodeAddress fromString(const std::string& nodeAddress);
+  [[nodiscard]] static NodeAddress fromString(const std::string& nodeAddress);
 
   /**
    * Set a new public key for the node.
@@ -84,7 +81,7 @@ public:
    * @param accountId The account ID to be associated with the node
    * @return A reference to this NodeAddress with the newly-set account ID.
    */
-  NodeAddress& setNodeId(const int64_t nodeId);
+  NodeAddress& setNodeId(const int64_t& nodeId);
 
   /**
    * Set a new account ID associated with the node at this address.
@@ -124,7 +121,7 @@ public:
    * @param stake The new amount of tinybars staked to the node
    * @return A reference to this NodeAddress with the newly-set staked tinybars.
    */
-  NodeAddress& setStake(const int64_t stake);
+  NodeAddress& setStake(const int64_t& stake);
 
   /**
    * Determine if a particular port number corresponds to a TLS port.

--- a/sdk/main/include/impl/NodeAddress.h
+++ b/sdk/main/include/impl/NodeAddress.h
@@ -50,7 +50,7 @@ public:
    * @param address The IP address of the Node with separator and octets.
    * @param port    The port number of the server for the node.
    */
-  NodeAddress(const std::string address, int port);
+  NodeAddress(const std::string ipAddress, int port);
 
   /**
    * Create a NodeAddress object from a NodeAddress protobuf object.
@@ -63,10 +63,10 @@ public:
   /**
    * Create a NodeAddress object from a given string.
    *
-   * @param addressString The string representation from which to create a new NodeAddress object.
+   * @param nodeAddress The string representation from which to create a new NodeAddress object.
    * @return The created NodeAddress object.
    */
-  static NodeAddress fromString(const std::string& addressString);
+  static NodeAddress fromString(const std::string& nodeAddress);
 
   /**
    * Set a new public key for the node.
@@ -106,7 +106,7 @@ public:
    * @param endpoints The endpoints to be assigned to the node
    * @return A reference to this NodeAddress with the newsly-set endpoints.
    */
-  NodeAddress& setEndpoints(const std::vector<Endpoint>& endpoints);
+  NodeAddress& setEndpoints(const std::vector<std::shared_ptr<Endpoint>>& endpoints);
 
   /**
    * Assign а new description text for the node.
@@ -141,9 +141,9 @@ public:
   static inline bool isNonTlsPort(int port) { return (port == PORT_NODE_PLAIN) || (port == PORT_MIRROR_PLAIN); }
 
   /**
-   * Get a string representation of the address.
+   * Get a string representation of the node address.
    *
-   * @return A string representing the address.
+   * @return A string representing the node address.
    */
   [[nodiscard]] std::string toString() const;
 
@@ -152,7 +152,12 @@ public:
    *
    * @return An instance of IPv4Address containing the IP address of the node.
    */
-  [[nodiscard]] IPv4Address& getAddress() const;
+  [[nodiscard]] inline const IPv4Address getDefaultIpAddress() const
+  {
+    return getDefaultEndpoint().get()->getAddress();
+  }
+
+  [[nodiscard]] inline const int getDefaultPort() const { return getDefaultEndpoint().get()->getPort(); }
 
   /**
    * Get the node ID
@@ -183,11 +188,18 @@ public:
   [[nodiscard]] inline std::string getNodeCertHash() const { return mNodeCertHash; }
 
   /**
+   * Get the default endpoint associated with the node.
+   *
+   * @return The default node endpoint.
+   */
+  [[nodiscard]] inline const std::shared_ptr<Endpoint> getDefaultEndpoint() const { return mEndpoints.front(); }
+
+  /**
    * Get a vector of endpoints associated with the node.
    *
    * @return The node endpoints.
    */
-  [[nodiscard]] inline const std::vector<Endpoint>& getEndpoints() const { return mEndpoints; }
+  [[nodiscard]] inline const std::vector<std::shared_ptr<Endpoint>>& getEndpoints() const { return mEndpoints; }
 
   /**
    * Get the description text associated with the node.
@@ -215,7 +227,7 @@ private:
   /**
    * The endpoints associated with the node.
    */
-  std::vector<Endpoint> mEndpoints;
+  std::vector<std::shared_ptr<Endpoint>> mEndpoints;
 
   /**
    * The node's public key.

--- a/sdk/main/include/impl/NodeAddress.h
+++ b/sdk/main/include/impl/NodeAddress.h
@@ -53,7 +53,15 @@ public:
    * @param addressString The string representation from which to create a new NodeAddress object.
    * @return The created NodeAddress object.
    */
-  static NodeAddress fromString(const std::string addressString);
+  static NodeAddress fromString(const std::string& addressString);
+
+  /**
+   * Set a new public key for the node.
+   *
+   * @param publicKey The public key to be assigned to the node.
+   * @return A reference to this NodeAddress with the newly-set public key.
+   */
+  NodeAddress& setRSAPublicKey(const std::string& publicKey);
 
   /**
    * Set a new node ID associated with the node at this address.
@@ -80,12 +88,28 @@ public:
   NodeAddress& setNodeCertHash(const std::string& certHash);
 
   /**
+   * Set a vector of endpoints for the node.
+   *
+   * @param endpoints The endpoints to be assigned to the node
+   * @return A reference to this NodeAddress with the newsly-set endpoints.
+   */
+  NodeAddress& setEndpoints(const std::vector<Endpoint>& endpoints);
+
+  /**
    * Assign а new description text for the node.
    *
    * @param description The description text to be assigned with the node
    * @return A reference to this NodeAddress with the newly-set description.
    */
   NodeAddress& setDescription(const std::string& description);
+
+  /**
+   * Set new amount of tinybars staked to the node.
+   *
+   * @param stake The new amount of tinybars staked to the node
+   * @return A reference to this NodeAddress with the newly-set staked tinybars.
+   */
+  NodeAddress& setStake(const int64_t stake);
 
   /**
    * Determine if a particular port number corresponds to a TLS port.
@@ -118,18 +142,18 @@ public:
   [[nodiscard]] inline int64_t getNodeId() const { return mNodeId; }
 
   /**
+   * Get the public key of the node.
+   *
+   * @return A hash value representing the public key of the node.
+   */
+  [[nodiscard]] inline std::string getPublicKey() const { return mRSAPublicKey; }
+
+  /**
    * Get the account ID associated with the node at this address.
    *
    * @return The account ID associated with the node at this address.
    */
   [[nodiscard]] inline AccountId getNodeAccountId() const { return mNodeAccountId; }
-
-  /**
-   * Get a vector of endpoints associated with the node.
-   *
-   * @return The node endpoints.
-   */
-  [[nodiscard]] inline const std::vector<Endpoint>& getEndpoints() const { return mEndpoints; }
 
   /**
    * Get the SHA-384 hash of the node certificate chain.
@@ -139,11 +163,25 @@ public:
   [[nodiscard]] inline std::string getNodeCertHash() const { return mNodeCertHash; }
 
   /**
+   * Get a vector of endpoints associated with the node.
+   *
+   * @return The node endpoints.
+   */
+  [[nodiscard]] inline const std::vector<Endpoint>& getEndpoints() const { return mEndpoints; }
+
+  /**
    * Get the description text associated with the node.
    *
    * @return The description text.
    */
   [[nodiscard]] inline std::string getDescription() const { return mDescription; }
+
+  /**
+   * Get the amount of tinybars staked to the node.
+   *
+   * @return A int64 value representing the amount.
+   */
+  [[nodiscard]] inline int64_t getStake() const { return mStake; }
 
 private:
   /**

--- a/sdk/main/include/impl/NodeAddress.h
+++ b/sdk/main/include/impl/NodeAddress.h
@@ -135,6 +135,13 @@ public:
   [[nodiscard]] std::string toString() const;
 
   /**
+   * Get the IP address of the node.
+   *
+   * @return An instance of IPv4Address containing the IP address of the node.
+   */
+  [[nodiscard]] IPv4Address& getAddress() const;
+
+  /**
    * Get the node ID
    *
    * @return A int64 value representing the node ID.

--- a/sdk/main/include/impl/NodeAddress.h
+++ b/sdk/main/include/impl/NodeAddress.h
@@ -48,7 +48,7 @@ public:
    * @param port        The port number of the server for the node.
    * @throws IllegalStateException If the given IP address is malformed.
    */
-  NodeAddress(const std::string& ipAddressV4, const int port);
+  NodeAddress(std::string_view ipAddressV4, const int port);
 
   /**
    * Create a NodeAddress object from a NodeAddress protobuf object.
@@ -65,7 +65,7 @@ public:
    * @return The created NodeAddress object.
    * @throws IllegalStateException If the given node address is incorrect.
    */
-  [[nodiscard]] static NodeAddress fromString(const std::string& nodeAddress);
+  [[nodiscard]] static NodeAddress fromString(std::string_view nodeAddress);
 
   /**
    * Set a new public key for the node.
@@ -73,7 +73,7 @@ public:
    * @param publicKey The public key to be assigned to the node.
    * @return A reference to this NodeAddress with the newly-set public key.
    */
-  NodeAddress& setRSAPublicKey(const std::string& publicKey);
+  NodeAddress& setRSAPublicKey(std::string_view publicKey);
 
   /**
    * Set a new node ID associated with the node at this address.
@@ -97,7 +97,7 @@ public:
    * @param certHash The certificate hash to be assigned to the node
    * @return A reference to this NodeAddress with the newly-set certificate hash.
    */
-  NodeAddress& setNodeCertHash(const std::string& certHash);
+  NodeAddress& setNodeCertHash(std::string_view certHash);
 
   /**
    * Set a vector of endpoints for the node.
@@ -113,7 +113,7 @@ public:
    * @param description The description text to be assigned with the node
    * @return A reference to this NodeAddress with the newly-set description.
    */
-  NodeAddress& setDescription(const std::string& description);
+  NodeAddress& setDescription(std::string_view description);
 
   /**
    * Set new amount of tinybars staked to the node.

--- a/sdk/main/include/impl/NodeAddress.h
+++ b/sdk/main/include/impl/NodeAddress.h
@@ -66,6 +66,7 @@ public:
    *
    * @param nodeAddress The string representation from which to create a new NodeAddress object.
    * @return The created NodeAddress object.
+   * @throws IllegalStateException If the given node address is incorrect.
    */
   static NodeAddress fromString(const std::string& nodeAddress);
 

--- a/sdk/main/include/impl/NodeAddress.h
+++ b/sdk/main/include/impl/NodeAddress.h
@@ -47,10 +47,11 @@ public:
   /**
    * Construct a NodeAddress instance with a given address and port.
    *
-   * @param address The IP address of the Node with separator and octets.
-   * @param port    The port number of the server for the node.
+   * @param ipAddressV4 The IPv4 address of the Node with separator and octets.
+   * @param port        The port number of the server for the node.
+   * @throws IllegalStateException If the given IP address is incorrect.
    */
-  NodeAddress(const std::string ipAddress, int port);
+  NodeAddress(const std::string ipAddressV4, const int port);
 
   /**
    * Create a NodeAddress object from a NodeAddress protobuf object.

--- a/sdk/main/include/impl/NodeAddress.h
+++ b/sdk/main/include/impl/NodeAddress.h
@@ -121,7 +121,7 @@ public:
    * @param stake The new amount of tinybars staked to the node
    * @return A reference to this NodeAddress with the newly-set staked tinybars.
    */
-  NodeAddress& setStake(const int64_t& stake);
+  NodeAddress& setStake(const uint64_t& stake);
 
   /**
    * Determine if a particular port number corresponds to a TLS port.
@@ -217,7 +217,7 @@ public:
    *
    * @return A int64 value representing the amount.
    */
-  [[nodiscard]] inline int64_t getStake() const { return mStake; }
+  [[nodiscard]] inline uint64_t getStake() const { return mStake; }
 
 private:
   /**
@@ -261,7 +261,7 @@ private:
   /**
    * The amount of tinybars staked to the node
    */
-  int64_t mStake = 0;
+  uint64_t mStake = 0;
 };
 
 } // namespace Hedera::internal

--- a/sdk/main/include/impl/NodeAddress.h
+++ b/sdk/main/include/impl/NodeAddress.h
@@ -75,7 +75,7 @@ public:
    *
    * @return The account ID associated with the node at this address.
    */
-  [[nodiscard]] inline AccountId getAccountId() const { return mAccountId; }
+  [[nodiscard]] inline AccountId getNodeAccountId() const { return mNodeAccountId; }
 
   /**
    * Get a vector of endpoints associated with the node.
@@ -89,7 +89,7 @@ public:
    *
    * @return The certificate chain hash.
    */
-  [[nodiscard]] inline std::string getCertificateHash() const { return mCertificateHash; }
+  [[nodiscard]] inline std::string getNodeCertHash() const { return mNodeCertHash; }
 
 private:
   /**
@@ -116,9 +116,14 @@ private:
   int64_t mNodeId = -1;
 
   /**
+   * The account ID associated with the node.
+   */
+  AccountId mNodeAccountId;
+
+  /**
    * The SHA-384 hash of the node's certificate chain.
    */
-  std::string mCertificateHash;
+  std::string mNodeCertHash;
 
   /**
    * A string description of the node.
@@ -126,9 +131,9 @@ private:
   std::string mDescription;
 
   /**
-   * The account ID associated with the node.
+   * The amount of tinybars staked to the node
    */
-  AccountId mAccountId;
+  int64_t mStake = 0;
 };
 
 } // namespace Hedera::internal

--- a/sdk/main/include/impl/NodeAddress.h
+++ b/sdk/main/include/impl/NodeAddress.h
@@ -48,6 +48,38 @@ public:
   static NodeAddress fromProtobuf(const proto::NodeAddress& protoNodeAddress);
 
   /**
+   * Set a new node ID associated with the node at this address.
+   *
+   * @param accountId The account ID to be associated with the node
+   * @return A reference to this NodeAddress with the newly-set account ID.
+   */
+  NodeAddress& setNodeId(const int64_t nodeId);
+
+  /**
+   * Set a new account ID associated with the node at this address.
+   *
+   * @param accountId The account ID to be associated with the node
+   * @return A reference to this NodeAddress with the newly-set account ID.
+   */
+  NodeAddress& setNodeAccountId(const AccountId& accountId);
+
+  /**
+   * Set a new certificate hash for the node.
+   *
+   * @param certHash The certificate hash to be assigned to the node
+   * @return A reference to this NodeAddress with the newly-set certificate hash.
+   */
+  NodeAddress& setNodeCertHash(const std::string& certHash);
+
+  /**
+   * Assign а new description text for the node.
+   *
+   * @param description The description text to be assigned with the node
+   * @return A reference to this NodeAddress with the newly-set description.
+   */
+  NodeAddress& setDescription(const std::string& description);
+
+  /**
    * Determine if a particular port number corresponds to a TLS port.
    *
    * @param port The port number.
@@ -71,6 +103,13 @@ public:
   [[nodiscard]] std::string toString() const;
 
   /**
+   * Get the node ID
+   *
+   * @return A int64 value representing the node ID.
+   */
+  [[nodiscard]] inline int64_t getNodeId() const { return mNodeId; }
+
+  /**
    * Get the account ID associated with the node at this address.
    *
    * @return The account ID associated with the node at this address.
@@ -90,6 +129,13 @@ public:
    * @return The certificate chain hash.
    */
   [[nodiscard]] inline std::string getNodeCertHash() const { return mNodeCertHash; }
+
+  /**
+   * Get the description text associated with the node.
+   *
+   * @return The description text.
+   */
+  [[nodiscard]] inline std::string getDescription() const { return mDescription; }
 
 private:
   /**

--- a/sdk/main/include/impl/NodeAddress.h
+++ b/sdk/main/include/impl/NodeAddress.h
@@ -153,6 +153,11 @@ public:
    */
   [[nodiscard]] inline const IPv4Address getDefaultIpAddress() const { return getDefaultEndpoint()->getAddress(); }
 
+  /**
+   * Get the port number of the gRPC server for the node.
+   *
+   * @return An int value containing the port number.
+   */
   [[nodiscard]] inline const int getDefaultPort() const { return getDefaultEndpoint()->getPort(); }
 
   /**

--- a/sdk/main/include/impl/NodeAddress.h
+++ b/sdk/main/include/impl/NodeAddress.h
@@ -48,7 +48,7 @@ public:
    * @param port        The port number of the server for the node.
    * @throws IllegalStateException If the given IP address is malformed.
    */
-  NodeAddress(std::string_view ipAddressV4, const int port);
+  NodeAddress(std::string_view ipAddressV4, int port);
 
   /**
    * Create a NodeAddress object from a NodeAddress protobuf object.
@@ -63,7 +63,7 @@ public:
    *
    * @param nodeAddress The string representation from which to create a new NodeAddress object.
    * @return The created NodeAddress object.
-   * @throws IllegalStateException If the given node address is incorrect.
+   * @throws IllegalStateException If the given node address is malformed.
    */
   [[nodiscard]] static NodeAddress fromString(std::string_view nodeAddress);
 
@@ -158,7 +158,7 @@ public:
    *
    * @return An int value containing the port number.
    */
-  [[nodiscard]] inline const int getDefaultPort() const { return getDefaultEndpoint()->getPort(); }
+  [[nodiscard]] inline int getDefaultPort() const { return getDefaultEndpoint()->getPort(); }
 
   /**
    * Get the node ID
@@ -220,7 +220,7 @@ public:
   /**
    * Get the amount of tinybars staked to the node.
    *
-   * @return A int64 value representing the amount.
+   * @return A uint64_t value representing the amount.
    */
   [[nodiscard]] inline uint64_t getStake() const { return mStake; }
 

--- a/sdk/main/include/impl/NodeAddress.h
+++ b/sdk/main/include/impl/NodeAddress.h
@@ -40,6 +40,19 @@ class NodeAddress
 {
 public:
   /**
+   * Default constructor
+   */
+  NodeAddress() = default;
+
+  /**
+   * Construct a NodeAddress instance with a given address and port.
+   *
+   * @param address The IP address of the Node with separator and octets.
+   * @param port    The port number of the server for the node.
+   */
+  NodeAddress(const std::string address, int port);
+
+  /**
    * Create a NodeAddress object from a NodeAddress protobuf object.
    *
    * @param proto The NodeAddress protobuf object from which to create a NodeAddress object.

--- a/sdk/main/src/impl/Endpoint.cc
+++ b/sdk/main/src/impl/Endpoint.cc
@@ -32,8 +32,8 @@ Endpoint Endpoint::fromProtobuf(const proto::ServiceEndpoint& serviceEndpoint)
 }
 
 //-----
-Endpoint::Endpoint(const IPv4Address& address, int port)
-  : mAddress(address)
+Endpoint::Endpoint(const IPv4Address& ipAddressV4, int port)
+  : mAddress(ipAddressV4)
   , mPort(port)
 {
   // TODO: here we change the port to the TLS port, since the existing serialization of the testnet address book doesn't

--- a/sdk/main/src/impl/Endpoint.cc
+++ b/sdk/main/src/impl/Endpoint.cc
@@ -54,10 +54,4 @@ std::string Endpoint::toString() const
   return outputStream.str();
 }
 
-//-----
-int Endpoint::getPort() const
-{
-  return mPort;
-}
-
 } // namespace Hedera::internal

--- a/sdk/main/src/impl/Node.cc
+++ b/sdk/main/src/impl/Node.cc
@@ -32,7 +32,7 @@ Node::Node(std::shared_ptr<NodeAddress> address, TLSBehavior tls)
   : mAddress(std::move(address))
 {
   // In order to use TLS, a node certificate chain must be provided
-  if (tls == TLSBehavior::REQUIRE && mAddress->getCertificateHash().empty())
+  if (tls == TLSBehavior::REQUIRE && mAddress->getNodeCertHash().empty())
   {
     throw UninitializedException("NodeAddress has empty certificate chain hash for TLS connection");
   }
@@ -43,7 +43,7 @@ Node::Node(std::shared_ptr<NodeAddress> address, TLSBehavior tls)
   tlsChannelCredentialsOptions.set_verify_server_certs(false);
   tlsChannelCredentialsOptions.set_check_call_host(false);
   tlsChannelCredentialsOptions.set_certificate_verifier(
-    grpc::experimental::ExternalCertificateVerifier::Create<HederaCertificateVerifier>(mAddress->getCertificateHash()));
+    grpc::experimental::ExternalCertificateVerifier::Create<HederaCertificateVerifier>(mAddress->getNodeCertHash()));
 
   // Feed in the root CA's file manually for Windows (this is a bug in the gRPC implementation and says here
   // https://deploy-preview-763--grpc-io.netlify.app/docs/guides/auth/#using-client-side-ssltls that this needs to be
@@ -162,7 +162,7 @@ void Node::setTLSBehavior(TLSBehavior desiredBehavior)
   }
 
   // In order to use TLS, a node certificate chain must be provided
-  if (desiredBehavior == TLSBehavior::REQUIRE && mAddress->getCertificateHash().empty())
+  if (desiredBehavior == TLSBehavior::REQUIRE && mAddress->getNodeCertHash().empty())
   {
     throw UninitializedException("NodeAddress has empty certificate chain hash for TLS connection");
   }

--- a/sdk/main/src/impl/Node.cc
+++ b/sdk/main/src/impl/Node.cc
@@ -213,7 +213,7 @@ std::chrono::duration<double> Node::getRemainingTimeForBackoff() const
 //-----
 bool Node::initializeChannel(const std::chrono::system_clock::time_point& deadline)
 {
-  const std::vector<Endpoint> endpoints = mAddress->getEndpoints();
+  const std::vector<std::shared_ptr<Endpoint>> endpoints = mAddress->getEndpoints();
 
   std::shared_ptr<grpc::ChannelCredentials> channelCredentials = nullptr;
   for (const auto& endpoint : endpoints)
@@ -222,7 +222,7 @@ bool Node::initializeChannel(const std::chrono::system_clock::time_point& deadli
     {
       case TLSBehavior::REQUIRE:
       {
-        if (NodeAddress::isTlsPort(endpoint.getPort()))
+        if (NodeAddress::isTlsPort(endpoint.get()->getPort()))
         {
           channelCredentials = mTlsChannelCredentials;
         }
@@ -232,7 +232,7 @@ bool Node::initializeChannel(const std::chrono::system_clock::time_point& deadli
 
       case TLSBehavior::DISABLE:
       {
-        if (NodeAddress::isNonTlsPort(endpoint.getPort()))
+        if (NodeAddress::isNonTlsPort(endpoint.get()->getPort()))
         {
           channelCredentials = grpc::InsecureChannelCredentials();
         }
@@ -250,7 +250,7 @@ bool Node::initializeChannel(const std::chrono::system_clock::time_point& deadli
     {
       shutdown();
 
-      mChannel = grpc::CreateChannel(endpoint.toString(), channelCredentials);
+      mChannel = grpc::CreateChannel(endpoint.get()->toString(), channelCredentials);
 
       if (mChannel->WaitForConnected(deadline))
       {

--- a/sdk/main/src/impl/Node.cc
+++ b/sdk/main/src/impl/Node.cc
@@ -222,7 +222,7 @@ bool Node::initializeChannel(const std::chrono::system_clock::time_point& deadli
     {
       case TLSBehavior::REQUIRE:
       {
-        if (NodeAddress::isTlsPort(endpoint.get()->getPort()))
+        if (NodeAddress::isTlsPort(endpoint->getPort()))
         {
           channelCredentials = mTlsChannelCredentials;
         }
@@ -232,7 +232,7 @@ bool Node::initializeChannel(const std::chrono::system_clock::time_point& deadli
 
       case TLSBehavior::DISABLE:
       {
-        if (NodeAddress::isNonTlsPort(endpoint.get()->getPort()))
+        if (NodeAddress::isNonTlsPort(endpoint->getPort()))
         {
           channelCredentials = grpc::InsecureChannelCredentials();
         }
@@ -250,7 +250,7 @@ bool Node::initializeChannel(const std::chrono::system_clock::time_point& deadli
     {
       shutdown();
 
-      mChannel = grpc::CreateChannel(endpoint.get()->toString(), channelCredentials);
+      mChannel = grpc::CreateChannel(endpoint->toString(), channelCredentials);
 
       if (mChannel->WaitForConnected(deadline))
       {

--- a/sdk/main/src/impl/NodeAddress.cc
+++ b/sdk/main/src/impl/NodeAddress.cc
@@ -197,7 +197,7 @@ std::string NodeAddress::toString() const
       }
       else
       {
-        outputStream << std::setw(columnWidth) << "" << endpoint->toString();
+        outputStream << std::setw(columnWidth) << endpoint->toString();
       }
 
       ++counter;

--- a/sdk/main/src/impl/NodeAddress.cc
+++ b/sdk/main/src/impl/NodeAddress.cc
@@ -43,9 +43,10 @@ NodeAddress NodeAddress::fromProtobuf(const proto::NodeAddress& protoNodeAddress
 
   outputNodeAddress.mRSAPublicKey = protoNodeAddress.rsa_pubkey();
   outputNodeAddress.mNodeId = protoNodeAddress.nodeid();
-  outputNodeAddress.mCertificateHash = protoNodeAddress.nodecerthash();
+  outputNodeAddress.mNodeAccountId = AccountId::fromProtobuf(protoNodeAddress.nodeaccountid());
+  outputNodeAddress.mNodeCertHash = protoNodeAddress.nodecerthash();
   outputNodeAddress.mDescription = protoNodeAddress.description();
-  outputNodeAddress.mAccountId = AccountId::fromProtobuf(protoNodeAddress.nodeaccountid());
+  outputNodeAddress.mStake = protoNodeAddress.stake();
 
   return outputNodeAddress;
 }
@@ -56,12 +57,13 @@ std::string NodeAddress::toString() const
 
   int columnWidth = 20;
   outputStream << std::setw(columnWidth) << std::right << "NodeId: " << std::left << mNodeId << std::endl;
-  outputStream << std::setw(columnWidth) << std::right << "AccountId: " << std::left << mAccountId.toString()
+  outputStream << std::setw(columnWidth) << std::right << "AccountId: " << std::left << mNodeAccountId.toString()
                << std::endl;
   outputStream << std::setw(columnWidth) << std::right << "Description: " << std::left << mDescription << std::endl;
   outputStream << std::setw(columnWidth) << std::right << "RSA Public Key: " << std::left << mRSAPublicKey << std::endl;
-  outputStream << std::setw(columnWidth) << std::right << "Certificate Hash: " << std::left << mCertificateHash
+  outputStream << std::setw(columnWidth) << std::right << "Certificate Hash: " << std::left << mNodeCertHash
                << std::endl;
+  outputStream << std::setw(columnWidth) << std::right << "Stake: " << std::left << mStake << std::endl;
   outputStream << std::setw(columnWidth) << std::right << "Endpoints: ";
 
   if (size_t endpointCount = mEndpoints.size(); !endpointCount)

--- a/sdk/main/src/impl/NodeAddress.cc
+++ b/sdk/main/src/impl/NodeAddress.cc
@@ -18,6 +18,7 @@
  *
  */
 #include "impl/NodeAddress.h"
+#include "impl/Endpoint.h"
 #include "impl/IPv4Address.h"
 
 #include <iomanip>
@@ -27,6 +28,20 @@
 
 namespace Hedera::internal
 {
+//-----
+NodeAddress::NodeAddress(const std::string address, const int port)
+{
+  unsigned char octet1 = 1;
+  unsigned char octet2 = 2;
+  unsigned char octet3 = 3;
+  unsigned char octet4 = 4;
+
+  IPv4Address ipAddress_v4 = IPv4Address(octet1, octet2, octet3, octet4);
+  Endpoint endpoint = Endpoint(ipAddress_v4, port);
+
+  mEndpoints.push_back(endpoint);
+}
+
 //-----
 NodeAddress NodeAddress::fromProtobuf(const proto::NodeAddress& protoNodeAddress)
 {

--- a/sdk/main/src/impl/NodeAddress.cc
+++ b/sdk/main/src/impl/NodeAddress.cc
@@ -29,7 +29,7 @@
 namespace Hedera::internal
 {
 //-----
-NodeAddress::NodeAddress(const std::string ipAddressV4, const int port)
+NodeAddress::NodeAddress(const std::string& ipAddressV4, const int port)
 {
   std::vector<unsigned char> octets;
   std::stringstream strStream(ipAddressV4);
@@ -125,7 +125,7 @@ NodeAddress& NodeAddress::setRSAPublicKey(const std::string& publicKey)
 }
 
 //-----
-NodeAddress& NodeAddress::setNodeId(const int64_t nodeId)
+NodeAddress& NodeAddress::setNodeId(const int64_t& nodeId)
 {
   mNodeId = nodeId;
   return *this;
@@ -161,7 +161,7 @@ NodeAddress& NodeAddress::setDescription(const std::string& description)
 }
 
 //-----
-NodeAddress& NodeAddress::setStake(const int64_t stake)
+NodeAddress& NodeAddress::setStake(const int64_t& stake)
 {
   mStake = stake;
   return *this;

--- a/sdk/main/src/impl/NodeAddress.cc
+++ b/sdk/main/src/impl/NodeAddress.cc
@@ -26,6 +26,7 @@
 
 namespace Hedera::internal
 {
+//-----
 NodeAddress NodeAddress::fromProtobuf(const proto::NodeAddress& protoNodeAddress)
 {
   NodeAddress outputNodeAddress;
@@ -51,6 +52,28 @@ NodeAddress NodeAddress::fromProtobuf(const proto::NodeAddress& protoNodeAddress
   return outputNodeAddress;
 }
 
+//-----
+NodeAddress& NodeAddress::setNodeId(const int64_t nodeId)
+{
+  mNodeId = nodeId;
+  return *this;
+}
+
+//-----
+NodeAddress& NodeAddress::setNodeAccountId(const AccountId& accountId)
+{
+  mNodeAccountId = accountId;
+  return *this;
+}
+
+//-----
+NodeAddress& NodeAddress::setNodeCertHash(const std::string& certHash)
+{
+  mNodeCertHash = certHash;
+  return *this;
+}
+
+//-----
 std::string NodeAddress::toString() const
 {
   std::stringstream outputStream;

--- a/sdk/main/src/impl/NodeAddress.cc
+++ b/sdk/main/src/impl/NodeAddress.cc
@@ -160,7 +160,7 @@ NodeAddress& NodeAddress::setDescription(std::string_view description)
 }
 
 //-----
-NodeAddress& NodeAddress::setStake(const int64_t& stake)
+NodeAddress& NodeAddress::setStake(const uint64_t& stake)
 {
   mStake = stake;
   return *this;

--- a/sdk/main/src/impl/NodeAddress.cc
+++ b/sdk/main/src/impl/NodeAddress.cc
@@ -29,7 +29,7 @@
 namespace Hedera::internal
 {
 //-----
-NodeAddress::NodeAddress(std::string_view ipAddressV4, const int port)
+NodeAddress::NodeAddress(std::string_view ipAddressV4, int port)
 {
   std::vector<unsigned char> octets;
   std::stringstream strStream({ ipAddressV4.begin(), ipAddressV4.end() });

--- a/sdk/main/src/impl/NodeAddress.cc
+++ b/sdk/main/src/impl/NodeAddress.cc
@@ -53,10 +53,17 @@ NodeAddress NodeAddress::fromProtobuf(const proto::NodeAddress& protoNodeAddress
 }
 
 //-----
-NodeAddress NodeAddress::fromString(const std::string addressString)
+NodeAddress NodeAddress::fromString(const std::string& addressString)
 {
   NodeAddress outputNodeAddress;
   return outputNodeAddress;
+}
+
+//-----
+NodeAddress& NodeAddress::setRSAPublicKey(const std::string& publicKey)
+{
+  mRSAPublicKey = publicKey;
+  return *this;
 }
 
 //-----
@@ -77,6 +84,28 @@ NodeAddress& NodeAddress::setNodeAccountId(const AccountId& accountId)
 NodeAddress& NodeAddress::setNodeCertHash(const std::string& certHash)
 {
   mNodeCertHash = certHash;
+  return *this;
+}
+
+//-----
+NodeAddress& NodeAddress::setEndpoints(const std::vector<Endpoint>& endpoints)
+{
+  mEndpoints.clear();
+  mEndpoints.assign(endpoints.begin(), endpoints.end());
+  return *this;
+}
+
+//-----
+NodeAddress& NodeAddress::setDescription(const std::string& description)
+{
+  mDescription = description;
+  return *this;
+}
+
+//-----
+NodeAddress& NodeAddress::setStake(const int64_t stake)
+{
+  mStake = stake;
   return *this;
 }
 

--- a/sdk/main/src/impl/NodeAddress.cc
+++ b/sdk/main/src/impl/NodeAddress.cc
@@ -43,7 +43,7 @@ NodeAddress::NodeAddress(std::string_view ipAddressV4, const int port)
 
       if (octet > 0)
       {
-        octets.push_back((unsigned char)octet);
+        octets.push_back(static_cast<unsigned char>(octet));
       }
     }
   }

--- a/sdk/main/src/impl/NodeAddress.cc
+++ b/sdk/main/src/impl/NodeAddress.cc
@@ -26,11 +26,6 @@
 #include <proto/basic_types.pb.h>
 #include <sstream>
 
-#include <iostream>
-
-using std::cout;
-using std::endl;
-
 namespace Hedera::internal
 {
 //-----
@@ -99,14 +94,27 @@ NodeAddress NodeAddress::fromString(const std::string& nodeAddress)
 {
   std::vector<std::string> parts;
   std::stringstream strStream(nodeAddress);
-  std::string temp;
+  std::string ipAddressV4;
+  int port;
 
-  while (getline(strStream, temp, ':'))
+  try
   {
-    parts.push_back(temp.c_str());
+    std::string temp;
+
+    while (getline(strStream, temp, ':'))
+    {
+      parts.push_back(temp.c_str());
+    }
+
+    ipAddressV4 = parts[0].c_str();
+    port = atoi(parts[1].c_str());
+  }
+  catch (const std::exception& e)
+  {
+    throw IllegalStateException("Failed to parse the node address.");
   }
 
-  return NodeAddress(parts[0].c_str(), atoi(parts[1].c_str()));
+  return NodeAddress(ipAddressV4, port);
 }
 
 //-----

--- a/sdk/main/src/impl/NodeAddress.cc
+++ b/sdk/main/src/impl/NodeAddress.cc
@@ -148,8 +148,7 @@ NodeAddress& NodeAddress::setNodeCertHash(std::string_view certHash)
 //-----
 NodeAddress& NodeAddress::setEndpoints(const std::vector<std::shared_ptr<Endpoint>>& endpoints)
 {
-  mEndpoints.clear();
-  mEndpoints.assign(endpoints.begin(), endpoints.end());
+  mEndpoints = endpoints;
   return *this;
 }
 

--- a/sdk/main/src/impl/NodeAddress.cc
+++ b/sdk/main/src/impl/NodeAddress.cc
@@ -29,10 +29,10 @@
 namespace Hedera::internal
 {
 //-----
-NodeAddress::NodeAddress(const std::string& ipAddressV4, const int port)
+NodeAddress::NodeAddress(std::string_view ipAddressV4, const int port)
 {
   std::vector<unsigned char> octets;
-  std::stringstream strStream(ipAddressV4);
+  std::stringstream strStream({ ipAddressV4.begin(), ipAddressV4.end() });
   std::string temp;
 
   try
@@ -90,10 +90,10 @@ NodeAddress NodeAddress::fromProtobuf(const proto::NodeAddress& protoNodeAddress
 }
 
 //-----
-NodeAddress NodeAddress::fromString(const std::string& nodeAddress)
+NodeAddress NodeAddress::fromString(std::string_view nodeAddress)
 {
   std::vector<std::string> parts;
-  std::stringstream strStream(nodeAddress);
+  std::stringstream strStream({ nodeAddress.begin(), nodeAddress.end() });
   std::string ipAddressV4;
   int port;
 
@@ -118,7 +118,7 @@ NodeAddress NodeAddress::fromString(const std::string& nodeAddress)
 }
 
 //-----
-NodeAddress& NodeAddress::setRSAPublicKey(const std::string& publicKey)
+NodeAddress& NodeAddress::setRSAPublicKey(std::string_view publicKey)
 {
   mRSAPublicKey = publicKey;
   return *this;
@@ -139,7 +139,7 @@ NodeAddress& NodeAddress::setNodeAccountId(const AccountId& accountId)
 }
 
 //-----
-NodeAddress& NodeAddress::setNodeCertHash(const std::string& certHash)
+NodeAddress& NodeAddress::setNodeCertHash(std::string_view certHash)
 {
   mNodeCertHash = certHash;
   return *this;
@@ -154,7 +154,7 @@ NodeAddress& NodeAddress::setEndpoints(const std::vector<std::shared_ptr<Endpoin
 }
 
 //-----
-NodeAddress& NodeAddress::setDescription(const std::string& description)
+NodeAddress& NodeAddress::setDescription(std::string_view description)
 {
   mDescription = description;
   return *this;

--- a/sdk/main/src/impl/NodeAddress.cc
+++ b/sdk/main/src/impl/NodeAddress.cc
@@ -53,6 +53,13 @@ NodeAddress NodeAddress::fromProtobuf(const proto::NodeAddress& protoNodeAddress
 }
 
 //-----
+static NodeAddress fromString(const std::string addressString)
+{
+  NodeAddress outputNodeAddress;
+  return outputNodeAddress;
+}
+
+//-----
 NodeAddress& NodeAddress::setNodeId(const int64_t nodeId)
 {
   mNodeId = nodeId;

--- a/sdk/main/src/impl/NodeAddress.cc
+++ b/sdk/main/src/impl/NodeAddress.cc
@@ -18,6 +18,7 @@
  *
  */
 #include "impl/NodeAddress.h"
+#include "impl/IPv4Address.h"
 
 #include <iomanip>
 #include <memory>
@@ -153,6 +154,12 @@ std::string NodeAddress::toString() const
   }
 
   return outputStream.str();
+}
+
+IPv4Address& NodeAddress::getAddress() const
+{
+  auto ipAddress = mEndpoints.front().getAddress();
+  return ipAddress;
 }
 
 } // namespace Hedera::internal

--- a/sdk/main/src/impl/NodeAddress.cc
+++ b/sdk/main/src/impl/NodeAddress.cc
@@ -53,7 +53,7 @@ NodeAddress NodeAddress::fromProtobuf(const proto::NodeAddress& protoNodeAddress
 }
 
 //-----
-static NodeAddress fromString(const std::string addressString)
+NodeAddress NodeAddress::fromString(const std::string addressString)
 {
   NodeAddress outputNodeAddress;
   return outputNodeAddress;

--- a/sdk/main/src/impl/NodeAddress.cc
+++ b/sdk/main/src/impl/NodeAddress.cc
@@ -194,11 +194,11 @@ std::string NodeAddress::toString() const
     {
       if (counter == 0)
       {
-        outputStream << endpoint.get()->toString();
+        outputStream << endpoint->toString();
       }
       else
       {
-        outputStream << std::setw(columnWidth) << "" << endpoint.get()->toString();
+        outputStream << std::setw(columnWidth) << "" << endpoint->toString();
       }
 
       ++counter;

--- a/sdk/tests/CMakeLists.txt
+++ b/sdk/tests/CMakeLists.txt
@@ -30,6 +30,7 @@ add_executable(${TEST_PROJECT_NAME}
         HbarTest.cc
         JSONTest.cc
         NftIdTest.cc
+        NodeAddressTest.cc
         TokenIdTest.cc
         TokenNftTransferTest.cc
         TokenTransferTest.cc

--- a/sdk/tests/NodeAddressTest.cc
+++ b/sdk/tests/NodeAddressTest.cc
@@ -1,0 +1,41 @@
+/*-
+ *
+ * Hedera C++ SDK
+ *
+ * Copyright (C) 2020 - 2022 Hedera Hashgraph, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+#include "impl/NodeAddress.h"
+
+#include <gtest/gtest.h>
+
+using namespace Hedera::internal;
+
+class NodeAddressTest : public ::testing::Test
+{
+protected:
+  [[nodiscard]] inline const std::string& getTestAddress() const { return mTestAddress; }
+
+private:
+  const std::string mTestAddress = "35.237.200.180:50211";
+};
+
+//-----
+TEST_F(NodeAddressTest, ConstructFromString)
+{
+  NodeAddress nodeAddres = NodeAddress::fromString(getTestAddress());
+
+  EXPECT_TRUE(true);
+}

--- a/sdk/tests/NodeAddressTest.cc
+++ b/sdk/tests/NodeAddressTest.cc
@@ -26,11 +26,36 @@ using namespace Hedera::internal;
 class NodeAddressTest : public ::testing::Test
 {
 protected:
+  [[nodiscard]] inline const int getTestPort() const { return mTestPort; }
   [[nodiscard]] inline const std::string& getTestAddress() const { return mTestAddress; }
 
 private:
+  const int mTestPort = 50211;
   const std::string mTestAddress = "35.237.200.180:50211";
 };
+
+//-----
+TEST_F(NodeAddressTest, DefaultConstructNodeAddress)
+{
+  // Given
+  const int testPort = getTestPort();
+
+  // When
+  const NodeAddress nodeAddress;
+
+  // Then
+  EXPECT_FALSE(nodeAddress.isTlsPort(testPort));
+  EXPECT_TRUE(nodeAddress.isNonTlsPort(testPort));
+  EXPECT_EQ(nodeAddress.getNodeId(), -1);
+  EXPECT_EQ(nodeAddress.getNodeAccountId().getShardNum(), 0ULL);
+  EXPECT_EQ(nodeAddress.getNodeAccountId().getRealmNum(), 0ULL);
+  EXPECT_FALSE(nodeAddress.getNodeAccountId().getAccountNum().has_value());
+  EXPECT_EQ(nodeAddress.getNodeAccountId().getAlias(), nullptr);
+  EXPECT_FALSE(nodeAddress.getNodeAccountId().getEvmAddress().has_value());
+  EXPECT_TRUE(nodeAddress.getNodeCertHash().empty());
+  EXPECT_TRUE(nodeAddress.getDescription().empty());
+  EXPECT_TRUE(nodeAddress.getEndpoints().empty());
+}
 
 //-----
 TEST_F(NodeAddressTest, ConstructFromString)

--- a/sdk/tests/NodeAddressTest.cc
+++ b/sdk/tests/NodeAddressTest.cc
@@ -18,6 +18,7 @@
  *
  */
 #include "impl/NodeAddress.h"
+#include "impl/IPv4Address.h"
 
 #include <gtest/gtest.h>
 
@@ -27,11 +28,11 @@ class NodeAddressTest : public ::testing::Test
 {
 protected:
   [[nodiscard]] inline const int getTestPort() const { return mTestPort; }
-  [[nodiscard]] inline const std::string& getTestAddress() const { return mTestAddress; }
+  [[nodiscard]] inline const std::string& getTestIpAddress() const { return mTestIpAddress; }
 
 private:
   const int mTestPort = 50211;
-  const std::string mTestAddress = "35.237.200.180:50211";
+  const std::string mTestIpAddress = "35.237.200.180:50211";
 };
 
 //-----
@@ -60,7 +61,13 @@ TEST_F(NodeAddressTest, DefaultConstructNodeAddress)
 //-----
 TEST_F(NodeAddressTest, ConstructFromString)
 {
-  NodeAddress nodeAddres = NodeAddress::fromString(getTestAddress());
+  // Given
+  const std::string testIpAddress = getTestIpAddress();
 
-  EXPECT_TRUE(true);
+  // When
+  NodeAddress nodeAddress = NodeAddress::fromString(testIpAddress);
+
+  // Then
+  EXPECT_EQ(nodeAddress.getAddress().toString(), "35.237.200.180");
+  EXPECT_EQ(nodeAddress.getAddress().toString(), "35.237.200.180");
 }

--- a/sdk/tests/NodeAddressTest.cc
+++ b/sdk/tests/NodeAddressTest.cc
@@ -36,18 +36,21 @@ protected:
   [[nodiscard]] inline const std::string& getTestRSAPublicKey() const { return mTestRSAPublicKey; }
   [[nodiscard]] inline const std::string& getTestIpAddress() const { return mTestIpAddress; }
   [[nodiscard]] inline const std::string& getTestDescription() const { return mDescription; }
-  [[nodiscard]] const std::string getTestNodeAddress() const
+  [[nodiscard]] const std::string getTestNodeAddress() const { return mTestNodeAddress; }
+
+  void SetUp() override
   {
     const int testPortTLS = getTestPortTLS();
     std::stringstream outputStream;
     outputStream << getTestIpAddress() << ":" << std::to_string(testPortTLS);
-    return outputStream.str();
+    mTestNodeAddress = outputStream.str();
   }
 
 private:
   const int64_t mTestNodeId = 9;
   const int mTestPortTLS = 50212;
   const int mTestPortPlain = 50211;
+  std::string mTestNodeAddress;
   const std::string mTestRSAPublicKey = "TestPublicKey";
   const std::string mTestIpAddress = "35.237.200.180";
   const std::string mDescription = "Test Description";

--- a/sdk/tests/NodeAddressTest.cc
+++ b/sdk/tests/NodeAddressTest.cc
@@ -18,6 +18,7 @@
  *
  */
 #include "impl/NodeAddress.h"
+#include "exceptions/IllegalStateException.h"
 #include "impl/IPv4Address.h"
 
 #include <gtest/gtest.h>
@@ -73,6 +74,18 @@ TEST_F(NodeAddressTest, DefaultConstructNodeAddress)
   EXPECT_TRUE(nodeAddress.getNodeCertHash().empty());
   EXPECT_TRUE(nodeAddress.getDescription().empty());
   EXPECT_TRUE(nodeAddress.getEndpoints().empty());
+}
+
+// Test creation of NodeAddress instance using the default constructor.
+TEST_F(NodeAddressTest, ConstructFromStringAndThrowException)
+{
+  // Given
+  const std::string testNodeAddress_1 = "1";
+  const std::string testNodeAddress_2 = "aaa.bbb.ccc.ddd";
+
+  // When & Then
+  EXPECT_THROW(NodeAddress::fromString(testNodeAddress_1), Hedera::IllegalStateException);
+  EXPECT_THROW(NodeAddress::fromString(testNodeAddress_2), Hedera::IllegalStateException);
 }
 
 // Test creation of NodeAddress instance using a protobuf object.

--- a/sdk/tests/NodeAddressTest.cc
+++ b/sdk/tests/NodeAddressTest.cc
@@ -40,9 +40,10 @@ TEST_F(NodeAddressTest, DefaultConstructNodeAddress)
 {
   // Given
   const int testPort = getTestPort();
+  const std::string testIpAddress = getTestIpAddress();
 
   // When
-  const NodeAddress nodeAddress;
+  const NodeAddress nodeAddress = NodeAddress::fromString(testIpAddress);
 
   // Then
   EXPECT_FALSE(nodeAddress.isTlsPort(testPort));

--- a/sdk/tests/NodeAddressTest.cc
+++ b/sdk/tests/NodeAddressTest.cc
@@ -29,10 +29,12 @@ using namespace Hedera::internal;
 class NodeAddressTest : public ::testing::Test
 {
 protected:
-  [[nodiscard]] inline const int& getTestNodeId() const { return mTestNodeId; }
+  [[nodiscard]] inline const int64_t& getTestNodeId() const { return mTestNodeId; }
   [[nodiscard]] inline const int& getTestPortTLS() const { return mTestPortTLS; }
   [[nodiscard]] inline const int& getTestPortPlain() const { return mTestPortPlain; }
+  [[nodiscard]] inline const std::string& getTestRSAPublicKey() const { return mTestRSAPublicKey; }
   [[nodiscard]] inline const std::string& getTestIpAddress() const { return mTestIpAddress; }
+  [[nodiscard]] inline const std::string& getTestDescription() const { return mDescription; }
   [[nodiscard]] const std::string getTestNodeAddress() const
   {
     const int testPortTLS = getTestPortTLS();
@@ -45,7 +47,9 @@ private:
   const int64_t mTestNodeId = 9;
   const int mTestPortTLS = 50212;
   const int mTestPortPlain = 50211;
+  const std::string mTestRSAPublicKey = "TestPublicKey";
   const std::string mTestIpAddress = "35.237.200.180";
+  const std::string mDescription = "Test Description";
 };
 
 // Test creation of NodeAddress instance using the default constructor.
@@ -53,11 +57,9 @@ TEST_F(NodeAddressTest, DefaultConstructNodeAddress)
 {
   // Given
   const int testPortTLS = getTestPortTLS();
-  const std::string& testIpAddress = getTestIpAddress();
-  const std::string testNodeAddress = getTestNodeAddress();
 
   // When
-  const NodeAddress nodeAddress = NodeAddress::fromString(testNodeAddress);
+  const NodeAddress nodeAddress;
 
   // Then
   EXPECT_TRUE(nodeAddress.isTlsPort(testPortTLS));
@@ -70,7 +72,7 @@ TEST_F(NodeAddressTest, DefaultConstructNodeAddress)
   EXPECT_FALSE(nodeAddress.getNodeAccountId().getEvmAddress().has_value());
   EXPECT_TRUE(nodeAddress.getNodeCertHash().empty());
   EXPECT_TRUE(nodeAddress.getDescription().empty());
-  EXPECT_FALSE(nodeAddress.getEndpoints().empty());
+  EXPECT_TRUE(nodeAddress.getEndpoints().empty());
 }
 
 // Test creation of NodeAddress instance using a protobuf object.
@@ -79,11 +81,13 @@ TEST_F(NodeAddressTest, ConstructFromProtobuf)
   // Given
   const int testPortPlain = getTestPortPlain();
   const int64_t testNodeId = getTestNodeId();
+  const std::string& testRSAPublicKey = getTestRSAPublicKey();
   const std::string& testIpAddressV4 = getTestIpAddress();
-  const std::string testDescription = "Test Description";
+  const std::string& testDescription = getTestDescription();
   proto::NodeAddress testProtoNodeAddress = proto::NodeAddress();
   testProtoNodeAddress.set_nodeid(testNodeId);
   testProtoNodeAddress.set_description(testDescription);
+  testProtoNodeAddress.set_rsa_pubkey(testRSAPublicKey);
   proto::ServiceEndpoint* serviceEndpoint = testProtoNodeAddress.add_serviceendpoint();
   serviceEndpoint->set_ipaddressv4(testIpAddressV4);
   serviceEndpoint->set_port(testPortPlain);
@@ -94,6 +98,12 @@ TEST_F(NodeAddressTest, ConstructFromProtobuf)
   // Then
   EXPECT_EQ(nodeAddress.getDefaultIpAddress().toString(), testIpAddressV4);
   EXPECT_EQ(nodeAddress.getDefaultPort(), getTestPortTLS());
+  EXPECT_EQ(nodeAddress.getNodeId(), testNodeId);
+  EXPECT_EQ(nodeAddress.getPublicKey(), testRSAPublicKey);
+  EXPECT_EQ(nodeAddress.getNodeAccountId().getShardNum(), 0ULL);
+  EXPECT_EQ(nodeAddress.getNodeAccountId().getRealmNum(), 0ULL);
+  EXPECT_FALSE(nodeAddress.getNodeAccountId().getAccountNum().has_value());
+  EXPECT_EQ(nodeAddress.getNodeAccountId().getAlias(), nullptr);
   EXPECT_FALSE(nodeAddress.getNodeAccountId().getEvmAddress().has_value());
   EXPECT_TRUE(nodeAddress.getNodeCertHash().empty());
   EXPECT_FALSE(nodeAddress.getDescription().empty());
@@ -115,6 +125,12 @@ TEST_F(NodeAddressTest, ConstructFromString)
   // Then
   EXPECT_EQ(nodeAddress.getDefaultIpAddress().toString(), testIpAddressV4);
   EXPECT_EQ(nodeAddress.getDefaultPort(), testPort);
+  EXPECT_EQ(nodeAddress.getNodeId(), -1);
+  EXPECT_FALSE(nodeAddress.getNodeAccountId().getEvmAddress().has_value());
+  EXPECT_EQ(nodeAddress.getNodeAccountId().getShardNum(), 0ULL);
+  EXPECT_EQ(nodeAddress.getNodeAccountId().getRealmNum(), 0ULL);
+  EXPECT_FALSE(nodeAddress.getNodeAccountId().getAccountNum().has_value());
+  EXPECT_EQ(nodeAddress.getNodeAccountId().getAlias(), nullptr);
   EXPECT_FALSE(nodeAddress.getNodeAccountId().getEvmAddress().has_value());
   EXPECT_TRUE(nodeAddress.getNodeCertHash().empty());
   EXPECT_TRUE(nodeAddress.getDescription().empty());


### PR DESCRIPTION
**Description**:
This PR introduces a complete implementation for class `NodeAddress`. Added the following:
- constructor `NodeAddress(const std::string ipAddressV4, const int port)`;
- static factory method `NodeAddress::fromString(const std::string addressString)`;
- new `setters` methods - `setRSAPublicKey`, `setNodeId`, `setNodeAccountId`, `setNodeCertHash`, `setEndpoints`, `setDescription` and `setStake`;
- new `getters` methods - `getDefaultIpAddress`, `getDefaultPort`, `getNodeId`, `getPublicKey`, `getNodeAccountId`, `getNodeCertHash`, `getDefaultEndpoint`, `getEndpoints`, `getDescription` and `getStake`;
- new tests suite `NodeAddressTest` to verify class `NodeAddress`.

**Related issue(s)**:

Fixes [#217](https://github.com/hashgraph/hedera-sdk-cpp/issues/217)

**Notes for reviewer**:
For reference was used the [Java SDK](https://github.com/hashgraph/hedera-sdk-java) implementation of class [BaseNodeAddress.java](https://github.com/hashgraph/hedera-sdk-java/blob/develop/sdk/src/main/java/com/hedera/hashgraph/sdk/BaseNodeAddress.java) and class [NodeAddress.java](https://github.com/hashgraph/hedera-sdk-java/blob/develop/sdk/src/main/java/com/hedera/hashgraph/sdk/NodeAddress.java).

Also the official Hedera's SDK reference documentation was followed for [NodeAddress](https://docs.hedera.com/hedera/sdks-and-apis/hedera-api/basic-types/nodeaddress).

The following should be taken in account:
 - Calling the constructor `NodeAddress::NodeAddress(const std::string ipAddressV4, const int port)` with wrong format of the IPv4 address will result in throwing an `IllegalStateException` exception. The text message was taken from Java implementation of [NodeAddres.java](https://github.com/hashgraph/hedera-sdk-java/blob/2ff932e2e8e530bdd520efca346b3f26357132bb/sdk/src/main/java/com/hedera/hashgraph/sdk/BaseNodeAddress.java#L76).
 - Calling the factory method `NodeAddress::fromString(const std::string& nodeAddress)` with different format than `35.237.200.180:50212` will result in throwing an `IllegalStateException` exception. 
 - instance methods `getDefaultIpAddress()`, `getDefaultPort()` and `getDefaultEndpoint()` return data only for the first `Endpoint` object from vector `mEndpoints`;
 - in class `NodeAddress` instance variable `mEndpoints` updated to be of type `std::vector<std::shared_ptr<Endpoint>>`
 - more unit tests should be added to `NodeAddressTest`.
 - in `NodeAddressTest` private variable `mTestRSAPublicKey` is not using the proper value for RSA PublicKey.
 - class `Endpoint` was refactored;
 - class `Node` was also refactored;

**Checklist**

- [x] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
