### PR TITLE
Switch `std::vector<unsigned char>` to `std::vector<std::byte>`

### DIFF
--- a/sdk/main/include/Client.h
+++ b/sdk/main/include/Client.h
@@ -88,7 +88,7 @@ public:
    * @return The bytes with the signature of this Client's operator appended.
    * @throws UninitializedException If this Client's operator has not yet been set.
    */
-  [[nodiscard]] std::vector<unsigned char> sign(const std::vector<unsigned char>& bytes) const;
+  [[nodiscard]] std::vector<std::byte> sign(const std::vector<std::byte>& bytes) const;
 
   /**
    * Get a list of pointers to Nodes on this Client's network that are associated with the input account IDs. If no

--- a/sdk/main/include/ECDSAsecp256k1PrivateKey.h
+++ b/sdk/main/include/ECDSAsecp256k1PrivateKey.h
@@ -48,9 +48,11 @@ public:
   /**
    * The prefix bytes of a DER-encoded ECDSAsecp256k1PrivateKey.
    */
-  static inline const std::vector<unsigned char> DER_ENCODED_PREFIX_BYTES = { 0x30, 0x30, 0x02, 0x01, 0x00, 0x30,
-                                                                              0x07, 0x06, 0x05, 0x2B, 0x81, 0x04,
-                                                                              0x00, 0x0A, 0x04, 0x22, 0x04, 0x20 };
+  static inline const std::vector<std::byte> DER_ENCODED_PREFIX_BYTES = {
+    std::byte(0x30), std::byte(0x30), std::byte(0x02), std::byte(0x01), std::byte(0x00), std::byte(0x30),
+    std::byte(0x07), std::byte(0x06), std::byte(0x05), std::byte(0x2B), std::byte(0x81), std::byte(0x04),
+    std::byte(0x00), std::byte(0x0A), std::byte(0x04), std::byte(0x22), std::byte(0x04), std::byte(0x20)
+  };
 
   /**
    * The hex-encoded string of the DER-encoded prefix bytes of an ECDSAsecp256k1PrivateKey.
@@ -107,7 +109,7 @@ public:
    * @return A pointer to an ECDSAsecp256k1PrivateKey representing the input bytes.
    * @throws BadKeyException If an ECDSAsecp256k1PrivateKey cannot be realized from the input bytes.
    */
-  [[nodiscard]] static std::unique_ptr<ECDSAsecp256k1PrivateKey> fromBytes(const std::vector<unsigned char>& bytes);
+  [[nodiscard]] static std::unique_ptr<ECDSAsecp256k1PrivateKey> fromBytes(const std::vector<std::byte>& bytes);
 
   /**
    * Construct an ECDSAsecp256k1PrivateKey from a seed array.
@@ -116,7 +118,7 @@ public:
    * @return A pointer to an ECDSAsecp256k1PrivateKey representing the input seed bytes.
    * @throws BadKeyException If an ECDSAsecp256k1PrivateKey cannot be realized from the input seed bytes.
    */
-  [[nodiscard]] static std::unique_ptr<ECDSAsecp256k1PrivateKey> fromSeed(const std::vector<unsigned char>& seed);
+  [[nodiscard]] static std::unique_ptr<ECDSAsecp256k1PrivateKey> fromSeed(const std::vector<std::byte>& seed);
 
   /**
    * Derived from PrivateKey. Create a clone of this ECDSAsecp256k1PrivateKey object.
@@ -142,7 +144,7 @@ public:
    * @return The signature of the byte array.
    * @throws OpenSSLException If OpenSSL is unable to generate a signature.
    */
-  [[nodiscard]] std::vector<unsigned char> sign(const std::vector<unsigned char>& bytesToSign) const override;
+  [[nodiscard]] std::vector<std::byte> sign(const std::vector<std::byte>& bytesToSign) const override;
 
   /**
    * Derived from PrivateKey. Get the hex-encoded string of the DER-encoded bytes of this ECDSAsecp256k1PrivateKey.
@@ -164,14 +166,14 @@ public:
    *
    * @return The DER-encoded bytes of this ECDSAsecp256k1PrivateKey.
    */
-  [[nodiscard]] std::vector<unsigned char> toBytesDer() const override;
+  [[nodiscard]] std::vector<std::byte> toBytesDer() const override;
 
   /**
    * Derived from PrivateKey. Get the raw, non-DER-encoded bytes of this ECDSAsecp256k1PrivateKey.
    *
    * @return The raw bytes of this ECDSAsecp256k1PrivateKey.
    */
-  [[nodiscard]] std::vector<unsigned char> toBytesRaw() const override;
+  [[nodiscard]] std::vector<std::byte> toBytesRaw() const override;
 
 private:
   /**
@@ -184,7 +186,7 @@ private:
    * @throws BadKeyException  If the chain code is malformed.
    */
   explicit ECDSAsecp256k1PrivateKey(internal::OpenSSLUtils::EVP_PKEY&& key,
-                                    std::vector<unsigned char> chainCode = std::vector<unsigned char>());
+                                    std::vector<std::byte> chainCode = std::vector<std::byte>());
 };
 
 } // namespace Hedera

--- a/sdk/main/include/ECDSAsecp256k1PublicKey.h
+++ b/sdk/main/include/ECDSAsecp256k1PublicKey.h
@@ -48,9 +48,11 @@ public:
   /**
    * The prefix bytes of a DER-encoded, uncompressed ECDSAsecp256k1PublicKey.
    */
-  static inline const std::vector<unsigned char> DER_ENCODED_UNCOMPRESSED_PREFIX_BYTES = {
-    0x30, 0x56, 0x30, 0x10, 0x06, 0x07, 0x2A, 0x86, 0x48, 0xCE, 0x3D, 0x02,
-    0x01, 0x06, 0x05, 0x2B, 0x81, 0x04, 0x00, 0x0A, 0x03, 0x42, 0x00
+  static inline const std::vector<std::byte> DER_ENCODED_UNCOMPRESSED_PREFIX_BYTES = {
+    std::byte(0x30), std::byte(0x56), std::byte(0x30), std::byte(0x10), std::byte(0x06), std::byte(0x07),
+    std::byte(0x2A), std::byte(0x86), std::byte(0x48), std::byte(0xCE), std::byte(0x3D), std::byte(0x02),
+    std::byte(0x01), std::byte(0x06), std::byte(0x05), std::byte(0x2B), std::byte(0x81), std::byte(0x04),
+    std::byte(0x00), std::byte(0x0A), std::byte(0x03), std::byte(0x42), std::byte(0x00)
   };
 
   /**
@@ -62,9 +64,11 @@ public:
   /**
    * The prefix bytes of a DER-encoded, compressed ECDSAsecp256k1PublicKey.
    */
-  static inline const std::vector<unsigned char> DER_ENCODED_COMPRESSED_PREFIX_BYTES = { 0x30, 0x2D, 0x30, 0x07, 0x06,
-                                                                                         0x05, 0x2B, 0x81, 0x04, 0x00,
-                                                                                         0x0A, 0x03, 0x22, 0x00 };
+  static inline const std::vector<std::byte> DER_ENCODED_COMPRESSED_PREFIX_BYTES = {
+    std::byte(0x30), std::byte(0x2D), std::byte(0x30), std::byte(0x07), std::byte(0x06),
+    std::byte(0x05), std::byte(0x2B), std::byte(0x81), std::byte(0x04), std::byte(0x00),
+    std::byte(0x0A), std::byte(0x03), std::byte(0x22), std::byte(0x00)
+  };
 
   /**
    * The hex-encoded string of the DER-encoded prefix bytes of a compressed ECDSAsecp256k1PublicKey.
@@ -94,7 +98,7 @@ public:
    * @return A pointer to an ECDSAsecp256k1PublicKey representing the input bytes.
    * @throws BadKeyException If an ECDSAsecp256k1PublicKey cannot be realized from the input bytes.
    */
-  [[nodiscard]] static std::shared_ptr<ECDSAsecp256k1PublicKey> fromBytes(const std::vector<unsigned char>& bytes);
+  [[nodiscard]] static std::shared_ptr<ECDSAsecp256k1PublicKey> fromBytes(const std::vector<std::byte>& bytes);
 
   /**
    * Converts an uncompressed ECDSAsecp256k1PublicKey byte vector to a compressed ECDSAsecp256k1PublicKey byte vector.
@@ -104,7 +108,7 @@ public:
    * @throws std::invalid_argument If the input bytes are not the correct uncompressed key size or malformed.
    * @throws OpenSSLException      If OpenSSL is unable to compress the input bytes.
    */
-  [[nodiscard]] static std::vector<unsigned char> compressBytes(const std::vector<unsigned char>& uncompressedBytes);
+  [[nodiscard]] static std::vector<std::byte> compressBytes(const std::vector<std::byte>& uncompressedBytes);
 
   /**
    * Converts a compressed ECDSAsecp256k1PublicKey byte vector to an uncompressed ECDSAsecp256k1PublicKey byte vector.
@@ -114,7 +118,7 @@ public:
    * @throws std::invalid_argument If the input bytes are not the correct compressed key size or malformed.
    * @throws OpenSSLException      If OpenSSL is unable to uncompress the input bytes.
    */
-  [[nodiscard]] static std::vector<unsigned char> uncompressBytes(const std::vector<unsigned char>& compressedBytes);
+  [[nodiscard]] static std::vector<std::byte> uncompressBytes(const std::vector<std::byte>& compressedBytes);
 
   /**
    * Derived from PublicKey. Create a clone of this ECDSAsecp256k1PublicKey object.
@@ -132,8 +136,8 @@ public:
    * @return \c TRUE if the signature is valid, otherwise \c FALSE.
    * @throws OpenSSLException If OpenSSL is unable to verify the signature.
    */
-  [[nodiscard]] bool verifySignature(const std::vector<unsigned char>& signatureBytes,
-                                     const std::vector<unsigned char>& signedBytes) const override;
+  [[nodiscard]] bool verifySignature(const std::vector<std::byte>& signatureBytes,
+                                     const std::vector<std::byte>& signedBytes) const override;
 
   /**
    * Derived from PublicKey. Get the hex-encoded string of the DER-encoded bytes of this ECDSAsecp256k1PublicKey.
@@ -154,14 +158,14 @@ public:
    *
    * @return The DER-encoded bytes of this ECDSAsecp256k1PublicKey.
    */
-  [[nodiscard]] std::vector<unsigned char> toBytesDer() const override;
+  [[nodiscard]] std::vector<std::byte> toBytesDer() const override;
 
   /**
    * Derived from PublicKey. Get the raw bytes of this ECDSAsecp256k1PublicKey.
    *
    * @return The raw bytes of this ECDSAsecp256k1PublicKey.
    */
-  [[nodiscard]] std::vector<unsigned char> toBytesRaw() const override;
+  [[nodiscard]] std::vector<std::byte> toBytesRaw() const override;
 
   /**
    * Derived from PublicKey. Construct a Key protobuf object from this ECDSAsecp256k1PublicKey object.

--- a/sdk/main/include/ED25519PrivateKey.h
+++ b/sdk/main/include/ED25519PrivateKey.h
@@ -48,9 +48,11 @@ public:
   /**
    * The prefix bytes of a DER-encoded ED25519PrivateKey.
    */
-  static inline const std::vector<unsigned char> DER_ENCODED_PREFIX_BYTES = { 0x30, 0x2E, 0x02, 0x01, 0x00, 0x30,
-                                                                              0x05, 0x06, 0x03, 0x2B, 0x65, 0x70,
-                                                                              0x04, 0x22, 0x04, 0x20 };
+  static inline const std::vector<std::byte> DER_ENCODED_PREFIX_BYTES = {
+    std::byte(0x30), std::byte(0x2E), std::byte(0x02), std::byte(0x01), std::byte(0x00), std::byte(0x30),
+    std::byte(0x05), std::byte(0x06), std::byte(0x03), std::byte(0x2B), std::byte(0x65), std::byte(0x70),
+    std::byte(0x04), std::byte(0x22), std::byte(0x04), std::byte(0x20)
+  };
 
   /**
    * The hex-encoded string of the DER-encoded prefix bytes of an ED25519PrivateKey.
@@ -87,7 +89,7 @@ public:
    * @return A pointer to an ED25519PrivateKey representing the input bytes.
    * @throws BadKeyException If an ED25519PrivateKey cannot be realized from the input bytes.
    */
-  [[nodiscard]] static std::unique_ptr<ED25519PrivateKey> fromBytes(const std::vector<unsigned char>& bytes);
+  [[nodiscard]] static std::unique_ptr<ED25519PrivateKey> fromBytes(const std::vector<std::byte>& bytes);
 
   /**
    * Construct an ED25519PrivateKey from a seed array.
@@ -96,7 +98,7 @@ public:
    * @return A pointer to an ED25519PrivateKey representing the input seed bytes.
    * @throws BadKeyException If an ED25519PrivateKey cannot be realized from the input seed bytes.
    */
-  [[nodiscard]] static std::unique_ptr<ED25519PrivateKey> fromSeed(const std::vector<unsigned char>& seed);
+  [[nodiscard]] static std::unique_ptr<ED25519PrivateKey> fromSeed(const std::vector<std::byte>& seed);
 
   /**
    * Derived from PrivateKey. Create a clone of this ED25519PrivateKey object.
@@ -123,7 +125,7 @@ public:
    * @return The signature of the byte array.
    * @throws OpenSSLException If OpenSSL is unable to generate a signature.
    */
-  [[nodiscard]] std::vector<unsigned char> sign(const std::vector<unsigned char>& bytesToSign) const override;
+  [[nodiscard]] std::vector<std::byte> sign(const std::vector<std::byte>& bytesToSign) const override;
 
   /**
    * Derived from PrivateKey. Get the hex-encoded string of the DER-encoded bytes of this ED25519PrivateKey.
@@ -144,14 +146,14 @@ public:
    *
    * @return The DER-encoded bytes of this ED25519PrivateKey.
    */
-  [[nodiscard]] std::vector<unsigned char> toBytesDer() const override;
+  [[nodiscard]] std::vector<std::byte> toBytesDer() const override;
 
   /**
    * Derived from PrivateKey. Get the raw, non-DER-encoded bytes of this ED25519PrivateKey.
    *
    * @return The raw bytes of this ED25519PrivateKey.
    */
-  [[nodiscard]] std::vector<unsigned char> toBytesRaw() const override;
+  [[nodiscard]] std::vector<std::byte> toBytesRaw() const override;
 
 private:
   /**
@@ -164,7 +166,7 @@ private:
    * @throws BadKeyException  If the chain code is malformed.
    */
   explicit ED25519PrivateKey(internal::OpenSSLUtils::EVP_PKEY&& key,
-                             std::vector<unsigned char> chainCode = std::vector<unsigned char>());
+                             std::vector<std::byte> chainCode = std::vector<std::byte>());
 };
 
 } // namespace Hedera

