### PR TITLE
Add `forMainnet()` and `forPreviewnet()` Client APIs

### DIFF
--- a/sdk/examples/CMakeLists.txt
+++ b/sdk/examples/CMakeLists.txt
@@ -12,9 +12,11 @@ add_executable(${TRANSFER_CRYPTO_EXAMPLE_NAME} TransferCryptoExample.cc)
 add_executable(${TRANSFER_TOKENS_EXAMPLE_NAME} TransferTokensExample.cc)
 add_executable(${UPDATE_ACCOUNT_PUBLIC_KEY_EXAMPLE_NAME} UpdateAccountPublicKeyExample.cc)
 
-file(COPY ${PROJECT_SOURCE_DIR}/addressbook/testnet.pb
-        DESTINATION ${CMAKE_CURRENT_BINARY_DIR}/${CMAKE_BUILD_TYPE})
 file(COPY ${PROJECT_SOURCE_DIR}/addressbook/mainnet.pb
+        DESTINATION ${CMAKE_CURRENT_BINARY_DIR}/${CMAKE_BUILD_TYPE})
+file(COPY ${PROJECT_SOURCE_DIR}/addressbook/previewnet.pb
+        DESTINATION ${CMAKE_CURRENT_BINARY_DIR}/${CMAKE_BUILD_TYPE})
+file(COPY ${PROJECT_SOURCE_DIR}/addressbook/testnet.pb
         DESTINATION ${CMAKE_CURRENT_BINARY_DIR}/${CMAKE_BUILD_TYPE})
 
 # Install gRPC's roots.pem file for Windows with the examples so that it can be easily referenced.

--- a/sdk/main/include/Client.h
+++ b/sdk/main/include/Client.h
@@ -62,11 +62,25 @@ public:
   Client& operator=(Client&& other) noexcept;
 
   /**
+   * Construct a Client pre-configured for Hedera Mainnet access.
+   *
+   * @return A Client object that is set-up to communicate with the Hedera Mainnet.
+   */
+  [[nodiscard]] static Client forMainnet();
+
+  /**
    * Construct a Client pre-configured for Hedera Testnet access.
    *
    * @return A Client object that is set-up to communicate with the Hedera Testnet.
    */
-  static Client forTestnet();
+  [[nodiscard]] static Client forTestnet();
+
+  /**
+   * Construct a Client pre-configured for Hedera Previewnet access.
+   *
+   * @return A Client object that is set-up to communicate with the Hedera Previewnet.
+   */
+  [[nodiscard]] static Client forPreviewnet();
 
   /**
    * Set the account that will, by default, be paying for requests submitted by this Client. The operator account ID is

--- a/sdk/main/include/impl/Network.h
+++ b/sdk/main/include/impl/Network.h
@@ -40,11 +40,25 @@ class Network
 {
 public:
   /**
+   * Construct a Network that is pre-configured for Hedera Mainnet access.
+   *
+   * @return A Network object that is set-up to communicate with the Hedera Mainnet.
+   */
+  [[nodiscard]] static Network forMainnet();
+
+  /**
    * Construct a Network that is pre-configured for Hedera Testnet access.
    *
    * @return A Network object that is set-up to communicate with the Hedera Testnet.
    */
-  static Network forTestnet();
+  [[nodiscard]] static Network forTestnet();
+
+  /**
+   * Construct a Network that is pre-configured for Hedera Previewnet access.
+   *
+   * @return A Network object that is set-up to communicate with the Hedera Previewnet.
+   */
+  [[nodiscard]] static Network forPreviewnet();
 
   /**
    * Get a list of Node pointers that point to Nodes on this Network that are associated with the input account IDs. If

--- a/sdk/main/src/Client.cc
+++ b/sdk/main/src/Client.cc
@@ -97,10 +97,26 @@ Client& Client::operator=(Client&& other) noexcept
 }
 
 //-----
+Client Client::forMainnet()
+{
+  Client client;
+  client.mImpl->mNetwork = internal::Network::forMainnet();
+  return client;
+}
+
+//-----
 Client Client::forTestnet()
 {
   Client client;
   client.mImpl->mNetwork = internal::Network::forTestnet();
+  return client;
+}
+
+//-----
+Client Client::forPreviewnet()
+{
+  Client client;
+  client.mImpl->mNetwork = internal::Network::forPreviewnet();
   return client;
 }
 

--- a/sdk/main/src/impl/Network.cc
+++ b/sdk/main/src/impl/Network.cc
@@ -24,11 +24,26 @@
 namespace Hedera::internal
 {
 //-----
+Network Network::forMainnet()
+{
+  Network network;
+  network.setNetwork(NodeAddressBook::fromFile("mainnet.pb"));
+  return network;
+}
+
+//-----
 Network Network::forTestnet()
 {
   Network network;
   network.setNetwork(NodeAddressBook::fromFile("testnet.pb"));
+  return network;
+}
 
+//-----
+Network Network::forPreviewnet()
+{
+  Network network;
+  network.setNetwork(NodeAddressBook::fromFile("previewnet.pb"));
   return network;
 }
 


### PR DESCRIPTION
**Description**:
This PR adds `forMainnet()` and `forPreviewnet()` Client APIs, to allow users to easily communicate with different Hedera networks.

**Related issue(s)**:

Fixes #229 

**Notes for reviewer**:
These were tested using the examples and have been confirmed to work.

**Checklist**

- [x] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