--- a/sdk/main/include/ED25519PublicKey.h
+++ b/sdk/main/include/ED25519PublicKey.h
@@ -43,8 +43,10 @@ public:
   /**
    * The prefix bytes of a DER-encoded ED25519PublicKey.
    */
-  static inline const std::vector<unsigned char> DER_ENCODED_PREFIX_BYTES = { 0x30, 0x2A, 0x30, 0x05, 0x06, 0x03,
-                                                                              0x2B, 0x65, 0x70, 0x03, 0x21, 0x00 };
+  static inline const std::vector<std::byte> DER_ENCODED_PREFIX_BYTES = {
+    std::byte(0x30), std::byte(0x2A), std::byte(0x30), std::byte(0x05), std::byte(0x06), std::byte(0x03),
+    std::byte(0x2B), std::byte(0x65), std::byte(0x70), std::byte(0x03), std::byte(0x21), std::byte(0x00)
+  };
 
   /**
    * The hex-encoded string of the DER-encoded prefix bytes of an ED25519PublicKey.
@@ -73,7 +75,7 @@ public:
    * @return A pointer to an ED25519PublicKey representing the input bytes.
    * @throws BadKeyException If an ED25519PublicKey cannot be realized from the input bytes.
    */
-  [[nodiscard]] static std::shared_ptr<ED25519PublicKey> fromBytes(const std::vector<unsigned char>& bytes);
+  [[nodiscard]] static std::shared_ptr<ED25519PublicKey> fromBytes(const std::vector<std::byte>& bytes);
 
   /**
    * Derived from PublicKey. Create a clone of this ED25519PublicKey object.
@@ -91,8 +93,8 @@ public:
    * @return \c TRUE if the signature is valid for this ED25519PublicKey's private key, otherwise \c FALSE.
    * @throws OpenSSLException If OpenSSL is unable to verify the signature.
    */
-  [[nodiscard]] bool verifySignature(const std::vector<unsigned char>& signatureBytes,
-                                     const std::vector<unsigned char>& signedBytes) const override;
+  [[nodiscard]] bool verifySignature(const std::vector<std::byte>& signatureBytes,
+                                     const std::vector<std::byte>& signedBytes) const override;
 
   /**
    * Derived from PublicKey. Get the hex-encoded string of the DER-encoded bytes of this ED25519PublicKey.
@@ -113,14 +115,14 @@ public:
    *
    * @return The DER-encoded bytes of this ED25519PublicKey.
    */
-  [[nodiscard]] std::vector<unsigned char> toBytesDer() const override;
+  [[nodiscard]] std::vector<std::byte> toBytesDer() const override;
 
   /**
    * Derived from PublicKey. Get the raw bytes of this ED25519PublicKey.
    *
    * @return The raw bytes of this ED25519PublicKey.
    */
-  [[nodiscard]] std::vector<unsigned char> toBytesRaw() const override;
+  [[nodiscard]] std::vector<std::byte> toBytesRaw() const override;
 
   /**
    * Derived from PublicKey. Construct a Key protobuf object from this ED25519PublicKey object.

--- a/sdk/main/include/EvmAddress.h
+++ b/sdk/main/include/EvmAddress.h
@@ -47,7 +47,7 @@ public:
    * @param bytes The bytes of the EvmAddress.
    * @throws std::invalid_argument If the input byte buffer is not 20 bytes long.
    */
-  static EvmAddress fromBytes(const std::vector<unsigned char>& bytes);
+  static EvmAddress fromBytes(const std::vector<std::byte>& bytes);
 
   /**
    * Get the hex-encoded string representation of this EVM address.
@@ -61,7 +61,7 @@ public:
    *
    * @return The bytes of this EVM address.
    */
-  [[nodiscard]] std::vector<unsigned char> toBytes() const;
+  [[nodiscard]] std::vector<std::byte> toBytes() const;
 
 private:
   EvmAddress() = default;
@@ -81,7 +81,7 @@ private:
   /**
    * The 20-byte buffer that represents the address for an ethereum account.
    */
-  std::vector<unsigned char> mEvmAddress;
+  std::vector<std::byte> mEvmAddress;
 };
 
 } // namespace Hedera

--- a/sdk/main/include/Mnemonic.h
+++ b/sdk/main/include/Mnemonic.h
@@ -72,7 +72,7 @@ protected:
    * @param entropy The array of entropy of which to compute the checksum.
    * @return The checksum of the entropy.
    */
-  [[nodiscard]] static unsigned char computeChecksumFromEntropy(const std::vector<unsigned char>& entropy);
+  [[nodiscard]] static std::byte computeChecksumFromEntropy(const std::vector<std::byte>& entropy);
 
   /**
    * Initialize this Mnemonic with a vector of word indices.
@@ -102,7 +102,7 @@ protected:
    *
    * @return A byte vector, representing the entropy and checksum of the mnemonic.
    */
-  [[nodiscard]] std::vector<unsigned char> computeEntropyAndChecksum() const;
+  [[nodiscard]] std::vector<std::byte> computeEntropyAndChecksum() const;
 
   /**
    * Get the word list for this Mnemonic.

--- a/sdk/main/include/MnemonicBIP39.h
+++ b/sdk/main/include/MnemonicBIP39.h
@@ -114,7 +114,7 @@ public:
    * @return This MnemonicBIP39's seed, given the input passphrase.
    * @throws OpenSSLException If OpenSSL is unable to compute a seed.
    */
-  [[nodiscard]] std::vector<unsigned char> toSeed(std::string_view passphrase = "") const;
+  [[nodiscard]] std::vector<std::byte> toSeed(std::string_view passphrase = "") const;
 
   /**
    * Compute the word indices that result from the input entropy.
@@ -122,7 +122,7 @@ public:
    * @param entropy The entropy from which to compute the word indices.
    * @return A vector containing the word indices.
    */
-  static std::vector<uint16_t> entropyToWordIndices(const std::vector<unsigned char>& entropy);
+  static std::vector<uint16_t> entropyToWordIndices(const std::vector<std::byte>& entropy);
 
 private:
   /**

--- a/sdk/main/include/PrivateKey.h
+++ b/sdk/main/include/PrivateKey.h
@@ -75,7 +75,7 @@ public:
    * @param bytesToSign The bytes to sign.
    * @return The signature of the byte array.
    */
-  [[nodiscard]] virtual std::vector<unsigned char> sign(const std::vector<unsigned char>& bytesToSign) const = 0;
+  [[nodiscard]] virtual std::vector<std::byte> sign(const std::vector<std::byte>& bytesToSign) const = 0;
 
   /**
    * Get the hex-encoded string of the DER-encoded bytes of this PrivateKey.
@@ -96,21 +96,21 @@ public:
    *
    * @return The DER-encoded bytes of this PrivateKey.
    */
-  [[nodiscard]] virtual std::vector<unsigned char> toBytesDer() const = 0;
+  [[nodiscard]] virtual std::vector<std::byte> toBytesDer() const = 0;
 
   /**
    * Get the raw, non-DER-encoded bytes of this PrivateKey.
    *
    * @return The raw bytes of this PrivateKey.
    */
-  [[nodiscard]] virtual std::vector<unsigned char> toBytesRaw() const = 0;
+  [[nodiscard]] virtual std::vector<std::byte> toBytesRaw() const = 0;
 
   /**
    * Get this PrivateKey's chain code. It is possible that the chain code could be empty.
    *
    * @return This PrivateKey's chaincode if it exists, otherwise an empty vector.
    */
-  [[nodiscard]] std::vector<unsigned char> getChainCode() const;
+  [[nodiscard]] std::vector<std::byte> getChainCode() const;
 
   /**
    * Get the PublicKey that corresponds to this PrivateKey.
@@ -137,7 +137,7 @@ protected:
    * @throws BadKeyException  If the chain code is malformed.
    */
   explicit PrivateKey(internal::OpenSSLUtils::EVP_PKEY&& key,
-                      std::vector<unsigned char> chainCode = std::vector<unsigned char>());
+                      std::vector<std::byte> chainCode = std::vector<std::byte>());
 
   /**
    * Get this PrivateKey's wrapped OpenSSL key object.

--- a/sdk/main/include/PublicKey.h
+++ b/sdk/main/include/PublicKey.h
@@ -75,7 +75,7 @@ public:
    * @throws BadKeyException If the public key type (ED25519 or ECDSAsecp256k1) is unable to be determined or realized
    *                         from the input byte array.
    */
-  [[nodiscard]] static std::shared_ptr<PublicKey> fromBytesDer(const std::vector<unsigned char>& bytes);
+  [[nodiscard]] static std::shared_ptr<PublicKey> fromBytesDer(const std::vector<std::byte>& bytes);
 
   /**
    * Create a clone of this PublicKey object.
@@ -98,8 +98,8 @@ public:
    * @param signedBytes    The bytes which were purportedly signed to create the signature.
    * @return \c TRUE if the signature is valid, otherwise \c FALSE.
    */
-  [[nodiscard]] virtual bool verifySignature(const std::vector<unsigned char>& signatureBytes,
-                                             const std::vector<unsigned char>& signedBytes) const = 0;
+  [[nodiscard]] virtual bool verifySignature(const std::vector<std::byte>& signatureBytes,
+                                             const std::vector<std::byte>& signedBytes) const = 0;
 
   /**
    * Get the hex-encoded string of the DER-encoded bytes of this PublicKey.
@@ -120,14 +120,14 @@ public:
    *
    * @return The DER-encoded bytes of this PublicKey.
    */
-  [[nodiscard]] virtual std::vector<unsigned char> toBytesDer() const = 0;
+  [[nodiscard]] virtual std::vector<std::byte> toBytesDer() const = 0;
 
   /**
    * Get the raw bytes of this PublicKey.
    *
    * @return The raw bytes of this PublicKey.
    */
-  [[nodiscard]] virtual std::vector<unsigned char> toBytesRaw() const = 0;
+  [[nodiscard]] virtual std::vector<std::byte> toBytesRaw() const = 0;
 
 protected:
   /**

--- a/sdk/main/include/Transaction.h
+++ b/sdk/main/include/Transaction.h
@@ -67,7 +67,7 @@ public:
    * to create may not be known at compile time, a std::variant is used to encompass all possible Transactions. Usage of
    * this return type would look like the following:
    *
-   * std::vector<unsigned char> bytes;
+   * std::vector<std::byte> bytes;
    *                                                              The Transaction type here doesn't matter and is an
    *                                     vvvvvvvvvvvvvvvvvvvvvvvv unfortunate, ugly byproduct of this approach.
    * auto [index, variant] = Transaction<AccountCreateTransaction>::fromBytes(bytes);
@@ -94,7 +94,7 @@ public:
    * @throws std::invalid_argument If unable to construct a Transaction from the input bytes.
    */
   static std::pair<int, std::variant<AccountCreateTransaction, TransferTransaction, AccountUpdateTransaction>>
-  fromBytes(const std::vector<unsigned char>& bytes);
+  fromBytes(const std::vector<std::byte>& bytes);
 
   /**
    * Sign this Transaction with the given PrivateKey. Signing a Transaction with a key that has already been used to
@@ -116,7 +116,7 @@ public:
    * @throws IllegalStateException If this Transaction object is not frozen.
    */
   SdkRequestType& signWith(const std::shared_ptr<PublicKey>& key,
-                           const std::function<std::vector<unsigned char>(const std::vector<unsigned char>&)>& signer);
+                           const std::function<std::vector<std::byte>(const std::vector<std::byte>&)>& signer);
 
   /**
    * Freeze this transaction with a Client. The Client's operator will be used to generate a transaction ID, and the
@@ -320,7 +320,7 @@ private:
    * Container of PublicKey and signer function pairs to use to sign this Transaction.
    */
   std::vector<
-    std::pair<std::shared_ptr<PublicKey>, std::function<std::vector<unsigned char>(const std::vector<unsigned char>&)>>>
+    std::pair<std::shared_ptr<PublicKey>, std::function<std::vector<std::byte>(const std::vector<std::byte>&)>>>
     mSignatures;
 
   /**

--- a/sdk/main/include/impl/DerivationPathUtils.h
+++ b/sdk/main/include/impl/DerivationPathUtils.h
@@ -20,6 +20,7 @@
 #ifndef HEDERA_SDK_CPP_IMPL_DERIVATION_PATH_UTILS_H_
 #define HEDERA_SDK_CPP_IMPL_DERIVATION_PATH_UTILS_H_
 
+#include <cstddef>
 #include <cstdint>
 #include <vector>
 
@@ -52,7 +53,7 @@ uint32_t getHardenedIndex(uint32_t index);
  * @param childIndex The index to convert to a big endian byte array.
  * @return The big endian byte array representing the child index.
  */
-std::vector<unsigned char> indexToBigEndianArray(uint32_t childIndex);
+std::vector<std::byte> indexToBigEndianArray(uint32_t childIndex);
 
 }; // namespace Hedera::internal::DerivationPathUtils
 

--- a/sdk/main/include/impl/HederaCertificateVerifier.h
+++ b/sdk/main/include/impl/HederaCertificateVerifier.h
@@ -36,13 +36,13 @@ public:
    *
    * @param certificateHash The claimed hash of the node certificate chain.
    */
-  explicit HederaCertificateVerifier(std::vector<unsigned char> certificateHash);
+  explicit HederaCertificateVerifier(std::vector<std::byte> certificateHash);
 
 private:
   /**
    * The hash of the certificate chain for the node, from the address book.
    */
-  std::vector<unsigned char> mExpectedHash;
+  std::vector<std::byte> mExpectedHash;
 
   /**
    * The verification logic that will be performed after the TLS handshake completes.

--- a/sdk/main/include/impl/HexConverter.h
+++ b/sdk/main/include/impl/HexConverter.h
@@ -33,7 +33,7 @@ namespace Hedera::internal::HexConverter
  * @return A string containing the hex values of the input byte array.
  * @throws OpenSSLException If OpenSSL is unable to convert the input bytes to hex.
  */
-std::string bytesToHex(const std::vector<unsigned char>& bytes);
+std::string bytesToHex(const std::vector<std::byte>& bytes);
 
 /**
  * Convert a hex string to the array of bytes it represents.
@@ -43,7 +43,7 @@ std::string bytesToHex(const std::vector<unsigned char>& bytes);
  * @throws std::invalid_argument If the input hex string doesn't contain an even number of digits.
  * @throws OpenSSLException If OpenSSL is unable to convert the input string to a byte array.
  */
-std::vector<unsigned char> hexToBytes(std::string_view hex);
+std::vector<std::byte> hexToBytes(std::string_view hex);
 
 } // namespace Hedera::internal::HexConverter
 

--- a/sdk/main/include/impl/IPv4Address.h
+++ b/sdk/main/include/impl/IPv4Address.h
@@ -31,52 +31,59 @@ namespace Hedera::internal
 class IPv4Address
 {
 public:
-  /**
-   * Default constructor
-   */
   IPv4Address() = default;
 
   /**
-   * Constructor which initializes address octets
+   * Constructor with four octets.
+   *
+   * @param octet1 The first octet.
+   * @param octet2 The second octet.
+   * @param octet3 The third octet.
+   * @param octet4 The fourth octet.
    */
-  IPv4Address(unsigned char octet1, unsigned char octet2, unsigned char octet3, unsigned char octet4);
+  IPv4Address(std::byte octet1, std::byte octet2, std::byte octet3, std::byte octet4);
 
   /**
-   * Creates a new IP address from a string. Supports ascii or byte representation
+   * Creates a new IP address from a string. Supports ascii or byte representation.
    *
-   * @param inputString string representing an IP address
-   *
-   * @return the new IP address. Currently returns address of 0.0.0.0 if there is an error in creation
+   * @param address The IP address from which to construct, in string form.
+   * @return The new IP address.
+   * @throws std::invalid_argument If the input IPv4Address string is malformed.
    */
-  static IPv4Address fromString(const std::string& inputString);
+  [[nodiscard]] static IPv4Address fromString(std::string_view address);
 
   /**
-   * Converts address to form octet1.octet2.octet3.octet4
+   * Get the string representation of this IPv4Address (form is <octet>.<octet>.<octet>.<octet>).
    *
-   * @return string representing the address
+   * @return The string represenation of this IPv4Address.
    */
   [[nodiscard]] std::string toString() const;
 
 private:
   /**
+   * The number of octets in an IPv4Address.
+   */
+  static constexpr const unsigned int NUM_BYTES = 4U;
+
+  /**
    * The first octet of the address
    */
-  unsigned char mOctet1;
+  std::byte mOctet1;
 
   /**
    * The second octet of the address
    */
-  unsigned char mOctet2;
+  std::byte mOctet2;
 
   /**
    * The third octet of the address
    */
-  unsigned char mOctet3;
+  std::byte mOctet3;
 
   /**
    * The fourth octet of the address
    */
-  unsigned char mOctet4;
+  std::byte mOctet4;
 };
 
 } // namespace Hedera::internal

--- a/sdk/main/include/impl/IPv4Address.h
+++ b/sdk/main/include/impl/IPv4Address.h
@@ -61,11 +61,6 @@ public:
 
 private:
   /**
-   * The number of octets in an IPv4Address.
-   */
-  static constexpr const unsigned int NUM_BYTES = 4U;
-
-  /**
    * The first octet of the address
    */
   std::byte mOctet1;

--- a/sdk/main/include/impl/NodeAddress.h
+++ b/sdk/main/include/impl/NodeAddress.h
@@ -51,6 +51,22 @@ public:
   NodeAddress(std::string_view ipAddressV4, int port);
 
   /**
+   * Determine if a particular port number corresponds to a TLS port.
+   *
+   * @param port The port number.
+   * @return \c TRUE if the input port number corresponds to a TLS port, otherwise \c FALSE.
+   */
+  static inline bool isTlsPort(int port) { return (port == PORT_NODE_TLS) || (port == PORT_MIRROR_TLS); }
+
+  /**
+   * Determine if a particular port number corresponds to a non-TLS port.
+   *
+   * @param port The port number.
+   * @return \c TRUE if the input port number corresponds to a non-TLS port, otherwise \c FALSE.
+   */
+  static inline bool isNonTlsPort(int port) { return (port == PORT_NODE_PLAIN) || (port == PORT_MIRROR_PLAIN); }
+
+  /**
    * Create a NodeAddress object from a NodeAddress protobuf object.
    *
    * @param proto The NodeAddress protobuf object from which to create a NodeAddress object.
@@ -124,22 +140,6 @@ public:
   NodeAddress& setStake(const uint64_t& stake);
 
   /**
-   * Determine if a particular port number corresponds to a TLS port.
-   *
-   * @param port The port number.
-   * @return \c TRUE if the input port number corresponds to a TLS port, otherwise \c FALSE.
-   */
-  static inline bool isTlsPort(int port) { return (port == PORT_NODE_TLS) || (port == PORT_MIRROR_TLS); }
-
-  /**
-   * Determine if a particular port number corresponds to a non-TLS port.
-   *
-   * @param port The port number.
-   * @return \c TRUE if the input port number corresponds to a non-TLS port, otherwise \c FALSE.
-   */
-  static inline bool isNonTlsPort(int port) { return (port == PORT_NODE_PLAIN) || (port == PORT_MIRROR_PLAIN); }
-
-  /**
    * Get a string representation of the node address.
    *
    * @return A string representing the node address.
@@ -186,7 +186,7 @@ public:
    *
    * @return The certificate chain hash.
    */
-  [[nodiscard]] inline std::vector<unsigned char> getNodeCertHash() const { return mNodeCertHash; }
+  [[nodiscard]] inline std::vector<std::byte> getNodeCertHash() const { return mNodeCertHash; }
 
   /**
    * Get the default endpoint associated with the node.
@@ -256,7 +256,7 @@ private:
   /**
    * The SHA-384 hash of the node's certificate chain.
    */
-  std::vector<unsigned char> mNodeCertHash;
+  std::vector<std::byte> mNodeCertHash;
 
   /**
    * A string description of the node.

--- a/sdk/main/include/impl/PrivateKeyImpl.h
+++ b/sdk/main/include/impl/PrivateKeyImpl.h
@@ -41,7 +41,7 @@ struct PrivateKey::PrivateKeyImpl
   /**
    * This PrivateKey's chain code. If this is empty, then this PrivateKey will not support derivation.
    */
-  std::vector<unsigned char> mChainCode;
+  std::vector<std::byte> mChainCode;
 
   /**
    * A pointer to the PublicKey object that corresponds to this PrivateKey.

--- a/sdk/main/include/impl/Utilities.h
+++ b/sdk/main/include/impl/Utilities.h
@@ -20,6 +20,9 @@
 #ifndef HEDERA_SDK_CPP_IMPL_UTILITIES_H_
 #define HEDERA_SDK_CPP_IMPL_UTILITIES_H_
 
+#include <cstddef>
+#include <string>
+#include <string_view>
 #include <vector>
 
 namespace Hedera::internal::Utilities
@@ -31,7 +34,7 @@ namespace Hedera::internal::Utilities
  * @param prefix The prefix bytes to find in the byte array.
  * @return \c TRUE If prefix is a prefix of bytes, otherwise \c FALSE.
  */
-[[nodiscard]] bool isPrefixOf(const std::vector<unsigned char>& bytes, const std::vector<unsigned char>& prefix);
+[[nodiscard]] bool isPrefixOf(const std::vector<std::byte>& bytes, const std::vector<std::byte>& prefix);
 
 /**
  * Remove a certain number of bytes from the beginning of a byte vector.
@@ -40,7 +43,7 @@ namespace Hedera::internal::Utilities
  * @param num   The number of bytes to remove.
  * @return The byte vector with the removed prefix bytes.
  */
-[[nodiscard]] std::vector<unsigned char> removePrefix(const std::vector<unsigned char>& bytes, long num);
+[[nodiscard]] std::vector<std::byte> removePrefix(const std::vector<std::byte>& bytes, long num);
 
 /**
  * Concatenate bytes vectors together (in the order of the arguments).
@@ -48,7 +51,31 @@ namespace Hedera::internal::Utilities
  * @param vectors  The bytes vectors to concatenate together.
  * @return A byte vector containing the input byte vectors concatenated into one.
  */
-[[nodiscard]] std::vector<unsigned char> concatenateVectors(const std::vector<std::vector<unsigned char>>& vectors);
+[[nodiscard]] std::vector<std::byte> concatenateVectors(const std::vector<std::vector<std::byte>>& vectors);
+
+/**
+ * Convert a string to a byte vector.
+ *
+ * @param str The string to convert.
+ * @return The byte vector representing the input string.
+ */
+[[nodiscard]] std::vector<std::byte> stringToByteVector(std::string_view str);
+
+/**
+ * Convert a string to a byte.
+ *
+ * @param str The string to convert.
+ * @return The byte representing the string.
+ */
+[[nodiscard]] std::byte stringToByte(std::string_view str);
+
+/**
+ * Convert a byte vector to a string.
+ *
+ * @param bytes The byte vector to convert to a string.
+ * @return The string that represent of the byte vector.
+ */
+[[nodiscard]] std::string byteVectorToString(const std::vector<std::byte>& bytes);
 
 } // namespace Hedera::internal::Utilities
 

--- a/sdk/main/include/impl/openssl_utils/BIGNUM.h
+++ b/sdk/main/include/impl/openssl_utils/BIGNUM.h
@@ -71,7 +71,7 @@ public:
    * @param bytes The vector of bytes representing the BIGNUM.
    * @return A newly constructed BIGNUM.
    */
-  [[nodiscard]] static BIGNUM fromBytes(const std::vector<unsigned char>& bytes)
+  [[nodiscard]] static BIGNUM fromBytes(const std::vector<std::byte>& bytes)
   {
     return fromHex(HexConverter::bytesToHex(bytes));
   }
@@ -110,7 +110,7 @@ public:
    *
    * @return The byte vector representing this BIGNUM.
    */
-  [[nodiscard]] std::vector<unsigned char> toBytes() const
+  [[nodiscard]] std::vector<std::byte> toBytes() const
   {
     char* hex = BN_bn2hex(get());
     const std::string hexString(hex);

--- a/sdk/main/include/impl/openssl_utils/OpenSSLUtils.h
+++ b/sdk/main/include/impl/openssl_utils/OpenSSLUtils.h
@@ -32,7 +32,7 @@ namespace Hedera::internal::OpenSSLUtils
  * @param data The byte array from which to compute the hash.
  * @return The SHA256 hash of the data.
  */
-[[nodiscard]] std::vector<unsigned char> computeSHA256(const std::vector<unsigned char>& data);
+[[nodiscard]] std::vector<std::byte> computeSHA256(const std::vector<std::byte>& data);
 
 /**
  * Compute the SHA384 hash of a byte array.
@@ -40,7 +40,7 @@ namespace Hedera::internal::OpenSSLUtils
  * @param data The byte array from which to compute the hash.
  * @return The SHA384 hash of the data.
  */
-[[nodiscard]] std::vector<unsigned char> computeSHA384(const std::vector<unsigned char>& data);
+[[nodiscard]] std::vector<std::byte> computeSHA384(const std::vector<std::byte>& data);
 
 /**
  * Compute the HMAC-SHA512 hash of a key and data.
@@ -50,8 +50,8 @@ namespace Hedera::internal::OpenSSLUtils
  * @return The hash of the data and key.
  * @throws OpenSSLException If OpenSSL is unable to compute the HMAC-SHA512 hash of the given inputs.
  */
-[[nodiscard]] std::vector<unsigned char> computeSHA512HMAC(const std::vector<unsigned char>& key,
-                                                           const std::vector<unsigned char>& data);
+[[nodiscard]] std::vector<std::byte> computeSHA512HMAC(const std::vector<std::byte>& key,
+                                                       const std::vector<std::byte>& data);
 
 /**
  * Gets an error message for an OpenSSL error. Includes as much detail as possible.
@@ -69,7 +69,16 @@ namespace Hedera::internal::OpenSSLUtils
  * @throws std::invalid_argument If the input count is negative.
  * @throws OpenSSLException If OpenSSL is unable to generate random bytes.
  */
-[[nodiscard]] std::vector<unsigned char> getRandomBytes(int count);
+[[nodiscard]] std::vector<std::byte> getRandomBytes(int count);
+
+/**
+ * Reinterpret a std::byte pointer as an unsigned char pointer (for intergration with OpenSSL APIs).
+ *
+ * @param byte The pointer to the std::byte to reinterpret.
+ * @return A pointer to the std::byte as an unsigned char.
+ */
+[[nodiscard]] unsigned char* toUnsignedCharPtr(std::byte* byte);
+[[nodiscard]] const unsigned char* toUnsignedCharPtr(const std::byte* byte);
 
 } // namespace Hedera::internal::OpenSSLUtils
 

--- a/sdk/main/src/AccountCreateTransaction.cc
+++ b/sdk/main/src/AccountCreateTransaction.cc
@@ -21,6 +21,7 @@
 #include "TransactionResponse.h"
 #include "impl/DurationConverter.h"
 #include "impl/Node.h"
+#include "impl/Utilities.h"
 
 #include <grpcpp/client_context.h>
 #include <proto/crypto_create.pb.h>
@@ -78,12 +79,12 @@ AccountCreateTransaction::AccountCreateTransaction(const proto::TransactionBody&
 
   if (!body.alias().empty())
   {
-    mAlias = PublicKey::fromBytesDer({ body.alias().cbegin(), body.alias().cend() });
+    mAlias = PublicKey::fromBytesDer(internal::Utilities::stringToByteVector(body.alias()));
   }
 
   if (!body.evm_address().empty())
   {
-    mEvmAddress = EvmAddress::fromBytes({ body.evm_address().cbegin(), body.evm_address().cend() });
+    mEvmAddress = EvmAddress::fromBytes(internal::Utilities::stringToByteVector(body.evm_address()));
   }
 }
 
@@ -250,14 +251,12 @@ proto::CryptoCreateTransactionBody* AccountCreateTransaction::build() const
 
   if (mAlias)
   {
-    const std::vector<unsigned char> aliasBytes = mAlias->toBytesDer();
-    body->set_allocated_alias(new std::string{ aliasBytes.cbegin(), aliasBytes.cend() });
+    body->set_allocated_alias(new std::string(internal::Utilities::byteVectorToString(mAlias->toBytesDer())));
   }
 
   if (mEvmAddress)
   {
-    const std::vector<unsigned char> addressBytes = mEvmAddress->toBytes();
-    body->set_allocated_evm_address(new std::string{ addressBytes.cbegin(), addressBytes.cend() });
+    body->set_allocated_evm_address(new std::string(internal::Utilities::byteVectorToString(mEvmAddress->toBytes())));
   }
 
   return body.release();

--- a/sdk/main/src/AccountId.cc
+++ b/sdk/main/src/AccountId.cc
@@ -20,6 +20,7 @@
 #include "AccountId.h"
 #include "PublicKey.h"
 #include "exceptions/BadKeyException.h"
+#include "impl/Utilities.h"
 
 #include <charconv>
 #include <limits>
@@ -172,7 +173,7 @@ AccountId AccountId::fromProtobuf(const proto::AccountID& proto)
     {
       try
       {
-        accountId.mAlias = PublicKey::fromBytesDer({ proto.alias().cbegin(), proto.alias().cend() });
+        accountId.mAlias = PublicKey::fromBytesDer(internal::Utilities::stringToByteVector(proto.alias()));
       }
       catch (const BadKeyException& ex)
       {
@@ -182,7 +183,7 @@ AccountId AccountId::fromProtobuf(const proto::AccountID& proto)
     }
     case proto::AccountID::kEvmAddress:
     {
-      accountId.mEvmAddress = EvmAddress::fromBytes({ proto.evm_address().cbegin(), proto.evm_address().cend() });
+      accountId.mEvmAddress = EvmAddress::fromBytes(internal::Utilities::stringToByteVector(proto.evm_address()));
       break;
     }
     default:
@@ -205,13 +206,11 @@ std::unique_ptr<proto::AccountID> AccountId::toProtobuf() const
   }
   else if (mAlias)
   {
-    const std::vector<unsigned char> bytes = mAlias->toBytesDer();
-    proto->set_allocated_alias(new std::string{ bytes.cbegin(), bytes.cend() });
+    proto->set_allocated_alias(new std::string(internal::Utilities::byteVectorToString(mAlias->toBytesDer())));
   }
   else if (mEvmAddress)
   {
-    const std::vector<unsigned char> bytes = mEvmAddress->toBytes();
-    proto->set_allocated_evm_address(new std::string{ bytes.cbegin(), bytes.cend() });
+    proto->set_allocated_evm_address(new std::string(internal::Utilities::byteVectorToString(mEvmAddress->toBytes())));
   }
 
   return proto;

--- a/sdk/main/src/Client.cc
+++ b/sdk/main/src/Client.cc
@@ -120,7 +120,7 @@ Client& Client::setOperator(const AccountId& accountId, std::unique_ptr<PrivateK
 }
 
 //-----
-std::vector<unsigned char> Client::sign(const std::vector<unsigned char>& bytes) const
+std::vector<std::byte> Client::sign(const std::vector<std::byte>& bytes) const
 {
   if (mImpl->mOperatorPrivateKey)
   {

--- a/sdk/main/src/EvmAddress.cc
+++ b/sdk/main/src/EvmAddress.cc
@@ -59,7 +59,7 @@ EvmAddress EvmAddress::fromString(std::string_view address)
 }
 
 //-----
-EvmAddress EvmAddress::fromBytes(const std::vector<unsigned char>& bytes)
+EvmAddress EvmAddress::fromBytes(const std::vector<std::byte>& bytes)
 {
   EvmAddress evmAddress;
   evmAddress.mEvmAddress = bytes;
@@ -74,7 +74,7 @@ std::string EvmAddress::toString() const
 }
 
 //-----
-std::vector<unsigned char> EvmAddress::toBytes() const
+std::vector<std::byte> EvmAddress::toBytes() const
 {
   return mEvmAddress;
 }

--- a/sdk/main/src/Mnemonic.cc
+++ b/sdk/main/src/Mnemonic.cc
@@ -288,10 +288,9 @@ std::vector<std::string> Mnemonic::splitMnemonicString(std::string_view fullMnem
 }
 
 //-----
-unsigned char Mnemonic::computeChecksumFromEntropy(const std::vector<unsigned char>& entropy)
+std::byte Mnemonic::computeChecksumFromEntropy(const std::vector<std::byte>& entropy)
 {
-  unsigned char mask = ~(0xFF >> (entropy.size() * 8 / 32));
-  return internal::OpenSSLUtils::computeSHA256(entropy)[0] & mask;
+  return internal::OpenSSLUtils::computeSHA256(entropy).at(0) & ~(std::byte(0xFF) >> (entropy.size() * 8 / 32));
 }
 
 //-----
@@ -321,7 +320,7 @@ std::vector<uint16_t> Mnemonic::wordsToIndices(const std::vector<std::string>& w
 //-----
 bool Mnemonic::verifyChecksum() const
 {
-  const std::vector<unsigned char>& entropyAndChecksum = computeEntropyAndChecksum();
+  const std::vector<std::byte>& entropyAndChecksum = computeEntropyAndChecksum();
 
   return ((entropyAndChecksum.size() * 8) % 32) &&
          (computeChecksumFromEntropy({ entropyAndChecksum.begin(), entropyAndChecksum.end() - 1 }) ==
@@ -329,7 +328,7 @@ bool Mnemonic::verifyChecksum() const
 }
 
 //-----
-std::vector<unsigned char> Mnemonic::computeEntropyAndChecksum() const
+std::vector<std::byte> Mnemonic::computeEntropyAndChecksum() const
 {
   // The algorithm described below is the reverse algorithm of `MnemonicBIP39::entropyToWordIndices`
   // Recall, since each mnemonic word index is < 2048 in the BIP39 list, they can be contained each in an 11 bit
@@ -373,7 +372,7 @@ std::vector<unsigned char> Mnemonic::computeEntropyAndChecksum() const
   // (4) For 12 word mnemonics, the final byte of the buffer will only have 4 meaningful bits. This is handled
   // separately, after having iterated through all mnemonic words
 
-  std::vector<unsigned char> buffer;
+  std::vector<std::byte> buffer;
 
   unsigned int scratch = 0;
   unsigned int offset = 0;
@@ -386,14 +385,14 @@ std::vector<unsigned char> Mnemonic::computeEntropyAndChecksum() const
 
     while (offset >= 8) // (2)
     {
-      buffer.push_back(static_cast<unsigned char>(scratch >> (offset - 8)));
+      buffer.push_back(std::byte(scratch >> (offset - 8)));
       offset -= 8;
     }
   }
 
   if (offset != 0) // (4)
   {
-    buffer.push_back(static_cast<unsigned char>(scratch << offset));
+    buffer.push_back(std::byte(scratch << offset));
   }
 
   return buffer;

--- a/sdk/main/src/Mnemonic.cc
+++ b/sdk/main/src/Mnemonic.cc
@@ -22,6 +22,7 @@
 #include "impl/openssl_utils/OpenSSLUtils.h"
 
 #include <algorithm>
+#include <cstddef>
 #include <stdexcept>
 
 namespace Hedera
@@ -290,7 +291,8 @@ std::vector<std::string> Mnemonic::splitMnemonicString(std::string_view fullMnem
 //-----
 std::byte Mnemonic::computeChecksumFromEntropy(const std::vector<std::byte>& entropy)
 {
-  return internal::OpenSSLUtils::computeSHA256(entropy).at(0) & ~(std::byte(0xFF) >> (entropy.size() * 8 / 32));
+  return internal::OpenSSLUtils::computeSHA256(entropy).at(0) &
+         ~(std::byte(0xFF) >> static_cast<int>(entropy.size() * 8 / 32));
 }
 
 //-----

--- a/sdk/main/src/PublicKey.cc
+++ b/sdk/main/src/PublicKey.cc
@@ -36,11 +36,11 @@ std::shared_ptr<PublicKey> PublicKey::fromProtobuf(const proto::Key& key)
 {
   if (key.key_case() == proto::Key::KeyCase::kEd25519)
   {
-    return ED25519PublicKey::fromBytes({ key.ed25519().cbegin(), key.ed25519().cend() });
+    return ED25519PublicKey::fromBytes(internal::Utilities::stringToByteVector(key.ed25519()));
   }
   else if (key.key_case() == proto::Key::KeyCase::kECDSASecp256K1)
   {
-    return ECDSAsecp256k1PublicKey::fromBytes({ key.ecdsa_secp256k1().cbegin(), key.ecdsa_secp256k1().cend() });
+    return ECDSAsecp256k1PublicKey::fromBytes(internal::Utilities::stringToByteVector(key.ecdsa_secp256k1()));
   }
   else
   {
@@ -65,7 +65,7 @@ std::shared_ptr<PublicKey> PublicKey::fromStringDer(std::string_view key)
 }
 
 //-----
-std::shared_ptr<PublicKey> PublicKey::fromBytesDer(const std::vector<unsigned char>& bytes)
+std::shared_ptr<PublicKey> PublicKey::fromBytesDer(const std::vector<std::byte>& bytes)
 {
   if (internal::Utilities::isPrefixOf(bytes, ED25519PublicKey::DER_ENCODED_PREFIX_BYTES))
   {

--- a/sdk/main/src/TransactionRecord.cc
+++ b/sdk/main/src/TransactionRecord.cc
@@ -19,6 +19,7 @@
  */
 #include "TransactionRecord.h"
 #include "impl/TimestampConverter.h"
+#include "impl/Utilities.h"
 
 #include <proto/transaction_record.pb.h>
 
@@ -97,7 +98,7 @@ TransactionRecord TransactionRecord::fromProtobuf(const proto::TransactionRecord
 
   if (!proto.evm_address().empty())
   {
-    transactionRecord.mEvmAddress = EvmAddress::fromBytes({ proto.evm_address().cbegin(), proto.evm_address().cend() });
+    transactionRecord.mEvmAddress = EvmAddress::fromBytes(internal::Utilities::stringToByteVector(proto.evm_address()));
   }
 
   return transactionRecord;

--- a/sdk/main/src/impl/DerivationPathUtils.cc
+++ b/sdk/main/src/impl/DerivationPathUtils.cc
@@ -19,6 +19,7 @@
  */
 #include "impl/DerivationPathUtils.h"
 
+#include <iostream>
 #include <stdexcept>
 
 namespace Hedera::internal::DerivationPathUtils
@@ -41,12 +42,12 @@ uint32_t getHardenedIndex(uint32_t index)
 }
 
 //-----
-std::vector<unsigned char> indexToBigEndianArray(uint32_t childIndex)
+std::vector<std::byte> indexToBigEndianArray(uint32_t childIndex)
 {
-  std::vector<unsigned char> indexVector;
+  std::vector<std::byte> indexVector;
   for (int byteIndex = 3; byteIndex >= 0; --byteIndex)
   {
-    indexVector.push_back((childIndex >> (byteIndex << 3)) & 0xFF);
+    indexVector.push_back(std::byte((childIndex >> (byteIndex << 3)) & 0xFF));
   }
 
   return indexVector;

--- a/sdk/main/src/impl/HederaCertificateVerifier.cc
+++ b/sdk/main/src/impl/HederaCertificateVerifier.cc
@@ -19,6 +19,7 @@
  */
 #include "impl/HederaCertificateVerifier.h"
 #include "impl/HexConverter.h"
+#include "impl/Utilities.h"
 #include "impl/openssl_utils/OpenSSLUtils.h"
 
 #include <algorithm>
@@ -26,7 +27,7 @@
 namespace Hedera::internal
 {
 //-----
-HederaCertificateVerifier::HederaCertificateVerifier(std::vector<unsigned char> certificateHash)
+HederaCertificateVerifier::HederaCertificateVerifier(std::vector<std::byte> certificateHash)
   : mExpectedHash(std::move(certificateHash))
 {
 }
@@ -37,7 +38,8 @@ bool HederaCertificateVerifier::Verify(grpc::experimental::TlsCustomVerification
                                        grpc::Status* sync_status)
 {
   if (const grpc::string_ref grpcCertificateChain = request->peer_cert_full_chain();
-      mExpectedHash == OpenSSLUtils::computeSHA384({ grpcCertificateChain.cbegin(), grpcCertificateChain.cend() }))
+      mExpectedHash ==
+      OpenSSLUtils::computeSHA384(internal::Utilities::stringToByteVector(grpcCertificateChain.data())))
   {
     *sync_status = grpc::Status(grpc::StatusCode::UNAUTHENTICATED,
                                 "Hash of node certificate chain doesn't match hash contained in address book");

--- a/sdk/main/src/impl/HexConverter.cc
+++ b/sdk/main/src/impl/HexConverter.cc
@@ -27,16 +27,19 @@
 namespace Hedera::internal::HexConverter
 {
 //-----
-std::string bytesToHex(const std::vector<unsigned char>& bytes)
+std::string bytesToHex(const std::vector<std::byte>& bytes)
 {
   size_t stringLength;
-  if (OPENSSL_buf2hexstr_ex(nullptr, 0, &stringLength, bytes.data(), bytes.size(), '\0') <= 0)
+  if (OPENSSL_buf2hexstr_ex(
+        nullptr, 0, &stringLength, OpenSSLUtils::toUnsignedCharPtr(bytes.data()), bytes.size(), '\0') <= 0)
   {
     throw OpenSSLException(internal::OpenSSLUtils::getErrorMessage("OPENSSL_buf2hexstr_ex"));
   }
 
   std::string charString(stringLength, '\0');
-  if (OPENSSL_buf2hexstr_ex(charString.data(), stringLength, nullptr, bytes.data(), bytes.size(), '\0') <= 0)
+  if (OPENSSL_buf2hexstr_ex(
+        charString.data(), stringLength, nullptr, OpenSSLUtils::toUnsignedCharPtr(bytes.data()), bytes.size(), '\0') <=
+      0)
   {
     throw OpenSSLException(internal::OpenSSLUtils::getErrorMessage("OPENSSL_buf2hexstr_ex"));
   }
@@ -46,7 +49,7 @@ std::string bytesToHex(const std::vector<unsigned char>& bytes)
 }
 
 //-----
-std::vector<unsigned char> hexToBytes(std::string_view hex)
+std::vector<std::byte> hexToBytes(std::string_view hex)
 {
   size_t bufferLength;
   if (OPENSSL_hexstr2buf_ex(nullptr, 0, &bufferLength, hex.data(), '\0') <= 0)
@@ -54,8 +57,9 @@ std::vector<unsigned char> hexToBytes(std::string_view hex)
     throw OpenSSLException(internal::OpenSSLUtils::getErrorMessage("OPENSSL_hexstr2buf_ex"));
   }
 
-  std::vector<unsigned char> outputBytes(bufferLength);
-  if (OPENSSL_hexstr2buf_ex(outputBytes.data(), bufferLength, nullptr, hex.data(), '\0') <= 0)
+  std::vector<std::byte> outputBytes(bufferLength);
+  if (OPENSSL_hexstr2buf_ex(
+        OpenSSLUtils::toUnsignedCharPtr(outputBytes.data()), bufferLength, nullptr, hex.data(), '\0') <= 0)
   {
     throw OpenSSLException(internal::OpenSSLUtils::getErrorMessage("OPENSSL_hexstr2buf_ex"));
   }

--- a/sdk/main/src/impl/IPv4Address.cc
+++ b/sdk/main/src/impl/IPv4Address.cc
@@ -37,7 +37,7 @@ IPv4Address::IPv4Address(std::byte octet1, std::byte octet2, std::byte octet3, s
 IPv4Address IPv4Address::fromString(std::string_view address)
 {
   // The input string is in byte format, where each byte represents a single IP address octet.
-  if (address.size() == NUM_BYTES)
+  if (address.size() == 4)
   {
     const std::vector<std::byte> byteVector = Utilities::stringToByteVector(address);
     return { byteVector.at(0), byteVector.at(1), byteVector.at(2), byteVector.at(3) };
@@ -47,13 +47,14 @@ IPv4Address IPv4Address::fromString(std::string_view address)
   {
     std::vector<std::byte> byteVector;
     std::string_view octet;
-    for (int i = 0; i < NUM_BYTES; ++i)
+    for (int i = 0; i < 3; ++i)
     {
       octet = address.substr(0, address.find_first_of('.'));
       byteVector.push_back(Utilities::stringToByte(octet));
       address.remove_prefix(octet.size() + 1);
     }
 
+    byteVector.push_back(Utilities::stringToByte(address));
     return { byteVector.at(0), byteVector.at(1), byteVector.at(2), byteVector.at(3) };
   }
   catch (const std::exception&)

--- a/sdk/main/src/impl/Utilities.cc
+++ b/sdk/main/src/impl/Utilities.cc
@@ -19,10 +19,14 @@
  */
 #include "impl/Utilities.h"
 
+#include <algorithm>
+#include <charconv>
+#include <iostream>
+
 namespace Hedera::internal::Utilities
 {
 //-----
-bool isPrefixOf(const std::vector<unsigned char>& bytes, const std::vector<unsigned char>& prefix)
+bool isPrefixOf(const std::vector<std::byte>& bytes, const std::vector<std::byte>& prefix)
 {
   if (prefix.size() > bytes.size())
   {
@@ -41,21 +45,51 @@ bool isPrefixOf(const std::vector<unsigned char>& bytes, const std::vector<unsig
 }
 
 //-----
-std::vector<unsigned char> removePrefix(const std::vector<unsigned char>& bytes, long num)
+std::vector<std::byte> removePrefix(const std::vector<std::byte>& bytes, long num)
 {
   return { bytes.cbegin() + num, bytes.cend() };
 }
 
 //-----
-std::vector<unsigned char> concatenateVectors(const std::vector<std::vector<unsigned char>>& vectors)
+std::vector<std::byte> concatenateVectors(const std::vector<std::vector<std::byte>>& vectors)
 {
-  std::vector<unsigned char> bytes;
-  for (const std::vector<unsigned char>& vec : vectors)
+  std::vector<std::byte> bytes;
+  for (const std::vector<std::byte>& vec : vectors)
   {
     bytes.insert(bytes.end(), vec.cbegin(), vec.cend());
   }
 
   return bytes;
+}
+
+//-----
+std::vector<std::byte> stringToByteVector(std::string_view str)
+{
+  std::vector<std::byte> bytes;
+  std::transform(str.cbegin(), str.cend(), std::back_inserter(bytes), [](char c) { return std::byte(c); });
+  return bytes;
+}
+
+//-----
+std::byte stringToByte(std::string_view str)
+{
+  unsigned char byte;
+  if (const auto result = std::from_chars(str.data(), str.data() + str.size(), byte);
+      result.ptr != str.data() + str.size() || result.ec != std::errc())
+  {
+    throw std::invalid_argument("Cannot convert string to byte");
+  }
+
+  return std::byte(byte);
+}
+
+//-----
+std::string byteVectorToString(const std::vector<std::byte>& bytes)
+{
+  std::string str;
+  std::transform(
+    bytes.cbegin(), bytes.cend(), std::back_inserter(str), [](std::byte byte) { return static_cast<char>(byte); });
+  return str;
 }
 
 } // namespace Hedera::internal::Utilities

--- a/sdk/tests/AccountCreateTransactionTest.cc
+++ b/sdk/tests/AccountCreateTransactionTest.cc
@@ -25,6 +25,7 @@
 #include "PublicKey.h"
 #include "exceptions/IllegalStateException.h"
 #include "impl/DurationConverter.h"
+#include "impl/Utilities.h"
 
 #include <gtest/gtest.h>
 #include <proto/transaction_body.pb.h>
@@ -88,15 +89,15 @@ TEST_F(AccountCreateTransactionTest, ConstructAccountCreateTransactionFromTransa
   body->set_initialbalance(static_cast<uint64_t>(getTestInitialBalance().toTinybars()));
   body->set_receiversigrequired(getTestReceiverSignatureRequired());
   body->set_allocated_autorenewperiod(internal::DurationConverter::toProtobuf(getTestAutoRenewPeriod()));
-  body->set_allocated_memo(new std::string{ getTestAccountMemo().cbegin(), getTestAccountMemo().cend() });
+  body->set_allocated_memo(new std::string(getTestAccountMemo()));
   body->set_max_automatic_token_associations(static_cast<int32_t>(getTestMaximumTokenAssociations()));
   body->set_allocated_staked_account_id(getTestAccountId().toProtobuf().release());
   body->set_decline_reward(getTestDeclineStakingReward());
 
-  const std::vector<unsigned char> testPublicKeyBytes = getTestPublicKey()->toBytesDer();
-  const std::vector<unsigned char> testEvmAddressBytes = getTestEvmAddress().toBytes();
-  body->set_allocated_alias(new std::string{ testPublicKeyBytes.cbegin(), testPublicKeyBytes.cend() });
-  body->set_allocated_evm_address(new std::string{ testEvmAddressBytes.cbegin(), testEvmAddressBytes.cend() });
+  const std::vector<std::byte> testPublicKeyBytes = getTestPublicKey()->toBytesDer();
+  const std::vector<std::byte> testEvmAddressBytes = getTestEvmAddress().toBytes();
+  body->set_allocated_alias(new std::string(internal::Utilities::byteVectorToString(testPublicKeyBytes)));
+  body->set_allocated_evm_address(new std::string(internal::Utilities::byteVectorToString(testEvmAddressBytes)));
 
   proto::TransactionBody txBody;
   txBody.set_allocated_cryptocreateaccount(body.release());

--- a/sdk/tests/AccountIdTest.cc
+++ b/sdk/tests/AccountIdTest.cc
@@ -21,6 +21,7 @@
 #include "ECDSAsecp256k1PrivateKey.h"
 #include "ED25519PrivateKey.h"
 #include "PublicKey.h"
+#include "impl/Utilities.h"
 
 #include <gtest/gtest.h>
 #include <limits>
@@ -415,8 +416,8 @@ TEST_F(AccountIdTest, ProtobufAccountId)
   EXPECT_EQ(protoAccountId->account_case(), proto::AccountID::AccountCase::kAlias);
 
   // Adjust protobuf fields
-  std::vector<unsigned char> testBytes = ED25519PrivateKey::generatePrivateKey()->getPublicKey()->toBytesDer();
-  protoAccountId->set_allocated_alias(new std::string{ testBytes.cbegin(), testBytes.cend() });
+  std::vector<std::byte> testBytes = ED25519PrivateKey::generatePrivateKey()->getPublicKey()->toBytesDer();
+  protoAccountId->set_allocated_alias(new std::string(internal::Utilities::byteVectorToString(testBytes)));
 
   // Deserialize ED25519 alias
   accountId = AccountId::fromProtobuf(*protoAccountId);
@@ -430,7 +431,7 @@ TEST_F(AccountIdTest, ProtobufAccountId)
 
   // Adjust protobuf fields
   testBytes = ECDSAsecp256k1PrivateKey::generatePrivateKey()->getPublicKey()->toBytesDer();
-  protoAccountId->set_allocated_alias(new std::string{ testBytes.cbegin(), testBytes.cend() });
+  protoAccountId->set_allocated_alias(new std::string(internal::Utilities::byteVectorToString(testBytes)));
 
   // Deserialize ECDSA alias
   accountId = AccountId::fromProtobuf(*protoAccountId);
@@ -443,8 +444,11 @@ TEST_F(AccountIdTest, ProtobufAccountId)
   EXPECT_EQ(protoAccountId->account_case(), proto::AccountID::AccountCase::kEvmAddress);
 
   // Adjust protobuf fields
-  testBytes = { '0', '1', '2', '3', '4', '5', '6', '7', '8', '9', 'a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'i', 'j' };
-  protoAccountId->set_allocated_evm_address(new std::string{ testBytes.cbegin(), testBytes.cend() });
+  testBytes = { std::byte('0'), std::byte('1'), std::byte('2'), std::byte('3'), std::byte('4'),
+                std::byte('5'), std::byte('6'), std::byte('7'), std::byte('8'), std::byte('9'),
+                std::byte('a'), std::byte('b'), std::byte('c'), std::byte('d'), std::byte('e'),
+                std::byte('f'), std::byte('g'), std::byte('h'), std::byte('i'), std::byte('j') };
+  protoAccountId->set_allocated_evm_address(new std::string(internal::Utilities::byteVectorToString(testBytes)));
 
   // Deserialize EVM address
   accountId = AccountId::fromProtobuf(*protoAccountId);

--- a/sdk/tests/ClientTest.cc
+++ b/sdk/tests/ClientTest.cc
@@ -77,7 +77,7 @@ TEST_F(ClientTest, SetOperator)
 //-----
 TEST_F(ClientTest, SignWithOperator)
 {
-  const std::vector<unsigned char> bytesToSign = { 0x1, 0x2, 0x3 };
+  const std::vector<std::byte> bytesToSign = { std::byte(0x1), std::byte(0x2), std::byte(0x3) };
 
   Client client;
   EXPECT_THROW(auto bytes = client.sign(bytesToSign), UninitializedException);

--- a/sdk/tests/ECDSAsecp256k1PrivateKeyTest.cc
+++ b/sdk/tests/ECDSAsecp256k1PrivateKeyTest.cc
@@ -36,14 +36,18 @@ class ECDSAsecp256k1PrivateKeyTest : public ::testing::Test
 {
 protected:
   [[nodiscard]] inline const std::string& getTestPrivateKeyHexString() const { return mPrivateKeyHexString; }
-  [[nodiscard]] inline const std::vector<unsigned char>& getTestPrivateKeyBytes() const { return mPrivateKeyBytes; }
+  [[nodiscard]] inline const std::vector<std::byte>& getTestPrivateKeyBytes() const { return mPrivateKeyBytes; }
 
 private:
   const std::string mPrivateKeyHexString = "E8F32E723DECF4051AEFAC8E2C93C9C5B214313817CDB01A1494B917C8436B35";
-  const std::vector<unsigned char> mPrivateKeyBytes = { 0xE8, 0xF3, 0x2E, 0x72, 0x3D, 0xEC, 0xF4, 0x05,
-                                                        0x1A, 0xEF, 0xAC, 0x8E, 0x2C, 0x93, 0xC9, 0xC5,
-                                                        0xB2, 0x14, 0x31, 0x38, 0x17, 0xCD, 0xB0, 0x1A,
-                                                        0x14, 0x94, 0xB9, 0x17, 0xC8, 0x43, 0x6B, 0x35 };
+  const std::vector<std::byte> mPrivateKeyBytes = {
+    std::byte(0xE8), std::byte(0xF3), std::byte(0x2E), std::byte(0x72), std::byte(0x3D), std::byte(0xEC),
+    std::byte(0xF4), std::byte(0x05), std::byte(0x1A), std::byte(0xEF), std::byte(0xAC), std::byte(0x8E),
+    std::byte(0x2C), std::byte(0x93), std::byte(0xC9), std::byte(0xC5), std::byte(0xB2), std::byte(0x14),
+    std::byte(0x31), std::byte(0x38), std::byte(0x17), std::byte(0xCD), std::byte(0xB0), std::byte(0x1A),
+    std::byte(0x14), std::byte(0x94), std::byte(0xB9), std::byte(0x17), std::byte(0xC8), std::byte(0x43),
+    std::byte(0x6B), std::byte(0x35)
+  };
 };
 
 //-----
@@ -110,7 +114,7 @@ TEST_F(ECDSAsecp256k1PrivateKeyTest, FromString)
 //-----
 TEST_F(ECDSAsecp256k1PrivateKeyTest, FromBytes)
 {
-  const std::vector<unsigned char> derEncodedPrivateKeyBytes =
+  const std::vector<std::byte> derEncodedPrivateKeyBytes =
     concatenateVectors({ ECDSAsecp256k1PrivateKey::DER_ENCODED_PREFIX_BYTES, getTestPrivateKeyBytes() });
 
   const std::unique_ptr<ECDSAsecp256k1PrivateKey> privateKeyFromBytes =
@@ -168,10 +172,10 @@ TEST_F(ECDSAsecp256k1PrivateKeyTest, Sign)
   // Given
   const std::unique_ptr<ECDSAsecp256k1PrivateKey> privateKey =
     ECDSAsecp256k1PrivateKey::fromString(getTestPrivateKeyHexString());
-  const std::vector<unsigned char> bytesToSign = { 0x1, 0x2, 0x3 };
+  const std::vector<std::byte> bytesToSign = { std::byte(0x1), std::byte(0x2), std::byte(0x3) };
 
   // When
-  const std::vector<unsigned char> signature = privateKey->sign(bytesToSign);
+  const std::vector<std::byte> signature = privateKey->sign(bytesToSign);
 
   // Then
   // ECDSA signatures incorporate random elements, so equality can't be tested. Just make sure its size makes sense.
@@ -186,7 +190,7 @@ TEST_F(ECDSAsecp256k1PrivateKeyTest, SignEmptyBytes)
     ECDSAsecp256k1PrivateKey::fromString(getTestPrivateKeyHexString());
 
   // When
-  const std::vector<unsigned char> signature = privateKey->sign({});
+  const std::vector<std::byte> signature = privateKey->sign({});
 
   // Then
   EXPECT_LE(signature.size(), ECDSAsecp256k1PrivateKey::MAX_SIGNATURE_SIZE);
@@ -216,8 +220,8 @@ TEST_F(ECDSAsecp256k1PrivateKeyTest, ToBytes)
     ECDSAsecp256k1PrivateKey::fromString(getTestPrivateKeyHexString());
 
   // When
-  const std::vector<unsigned char> bytesDer = privateKey->toBytesDer();
-  const std::vector<unsigned char> bytesRaw = privateKey->toBytesRaw();
+  const std::vector<std::byte> bytesDer = privateKey->toBytesDer();
+  const std::vector<std::byte> bytesRaw = privateKey->toBytesRaw();
 
   // Then
   EXPECT_EQ(bytesDer,
@@ -233,7 +237,7 @@ TEST_F(ECDSAsecp256k1PrivateKeyTest, GetChainCode)
     ECDSAsecp256k1PrivateKey::fromString(getTestPrivateKeyHexString());
 
   // When
-  const std::vector<unsigned char> chainCode = privateKey->getChainCode();
+  const std::vector<std::byte> chainCode = privateKey->getChainCode();
 
   // Then
   EXPECT_TRUE(chainCode.empty());

--- a/sdk/tests/ECDSAsecp256k1PublicKeyTest.cc
+++ b/sdk/tests/ECDSAsecp256k1PublicKeyTest.cc
@@ -35,11 +35,11 @@ class ECDSAsecp256k1PublicKeyTest : public ::testing::Test
 protected:
   [[nodiscard]] inline const std::string& getTestUncompressedPublicKeyHex() const { return mUncompressedPublicKeyHex; }
   [[nodiscard]] inline const std::string& getTestCompressedPublicKeyHex() const { return mCompressedPublicKeyHex; }
-  [[nodiscard]] inline const std::vector<unsigned char>& getTestUncompressedPublicKeyBytes() const
+  [[nodiscard]] inline const std::vector<std::byte>& getTestUncompressedPublicKeyBytes() const
   {
     return mUncompressedPublicKeyBytes;
   }
-  [[nodiscard]] inline const std::vector<unsigned char>& getTestCompressedPublicKeyBytes() const
+  [[nodiscard]] inline const std::vector<std::byte>& getTestCompressedPublicKeyBytes() const
   {
     return mCompressedPublicKeyBytes;
   }
@@ -48,16 +48,27 @@ private:
   const std::string mUncompressedPublicKeyHex = "045B36E22D710E79646F1A86D633EB38343BFE9DF39185EC730B1E7DFA79EE92CFD8C9"
                                                 "80B4FB4DC5493A0EE40A85543FFC49E3CDC65E0B8B8C8A8AB64A00D9B5BE";
   const std::string mCompressedPublicKeyHex = "025B36E22D710E79646F1A86D633EB38343BFE9DF39185EC730B1E7DFA79EE92CF";
-  const std::vector<unsigned char> mUncompressedPublicKeyBytes = {
-    0x04, 0x5B, 0x36, 0xE2, 0x2D, 0x71, 0x0E, 0x79, 0x64, 0x6F, 0x1A, 0x86, 0xD6, 0x33, 0xEB, 0x38, 0x34,
-    0x3B, 0xFE, 0x9D, 0xF3, 0x91, 0x85, 0xEC, 0x73, 0x0B, 0x1E, 0x7D, 0xFA, 0x79, 0xEE, 0x92, 0xCF, 0xD8,
-    0xC9, 0x80, 0xB4, 0xFB, 0x4D, 0xC5, 0x49, 0x3A, 0x0E, 0xE4, 0x0A, 0x85, 0x54, 0x3F, 0xFC, 0x49, 0xE3,
-    0xCD, 0xC6, 0x5E, 0x0B, 0x8B, 0x8C, 0x8A, 0x8A, 0xB6, 0x4A, 0x00, 0xD9, 0xB5, 0xBE
+  const std::vector<std::byte> mUncompressedPublicKeyBytes = {
+    std::byte(0x04), std::byte(0x5B), std::byte(0x36), std::byte(0xE2), std::byte(0x2D), std::byte(0x71),
+    std::byte(0x0E), std::byte(0x79), std::byte(0x64), std::byte(0x6F), std::byte(0x1A), std::byte(0x86),
+    std::byte(0xD6), std::byte(0x33), std::byte(0xEB), std::byte(0x38), std::byte(0x34), std::byte(0x3B),
+    std::byte(0xFE), std::byte(0x9D), std::byte(0xF3), std::byte(0x91), std::byte(0x85), std::byte(0xEC),
+    std::byte(0x73), std::byte(0x0B), std::byte(0x1E), std::byte(0x7D), std::byte(0xFA), std::byte(0x79),
+    std::byte(0xEE), std::byte(0x92), std::byte(0xCF), std::byte(0xD8), std::byte(0xC9), std::byte(0x80),
+    std::byte(0xB4), std::byte(0xFB), std::byte(0x4D), std::byte(0xC5), std::byte(0x49), std::byte(0x3A),
+    std::byte(0x0E), std::byte(0xE4), std::byte(0x0A), std::byte(0x85), std::byte(0x54), std::byte(0x3F),
+    std::byte(0xFC), std::byte(0x49), std::byte(0xE3), std::byte(0xCD), std::byte(0xC6), std::byte(0x5E),
+    std::byte(0x0B), std::byte(0x8B), std::byte(0x8C), std::byte(0x8A), std::byte(0x8A), std::byte(0xB6),
+    std::byte(0x4A), std::byte(0x00), std::byte(0xD9), std::byte(0xB5), std::byte(0xBE)
   };
-  const std::vector<unsigned char> mCompressedPublicKeyBytes = { 0x02, 0x5B, 0x36, 0xE2, 0x2D, 0x71, 0x0E, 0x79, 0x64,
-                                                                 0x6F, 0x1A, 0x86, 0xD6, 0x33, 0xEB, 0x38, 0x34, 0x3B,
-                                                                 0xFE, 0x9D, 0xF3, 0x91, 0x85, 0xEC, 0x73, 0x0B, 0x1E,
-                                                                 0x7D, 0xFA, 0x79, 0xEE, 0x92, 0xCF };
+  const std::vector<std::byte> mCompressedPublicKeyBytes = {
+    std::byte(0x02), std::byte(0x5B), std::byte(0x36), std::byte(0xE2), std::byte(0x2D), std::byte(0x71),
+    std::byte(0x0E), std::byte(0x79), std::byte(0x64), std::byte(0x6F), std::byte(0x1A), std::byte(0x86),
+    std::byte(0xD6), std::byte(0x33), std::byte(0xEB), std::byte(0x38), std::byte(0x34), std::byte(0x3B),
+    std::byte(0xFE), std::byte(0x9D), std::byte(0xF3), std::byte(0x91), std::byte(0x85), std::byte(0xEC),
+    std::byte(0x73), std::byte(0x0B), std::byte(0x1E), std::byte(0x7D), std::byte(0xFA), std::byte(0x79),
+    std::byte(0xEE), std::byte(0x92), std::byte(0xCF)
+  };
 };
 
 //-----
@@ -116,9 +127,9 @@ TEST_F(ECDSAsecp256k1PublicKeyTest, FromString)
 //-----
 TEST_F(ECDSAsecp256k1PublicKeyTest, FromBytes)
 {
-  const std::vector<unsigned char> derEncodedUncompressedPublicKeyBytes = concatenateVectors(
+  const std::vector<std::byte> derEncodedUncompressedPublicKeyBytes = concatenateVectors(
     { ECDSAsecp256k1PublicKey::DER_ENCODED_UNCOMPRESSED_PREFIX_BYTES, getTestUncompressedPublicKeyBytes() });
-  const std::vector<unsigned char> derEncodedCompressedPublicKeyBytes = concatenateVectors(
+  const std::vector<std::byte> derEncodedCompressedPublicKeyBytes = concatenateVectors(
     { ECDSAsecp256k1PublicKey::DER_ENCODED_COMPRESSED_PREFIX_BYTES, getTestCompressedPublicKeyBytes() });
 
   const std::shared_ptr<ECDSAsecp256k1PublicKey> publicKeyFromUncompressed =
@@ -152,11 +163,19 @@ TEST_F(ECDSAsecp256k1PublicKeyTest, FromBytes)
 
   // Throw if input garbage
   EXPECT_THROW(const std::shared_ptr<ECDSAsecp256k1PublicKey> key =
-                 ECDSAsecp256k1PublicKey::fromBytes({ 0x65, 0x4D, 0x58, 0x13, 0x47, 0x21, 0x04, 0x76 }),
+                 ECDSAsecp256k1PublicKey::fromBytes({ std::byte(0x65),
+                                                      std::byte(0x4D),
+                                                      std::byte(0x58),
+                                                      std::byte(0x13),
+                                                      std::byte(0x47),
+                                                      std::byte(0x21),
+                                                      std::byte(0x04),
+                                                      std::byte(0x76) }),
                BadKeyException);
   EXPECT_THROW(
     const std::shared_ptr<ECDSAsecp256k1PublicKey> key = ECDSAsecp256k1PublicKey::fromBytes(concatenateVectors({
-      ECDSAsecp256k1PublicKey::DER_ENCODED_UNCOMPRESSED_PREFIX_BYTES, {0x76, 0x47, 0x85, 0x47, 0x15, 0xd4}
+      ECDSAsecp256k1PublicKey::DER_ENCODED_UNCOMPRESSED_PREFIX_BYTES,
+      {std::byte(0x76), std::byte(0x47), std::byte(0x85), std::byte(0x47), std::byte(0x15), std::byte(0xd4)}
   })),
     BadKeyException);
   EXPECT_THROW(const std::shared_ptr<ECDSAsecp256k1PublicKey> key =
@@ -168,18 +187,19 @@ TEST_F(ECDSAsecp256k1PublicKeyTest, FromBytes)
 TEST_F(ECDSAsecp256k1PublicKeyTest, CompressBytes)
 {
   // Given / When
-  const std::vector<unsigned char> compressedBytes =
+  const std::vector<std::byte> compressedBytes =
     ECDSAsecp256k1PublicKey::compressBytes(getTestUncompressedPublicKeyBytes());
 
   // Then
   EXPECT_EQ(compressedBytes, getTestCompressedPublicKeyBytes());
 
   // Throw if not correct size
-  EXPECT_THROW(const std::vector<unsigned char> bytes = ECDSAsecp256k1PublicKey::compressBytes({ 0x4, 0x3, 0x2, 0x1 }),
+  EXPECT_THROW(const std::vector<std::byte> bytes = ECDSAsecp256k1PublicKey::compressBytes(
+                 { std::byte(0x4), std::byte(0x3), std::byte(0x2), std::byte(0x1) }),
                std::invalid_argument);
   // Throw if not starting with 0x4
-  EXPECT_THROW(const std::vector<unsigned char> bytes = ECDSAsecp256k1PublicKey::compressBytes(
-                 std::vector<unsigned char>(ECDSAsecp256k1PublicKey::UNCOMPRESSED_KEY_SIZE, 0x3)),
+  EXPECT_THROW(const std::vector<std::byte> bytes = ECDSAsecp256k1PublicKey::compressBytes(
+                 std::vector<std::byte>(ECDSAsecp256k1PublicKey::UNCOMPRESSED_KEY_SIZE, std::byte(0x3))),
                std::invalid_argument);
 }
 
@@ -187,18 +207,19 @@ TEST_F(ECDSAsecp256k1PublicKeyTest, CompressBytes)
 TEST_F(ECDSAsecp256k1PublicKeyTest, UncompressBytes)
 {
   // Given / When
-  const std::vector<unsigned char> uncompressedBytes =
+  const std::vector<std::byte> uncompressedBytes =
     ECDSAsecp256k1PublicKey::uncompressBytes(getTestCompressedPublicKeyBytes());
 
   // Then
   EXPECT_EQ(uncompressedBytes, getTestUncompressedPublicKeyBytes());
 
   // Throw if not correct size
-  EXPECT_THROW(const std::vector<unsigned char> bytes = ECDSAsecp256k1PublicKey::uncompressBytes({ 0x3, 0x2, 0x1 }),
+  EXPECT_THROW(const std::vector<std::byte> bytes =
+                 ECDSAsecp256k1PublicKey::uncompressBytes({ std::byte(0x3), std::byte(0x2), std::byte(0x1) }),
                std::invalid_argument);
   // Throw if not starting with 0x2 or 0x3
-  EXPECT_THROW(const std::vector<unsigned char> bytes = ECDSAsecp256k1PublicKey::uncompressBytes(
-                 std::vector<unsigned char>(ECDSAsecp256k1PublicKey::COMPRESSED_KEY_SIZE, 0x1)),
+  EXPECT_THROW(const std::vector<std::byte> bytes = ECDSAsecp256k1PublicKey::uncompressBytes(
+                 std::vector<std::byte>(ECDSAsecp256k1PublicKey::COMPRESSED_KEY_SIZE, std::byte(0x1))),
                std::invalid_argument);
 }
 
@@ -225,10 +246,10 @@ TEST_F(ECDSAsecp256k1PublicKeyTest, VerifyValidSignature)
   // Given
   const std::unique_ptr<ECDSAsecp256k1PrivateKey> privateKey = ECDSAsecp256k1PrivateKey::generatePrivateKey();
   const std::shared_ptr<PublicKey> publicKey = privateKey->getPublicKey();
-  const std::vector<unsigned char> bytesToSign = { 0x1, 0x2, 0x3 };
+  const std::vector<std::byte> bytesToSign = { std::byte(0x1), std::byte(0x2), std::byte(0x3) };
 
   // When
-  const std::vector<unsigned char> signature = privateKey->sign(bytesToSign);
+  const std::vector<std::byte> signature = privateKey->sign(bytesToSign);
 
   // Then
   EXPECT_TRUE(publicKey->verifySignature(signature, bytesToSign));
@@ -242,7 +263,7 @@ TEST_F(ECDSAsecp256k1PublicKeyTest, VerifyValidSignatureOfEmptyMessage)
   const std::shared_ptr<PublicKey> publicKey = privateKey->getPublicKey();
 
   // When
-  const std::vector<unsigned char> signature = privateKey->sign({});
+  const std::vector<std::byte> signature = privateKey->sign({});
 
   // Then
   EXPECT_TRUE(publicKey->verifySignature(signature, {}));
@@ -254,11 +275,11 @@ TEST_F(ECDSAsecp256k1PublicKeyTest, VerifySignatureAgainstModifiedBytes)
   // Given
   const std::unique_ptr<ECDSAsecp256k1PrivateKey> privateKey = ECDSAsecp256k1PrivateKey::generatePrivateKey();
   const std::shared_ptr<PublicKey> publicKey = privateKey->getPublicKey();
-  std::vector<unsigned char> bytesToSign = { 0x1, 0x2, 0x3 };
+  std::vector<std::byte> bytesToSign = { std::byte(0x1), std::byte(0x2), std::byte(0x3) };
 
   // When
-  const std::vector<unsigned char> signature = privateKey->sign(bytesToSign);
-  bytesToSign.push_back(0x4);
+  const std::vector<std::byte> signature = privateKey->sign(bytesToSign);
+  bytesToSign.push_back(std::byte(0x4));
 
   // Then
   EXPECT_FALSE(publicKey->verifySignature(signature, bytesToSign));
@@ -270,8 +291,8 @@ TEST_F(ECDSAsecp256k1PublicKeyTest, VerifyArbitrarySignature)
   // Given
   const std::shared_ptr<ECDSAsecp256k1PublicKey> publicKey =
     ECDSAsecp256k1PublicKey::fromBytes(getTestUncompressedPublicKeyBytes());
-  const std::vector<unsigned char> bytesToSign = { 0x1, 0x2, 0x3 };
-  const std::vector<unsigned char> arbitrarySignature = { 0x1, 0x2, 0x3, 0x4 };
+  const std::vector<std::byte> bytesToSign = { std::byte(0x1), std::byte(0x2), std::byte(0x3) };
+  const std::vector<std::byte> arbitrarySignature = { std::byte(0x1), std::byte(0x2), std::byte(0x3), std::byte(0x4) };
 
   // When / Then
   EXPECT_FALSE(publicKey->verifySignature(arbitrarySignature, bytesToSign));
@@ -283,7 +304,7 @@ TEST_F(ECDSAsecp256k1PublicKeyTest, VerifyEmptySignature)
   // Given
   const std::shared_ptr<ECDSAsecp256k1PublicKey> publicKey =
     ECDSAsecp256k1PublicKey::fromBytes(getTestUncompressedPublicKeyBytes());
-  const std::vector<unsigned char> bytesToSign = { 0x1, 0x2, 0x3 };
+  const std::vector<std::byte> bytesToSign = { std::byte(0x1), std::byte(0x2), std::byte(0x3) };
 
   // When / Then
   EXPECT_FALSE(publicKey->verifySignature({}, bytesToSign));
@@ -297,7 +318,7 @@ TEST_F(ECDSAsecp256k1PublicKeyTest, VerifyEmptyMessage)
   const std::shared_ptr<PublicKey> publicKey = privateKey->getPublicKey();
 
   // When
-  const std::vector<unsigned char> signature = privateKey->sign({ 0x1, 0x2, 0x3 });
+  const std::vector<std::byte> signature = privateKey->sign({ std::byte(0x1), std::byte(0x2), std::byte(0x3) });
 
   // Then
   EXPECT_FALSE(publicKey->verifySignature(signature, {}));
@@ -327,8 +348,8 @@ TEST_F(ECDSAsecp256k1PublicKeyTest, ToBytes)
     ECDSAsecp256k1PublicKey::fromBytes(getTestUncompressedPublicKeyBytes());
 
   // When
-  const std::vector<unsigned char> bytesDer = publicKey->toBytesDer();
-  const std::vector<unsigned char> bytesRaw = publicKey->toBytesRaw();
+  const std::vector<std::byte> bytesDer = publicKey->toBytesDer();
+  const std::vector<std::byte> bytesRaw = publicKey->toBytesRaw();
 
   // Then
   EXPECT_EQ(bytesDer,
@@ -351,8 +372,8 @@ TEST_F(ECDSAsecp256k1PublicKeyTest, PublicKeyToProtobuf)
   ASSERT_NE(protobufKey, nullptr);
   EXPECT_TRUE(protobufKey->has_ecdsa_secp256k1());
 
-  const std::vector<unsigned char> protobufEcdsaSecp256K1PublicKeyBytes = { protobufKey->ecdsa_secp256k1().cbegin(),
-                                                                            protobufKey->ecdsa_secp256k1().cend() };
+  const std::vector<std::byte> protobufEcdsaSecp256K1PublicKeyBytes =
+    internal::Utilities::stringToByteVector(protobufKey->ecdsa_secp256k1());
   EXPECT_EQ(protobufEcdsaSecp256K1PublicKeyBytes, getTestCompressedPublicKeyBytes());
 }
 

--- a/sdk/tests/ED25519PrivateKeyTest.cc
+++ b/sdk/tests/ED25519PrivateKeyTest.cc
@@ -35,14 +35,18 @@ class ED25519PrivateKeyTest : public ::testing::Test
 {
 protected:
   [[nodiscard]] inline const std::string& getTestPrivateKeyHexString() const { return mPrivateKeyHexString; }
-  [[nodiscard]] inline const std::vector<unsigned char>& getTestPrivateKeyBytes() const { return mPrivateKeyBytes; }
+  [[nodiscard]] inline const std::vector<std::byte>& getTestPrivateKeyBytes() const { return mPrivateKeyBytes; }
 
 private:
   const std::string mPrivateKeyHexString = "68FBA516472B387C9F33C3E667616D806E5B9CEFF23A766E5D9A3818C77871F1";
-  const std::vector<unsigned char> mPrivateKeyBytes = { 0x68, 0xFB, 0xA5, 0x16, 0x47, 0x2B, 0x38, 0x7C,
-                                                        0x9F, 0x33, 0xC3, 0xE6, 0x67, 0x61, 0x6D, 0x80,
-                                                        0x6E, 0x5B, 0x9C, 0xEF, 0xF2, 0x3A, 0x76, 0x6E,
-                                                        0x5D, 0x9A, 0x38, 0x18, 0xC7, 0x78, 0x71, 0xF1 };
+  const std::vector<std::byte> mPrivateKeyBytes = {
+    std::byte(0x68), std::byte(0xFB), std::byte(0xA5), std::byte(0x16), std::byte(0x47), std::byte(0x2B),
+    std::byte(0x38), std::byte(0x7C), std::byte(0x9F), std::byte(0x33), std::byte(0xC3), std::byte(0xE6),
+    std::byte(0x67), std::byte(0x61), std::byte(0x6D), std::byte(0x80), std::byte(0x6E), std::byte(0x5B),
+    std::byte(0x9C), std::byte(0xEF), std::byte(0xF2), std::byte(0x3A), std::byte(0x76), std::byte(0x6E),
+    std::byte(0x5D), std::byte(0x9A), std::byte(0x38), std::byte(0x18), std::byte(0xC7), std::byte(0x78),
+    std::byte(0x71), std::byte(0xF1)
+  };
 };
 
 //-----
@@ -107,7 +111,7 @@ TEST_F(ED25519PrivateKeyTest, FromString)
 //-----
 TEST_F(ED25519PrivateKeyTest, FromBytes)
 {
-  const std::vector<unsigned char> derEncodedPrivateKeyBytes =
+  const std::vector<std::byte> derEncodedPrivateKeyBytes =
     concatenateVectors({ ED25519PrivateKey::DER_ENCODED_PREFIX_BYTES, getTestPrivateKeyBytes() });
 
   const std::unique_ptr<ED25519PrivateKey> privateKeyFromBytes = ED25519PrivateKey::fromBytes(getTestPrivateKeyBytes());
@@ -161,10 +165,10 @@ TEST_F(ED25519PrivateKeyTest, Sign)
 {
   // Given
   const std::unique_ptr<ED25519PrivateKey> privateKey = ED25519PrivateKey::fromString(getTestPrivateKeyHexString());
-  const std::vector<unsigned char> bytesToSign = { 0x1, 0x2, 0x3 };
+  const std::vector<std::byte> bytesToSign = { std::byte(0x1), std::byte(0x2), std::byte(0x3) };
 
   // When / Then
-  EXPECT_NO_THROW(const std::vector<unsigned char> signature = privateKey->sign(bytesToSign));
+  EXPECT_NO_THROW(const std::vector<std::byte> signature = privateKey->sign(bytesToSign));
 
   // Signature functionality is further tested in RFC8032 test vectors
 }
@@ -176,7 +180,7 @@ TEST_F(ED25519PrivateKeyTest, SignEmptyBytes)
   const std::unique_ptr<ED25519PrivateKey> privateKey = ED25519PrivateKey::fromString(getTestPrivateKeyHexString());
 
   // When / Then
-  EXPECT_NO_THROW(const std::vector<unsigned char> signature = privateKey->sign({}));
+  EXPECT_NO_THROW(const std::vector<std::byte> signature = privateKey->sign({}));
 
   // Signature functionality is further tested in RFC8032 test vectors
 }
@@ -203,8 +207,8 @@ TEST_F(ED25519PrivateKeyTest, ToBytes)
   const std::unique_ptr<ED25519PrivateKey> privateKey = ED25519PrivateKey::fromString(getTestPrivateKeyHexString());
 
   // When
-  const std::vector<unsigned char> bytesDer = privateKey->toBytesDer();
-  const std::vector<unsigned char> bytesRaw = privateKey->toBytesRaw();
+  const std::vector<std::byte> bytesDer = privateKey->toBytesDer();
+  const std::vector<std::byte> bytesRaw = privateKey->toBytesRaw();
 
   // Then
   EXPECT_EQ(bytesDer, concatenateVectors({ ED25519PrivateKey::DER_ENCODED_PREFIX_BYTES, getTestPrivateKeyBytes() }));
@@ -218,7 +222,7 @@ TEST_F(ED25519PrivateKeyTest, GetChainCode)
   const std::unique_ptr<ED25519PrivateKey> privateKey = ED25519PrivateKey::fromString(getTestPrivateKeyHexString());
 
   // When
-  const std::vector<unsigned char> chainCode = privateKey->getChainCode();
+  const std::vector<std::byte> chainCode = privateKey->getChainCode();
 
   // Then
   EXPECT_TRUE(chainCode.empty());

--- a/sdk/tests/EvmAddressTest.cc
+++ b/sdk/tests/EvmAddressTest.cc
@@ -29,12 +29,15 @@ class EvmAddressTest : public testing::Test
 {
 protected:
   [[nodiscard]] inline const std::string& getTestString() const { return mTestString; }
-  [[nodiscard]] inline const std::vector<unsigned char>& getTestBytes() const { return mTestBytes; }
+  [[nodiscard]] inline const std::vector<std::byte>& getTestBytes() const { return mTestBytes; }
 
 private:
   const std::string mTestString = "303132333435363738396162636465666768696A";
-  const std::vector<unsigned char> mTestBytes = { '0', '1', '2', '3', '4', '5', '6', '7', '8', '9',
-                                                  'a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'i', 'j' };
+  const std::vector<std::byte> mTestBytes = { std::byte('0'), std::byte('1'), std::byte('2'), std::byte('3'),
+                                              std::byte('4'), std::byte('5'), std::byte('6'), std::byte('7'),
+                                              std::byte('8'), std::byte('9'), std::byte('a'), std::byte('b'),
+                                              std::byte('c'), std::byte('d'), std::byte('e'), std::byte('f'),
+                                              std::byte('g'), std::byte('h'), std::byte('i'), std::byte('j') };
 };
 
 TEST_F(EvmAddressTest, StringConstructor)
@@ -65,28 +68,28 @@ TEST_F(EvmAddressTest, ByteConstructor)
 {
   EXPECT_NO_THROW(EvmAddress::fromBytes(getTestBytes()));
 
-  std::vector<unsigned char> badBytes = getTestBytes();
+  std::vector<std::byte> badBytes = getTestBytes();
 
   // Byte array too small
   badBytes.pop_back();
   EXPECT_THROW(EvmAddress::fromBytes(badBytes), std::invalid_argument);
 
   // Byte array too big
-  badBytes.push_back(255);
-  badBytes.push_back(172);
+  badBytes.push_back(std::byte(255));
+  badBytes.push_back(std::byte(172));
   EXPECT_THROW(EvmAddress::fromBytes(badBytes), std::invalid_argument);
 }
 
 TEST_F(EvmAddressTest, StringByteEquality)
 {
   std::string testString = getTestString();
-  std::vector<unsigned char> testBytes = getTestBytes();
+  std::vector<std::byte> testBytes = getTestBytes();
 
   EXPECT_EQ(EvmAddress::fromString(testString).toBytes(), testBytes);
   EXPECT_EQ(EvmAddress::fromBytes(testBytes).toString(), testString);
 
   testString.front() = '4';
-  testBytes.front() = '@';
+  testBytes.front() = std::byte('@');
 
   EXPECT_EQ(EvmAddress::fromString(testString).toBytes(), testBytes);
   EXPECT_EQ(EvmAddress::fromBytes(testBytes).toString(), testString);

--- a/sdk/tests/NodeAddressTest.cc
+++ b/sdk/tests/NodeAddressTest.cc
@@ -22,6 +22,7 @@
 #include "impl/Endpoint.h"
 #include "impl/HexConverter.h"
 #include "impl/IPv4Address.h"
+#include "impl/Utilities.h"
 
 #include <gtest/gtest.h>
 #include <proto/basic_types.pb.h>
@@ -98,7 +99,7 @@ TEST_F(NodeAddressTest, GettersAndSettersNodeAddress)
   const IPv4Address& testIpAddressV4_2 = IPv4Address::fromString(testStringForIpAddressV4_2);
   const std::string& testDescription = getTestDescription();
   const std::string& testNodeCertHash = getTestNodeCertHash();
-  const std::vector<unsigned char> nodeCertHashVec = { testNodeCertHash.cbegin(), testNodeCertHash.cend() };
+  const std::vector<std::byte> nodeCertHashVec = Utilities::stringToByteVector(testNodeCertHash);
   const auto testEndpointPtr_1 = std::make_shared<Endpoint>(testIpAddressV4_1, testPortTLS);
   const auto testEndpointPtr_2 = std::make_shared<Endpoint>(testIpAddressV4_2, testPortTLS);
   std::vector<std::shared_ptr<Endpoint>> testEndpoints;

--- a/sdk/tests/TransactionRecordTest.cc
+++ b/sdk/tests/TransactionRecordTest.cc
@@ -21,6 +21,7 @@
 #include "AccountId.h"
 #include "EvmAddress.h"
 #include "impl/TimestampConverter.h"
+#include "impl/Utilities.h"
 
 #include <chrono>
 #include <gtest/gtest.h>
@@ -45,8 +46,11 @@ TEST_F(TransactionRecordTest, ProtobufTransactionRecord)
   const uint64_t txFee = 10ULL;
   const auto tokenId = TokenId(10ULL);
   const auto nftId = NftId(TokenId(20ULL), 1000ULL);
-  const std::vector<unsigned char> testEvmAddressBytes = { '0', '1', '2', '3', '4', '5', '6', '7', '8', '9',
-                                                           'a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'i', 'j' };
+  const std::vector<std::byte> testEvmAddressBytes = { std::byte('0'), std::byte('1'), std::byte('2'), std::byte('3'),
+                                                       std::byte('4'), std::byte('5'), std::byte('6'), std::byte('7'),
+                                                       std::byte('8'), std::byte('9'), std::byte('a'), std::byte('b'),
+                                                       std::byte('c'), std::byte('d'), std::byte('e'), std::byte('f'),
+                                                       std::byte('g'), std::byte('h'), std::byte('i'), std::byte('j') };
 
   proto::TransactionRecord protoTransactionRecord;
   protoTransactionRecord.mutable_receipt()->set_allocated_accountid(accountIdFrom.toProtobuf().release());
@@ -56,7 +60,7 @@ TEST_F(TransactionRecordTest, ProtobufTransactionRecord)
   protoTransactionRecord.set_allocated_memo(new std::string(txMemo));
   protoTransactionRecord.set_transactionfee(txFee);
   protoTransactionRecord.set_allocated_evm_address(
-    new std::string{ testEvmAddressBytes.cbegin(), testEvmAddressBytes.cend() });
+    new std::string(internal::Utilities::byteVectorToString(testEvmAddressBytes)));
 
   proto::AccountAmount* aa = protoTransactionRecord.mutable_transferlist()->add_accountamounts();
   aa->set_allocated_accountid(accountIdFrom.toProtobuf().release());

--- a/sdk/tests/TransactionTest.cc
+++ b/sdk/tests/TransactionTest.cc
@@ -23,6 +23,7 @@
 #include "ECDSAsecp256k1PrivateKey.h"
 #include "TransferTransaction.h"
 #include "impl/DurationConverter.h"
+#include "impl/Utilities.h"
 
 #include <gtest/gtest.h>
 #include <proto/transaction.pb.h>
@@ -47,12 +48,12 @@ protected:
     mCryptoCreateTransactionBody->set_allocated_staked_account_id(mAccountId.toProtobuf().release());
     mCryptoCreateTransactionBody->set_decline_reward(mDeclineStakingReward);
 
-    const std::vector<unsigned char> testPublicKeyBytes = mPublicKey->toBytesDer();
-    const std::vector<unsigned char> testEvmAddressBytes = mEvmAddress.toBytes();
+    const std::vector<std::byte> testPublicKeyBytes = mPublicKey->toBytesDer();
+    const std::vector<std::byte> testEvmAddressBytes = mEvmAddress.toBytes();
     mCryptoCreateTransactionBody->set_allocated_alias(
-      new std::string{ testPublicKeyBytes.cbegin(), testPublicKeyBytes.cend() });
+      new std::string(internal::Utilities::byteVectorToString(testPublicKeyBytes)));
     mCryptoCreateTransactionBody->set_allocated_evm_address(
-      new std::string{ testEvmAddressBytes.cbegin(), testEvmAddressBytes.cend() });
+      new std::string(internal::Utilities::byteVectorToString(testEvmAddressBytes)));
 
     // Initialize the CryptoTransfer unique_ptr
     proto::AccountAmount* amount = mCryptoTransferTransactionBody->mutable_transfers()->add_accountamounts();
@@ -140,7 +141,7 @@ TEST_F(TransactionTest, AccountCreateTransactionFromTransactionBodyBytes)
 
   // When
   const auto [index, txVariant] =
-    Transaction<AccountCreateTransaction>::fromBytes({ serialized.cbegin(), serialized.cend() });
+    Transaction<AccountCreateTransaction>::fromBytes(internal::Utilities::stringToByteVector(serialized));
 
   // Then
   ASSERT_EQ(index, 0);
@@ -177,7 +178,7 @@ TEST_F(TransactionTest, AccountCreateTransactionFromSignedTransactionBytes)
 
   // When
   const auto [index, txVariant] =
-    Transaction<AccountCreateTransaction>::fromBytes({ serialized.cbegin(), serialized.cend() });
+    Transaction<AccountCreateTransaction>::fromBytes(internal::Utilities::stringToByteVector(serialized));
 
   // Then
   ASSERT_EQ(index, 0);
@@ -217,7 +218,7 @@ TEST_F(TransactionTest, AccountCreateTransactionFromTransactionBytes)
 
   // When
   const auto [index, txVariant] =
-    Transaction<AccountCreateTransaction>::fromBytes({ serialized.cbegin(), serialized.cend() });
+    Transaction<AccountCreateTransaction>::fromBytes(internal::Utilities::stringToByteVector(serialized));
 
   // Then
   ASSERT_EQ(index, 0);
@@ -250,7 +251,7 @@ TEST_F(TransactionTest, TransferTransactionFromTransactionBodyBytes)
 
   // When
   const auto [index, txVariant] =
-    Transaction<AccountCreateTransaction>::fromBytes({ serialized.cbegin(), serialized.cend() });
+    Transaction<AccountCreateTransaction>::fromBytes(internal::Utilities::stringToByteVector(serialized));
 
   // Then
   ASSERT_EQ(index, 1);
@@ -296,7 +297,7 @@ TEST_F(TransactionTest, TransferTransactionFromSignedTransactionBytes)
 
   // When
   const auto [index, txVariant] =
-    Transaction<AccountCreateTransaction>::fromBytes({ serialized.cbegin(), serialized.cend() });
+    Transaction<AccountCreateTransaction>::fromBytes(internal::Utilities::stringToByteVector(serialized));
 
   // Then
   ASSERT_EQ(index, 1);
@@ -345,7 +346,7 @@ TEST_F(TransactionTest, TransferTransactionFromTransactionBytes)
 
   // When
   const auto [index, txVariant] =
-    Transaction<AccountCreateTransaction>::fromBytes({ serialized.cbegin(), serialized.cend() });
+    Transaction<AccountCreateTransaction>::fromBytes(internal::Utilities::stringToByteVector(serialized));
 
   // Then
   ASSERT_EQ(index, 1);

--- a/sdk/tests/vectors/RFC8032TestVectors.cc
+++ b/sdk/tests/vectors/RFC8032TestVectors.cc
@@ -39,7 +39,7 @@ TEST_P(RFC8032TestVectors, TestVectors)
 
   // When
   const std::unique_ptr<ED25519PrivateKey> privateKey = ED25519PrivateKey::fromString(privateKeyHex);
-  const std::vector<unsigned char> signature = privateKey->sign(hexToBytes(message));
+  const std::vector<std::byte> signature = privateKey->sign(hexToBytes(message));
 
   // Then
   EXPECT_EQ(signature, hexToBytes(expectedSignature));


### PR DESCRIPTION
**Description**:
This PR switches `std::vector<unsigned char>` usage to `std::vector<std::byte>`. There are a couple benefits to this. First, the `std::byte` provides greater type safety and doesn't allow accidental operations and/or conversions to be performed on them. This makes it a bit more verbose but that verbosity can be encapsulated in helper functions. Also, `std::byte` is more direct with its naming, in that the user knows they should be viewing the unit as a "byte" and not a "char".

**Related issue(s)**:

Fixes #213 

**Checklist**

- [x] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
