### PR TITLE
Implement `AccountDeleteTransaction`

### DIFF
--- a/sdk/examples/CMakeLists.txt
+++ b/sdk/examples/CMakeLists.txt
@@ -1,4 +1,5 @@
 set(CREATE_ACCOUNT_EXAMPLE_NAME ${PROJECT_NAME}-create-account-example)
+set(DELETE_ACCOUNT_EXAMPLE_NAME ${PROJECT_NAME}-delete-account-example)
 set(GENERATE_PRIVATE_KEY_FROM_MNEMONIC_EXAMPLE_NAME ${PROJECT_NAME}-generate-private-key-from-mnemonic-example)
 set(GET_ACCOUNT_BALANCE_EXAMPLE_NAME ${PROJECT_NAME}-get-account-balance-example)
 set(TRANSFER_CRYPTO_EXAMPLE_NAME ${PROJECT_NAME}-transfer-crypto-example)
@@ -6,6 +7,7 @@ set(TRANSFER_TOKENS_EXAMPLE_NAME ${PROJECT_NAME}-transfer-tokens-example)
 set(UPDATE_ACCOUNT_PUBLIC_KEY_EXAMPLE_NAME ${PROJECT_NAME}-update-account-public-key-example)
 
 add_executable(${CREATE_ACCOUNT_EXAMPLE_NAME} CreateAccountExample.cc)
+add_executable(${DELETE_ACCOUNT_EXAMPLE_NAME} DeleteAccountExample.cc)
 add_executable(${GENERATE_PRIVATE_KEY_FROM_MNEMONIC_EXAMPLE_NAME} GeneratePrivateKeyFromMnemonic.cc)
 add_executable(${GET_ACCOUNT_BALANCE_EXAMPLE_NAME} GetAccountBalanceExample.cc)
 add_executable(${TRANSFER_CRYPTO_EXAMPLE_NAME} TransferCryptoExample.cc)
@@ -24,6 +26,7 @@ if (WIN32)
 endif ()
 
 target_link_libraries(${CREATE_ACCOUNT_EXAMPLE_NAME} PUBLIC ${PROJECT_NAME})
+target_link_libraries(${DELETE_ACCOUNT_EXAMPLE_NAME} PUBLIC ${PROJECT_NAME})
 target_link_libraries(${GENERATE_PRIVATE_KEY_FROM_MNEMONIC_EXAMPLE_NAME} PUBLIC ${PROJECT_NAME})
 target_link_libraries(${GET_ACCOUNT_BALANCE_EXAMPLE_NAME} PUBLIC ${PROJECT_NAME})
 target_link_libraries(${TRANSFER_CRYPTO_EXAMPLE_NAME} PUBLIC ${PROJECT_NAME})
@@ -34,6 +37,7 @@ install(DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/${CMAKE_BUILD_TYPE} DESTINATION ex
 
 install(TARGETS
         ${CREATE_ACCOUNT_EXAMPLE_NAME}
+        ${DELETE_ACCOUNT_EXAMPLE_NAME}
         ${GENERATE_PRIVATE_KEY_FROM_MNEMONIC_EXAMPLE_NAME}
         ${GET_ACCOUNT_BALANCE_EXAMPLE_NAME}
         ${TRANSFER_CRYPTO_EXAMPLE_NAME}

--- a/sdk/examples/DeleteAccountExample.cc
+++ b/sdk/examples/DeleteAccountExample.cc
@@ -1,0 +1,78 @@
+/*-
+ *
+ * Hedera C++ SDK
+ *
+ * Copyright (C) 2020 - 2022 Hedera Hashgraph, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+#include "AccountCreateTransaction.h"
+#include "AccountDeleteTransaction.h"
+#include "Client.h"
+#include "ED25519PrivateKey.h"
+#include "PublicKey.h"
+#include "Status.h"
+#include "TransactionReceipt.h"
+#include "TransactionResponse.h"
+
+#include <iostream>
+
+using namespace Hedera;
+
+int main(int argc, char** argv)
+{
+  if (argc < 3)
+  {
+    std::cout << "Please input account ID and private key" << std::endl;
+    return 1;
+  }
+
+  // Get a client for the Hedera testnet, and set the operator account ID and key such that all generated transactions
+  // will be paid for by this account and be signed by this key.
+  Client client = Client::forTestnet();
+  const AccountId operatorAccountId = AccountId::fromString(argv[1]);
+  client.setOperator(operatorAccountId, ED25519PrivateKey::fromString(argv[2]));
+
+  // Generate a ED25519 private, public key pair
+  const std::unique_ptr<PrivateKey> privateKey = ED25519PrivateKey::generatePrivateKey();
+  const std::shared_ptr<PublicKey> publicKey = privateKey->getPublicKey();
+
+  std::cout << "Generated private key: " << privateKey->toStringRaw() << std::endl;
+  std::cout << "Generated public key: " << publicKey->toStringRaw() << std::endl;
+
+  // Create a new account with an initial balance of 1000 tinybars. The only required field here is the key.
+  TransactionResponse txResp =
+    AccountCreateTransaction().setKey(publicKey).setInitialBalance(Hbar(1000ULL, HbarUnit::TINYBAR())).execute(client);
+
+  // Get the receipt when it becomes available
+  TransactionReceipt txReceipt = txResp.getReceipt(client);
+
+  const AccountId newAccountId = txReceipt.getAccountId().value();
+  std::cout << "Created new account with ID " << newAccountId.toString() << std::endl;
+
+  // Delete the newly-created account
+  txReceipt = AccountDeleteTransaction()
+                // The transaction ID has to use the ID of the account being deleted
+                .setTransactionId(TransactionId::generate(newAccountId))
+                .setDeleteAccountId(newAccountId)
+                .setTransferAccountId(operatorAccountId)
+                .freezeWith(client)
+                .sign(privateKey.get())
+                .execute(client)
+                .getReceipt(client);
+
+  std::cout << "Deleted account with response code: " << gStatusToString.at(txReceipt.getStatus()) << std::endl;
+
+  return 0;
+}

--- a/sdk/main/CMakeLists.txt
+++ b/sdk/main/CMakeLists.txt
@@ -9,7 +9,7 @@ add_library(${PROJECT_NAME} STATIC
         src/AccountBalance.cc
         src/AccountBalanceQuery.cc
         src/AccountCreateTransaction.cc
-        #    src/AccountDeleteTransaction.cc
+        src/AccountDeleteTransaction.cc
         src/AccountId.cc
         #    src/AccountInfo.cc
         #    src/AccountInfoQuery.cc

--- a/sdk/main/include/Transaction.h
+++ b/sdk/main/include/Transaction.h
@@ -36,6 +36,7 @@
 namespace Hedera
 {
 class AccountCreateTransaction;
+class AccountDeleteTransaction;
 class AccountUpdateTransaction;
 class PrivateKey;
 class TransactionResponse;
@@ -93,8 +94,9 @@ public:
    * @return A pair which contains an index into the variant, as well as
    * @throws std::invalid_argument If unable to construct a Transaction from the input bytes.
    */
-  [[nodiscard]] static std::pair<int,
-                                 std::variant<AccountCreateTransaction, TransferTransaction, AccountUpdateTransaction>>
+  [[nodiscard]] static std::pair<
+    int,
+    std::variant<AccountCreateTransaction, TransferTransaction, AccountUpdateTransaction, AccountDeleteTransaction>>
   fromBytes(const std::vector<std::byte>& bytes);
 
   /**

--- a/sdk/main/src/Executable.cc
+++ b/sdk/main/src/Executable.cc
@@ -21,6 +21,7 @@
 #include "AccountBalance.h"
 #include "AccountBalanceQuery.h"
 #include "AccountCreateTransaction.h"
+#include "AccountDeleteTransaction.h"
 #include "AccountUpdateTransaction.h"
 #include "Client.h"
 #include "TransactionReceipt.h"
@@ -272,6 +273,10 @@ Executable<SdkRequestType, ProtoRequestType, ProtoResponseType, SdkResponseType>
  */
 template class Executable<AccountBalanceQuery, proto::Query, proto::Response, AccountBalance>;
 template class Executable<AccountCreateTransaction,
+                          proto::Transaction,
+                          proto::TransactionResponse,
+                          TransactionResponse>;
+template class Executable<AccountDeleteTransaction,
                           proto::Transaction,
                           proto::TransactionResponse,
                           TransactionResponse>;

--- a/sdk/main/src/Transaction.cc
+++ b/sdk/main/src/Transaction.cc
@@ -19,6 +19,7 @@
  */
 #include "Transaction.h"
 #include "AccountCreateTransaction.h"
+#include "AccountDeleteTransaction.h"
 #include "AccountUpdateTransaction.h"
 #include "Client.h"
 #include "ECDSAsecp256k1PublicKey.h"
@@ -44,7 +45,9 @@ namespace Hedera
 {
 //-----
 template<typename SdkRequestType>
-std::pair<int, std::variant<AccountCreateTransaction, TransferTransaction, AccountUpdateTransaction>>
+std::pair<
+  int,
+  std::variant<AccountCreateTransaction, TransferTransaction, AccountUpdateTransaction, AccountDeleteTransaction>>
 Transaction<SdkRequestType>::fromBytes(const std::vector<std::byte>& bytes)
 {
   proto::TransactionBody txBody;
@@ -80,6 +83,8 @@ Transaction<SdkRequestType>::fromBytes(const std::vector<std::byte>& bytes)
       return { 1, TransferTransaction(txBody) };
     case proto::TransactionBody::kCryptoUpdateAccount:
       return { 2, AccountUpdateTransaction(txBody) };
+    case proto::TransactionBody::kCryptoDelete:
+      return { 3, AccountDeleteTransaction(txBody) };
     default:
       throw std::invalid_argument("Type of transaction cannot be determined from input bytes");
   }
@@ -379,6 +384,7 @@ void Transaction<SdkRequestType>::onExecute(const Client& client)
  * Explicit template instantiation.
  */
 template class Transaction<AccountCreateTransaction>;
+template class Transaction<AccountDeleteTransaction>;
 template class Transaction<AccountUpdateTransaction>;
 template class Transaction<TransferTransaction>;
 

--- a/sdk/tests/AccountDeleteTransactionTest.cc
+++ b/sdk/tests/AccountDeleteTransactionTest.cc
@@ -1,0 +1,92 @@
+/*-
+ *
+ * Hedera C++ SDK
+ *
+ * Copyright (C) 2020 - 2022 Hedera Hashgraph, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+#include "AccountDeleteTransaction.h"
+#include "Client.h"
+#include "ECDSAsecp256k1PrivateKey.h"
+#include "exceptions/IllegalStateException.h"
+
+#include <gtest/gtest.h>
+#include <proto/transaction_body.pb.h>
+
+using namespace Hedera;
+
+class AccountDeleteTransactionTest : public ::testing::Test
+{
+protected:
+  void SetUp() override { mClient.setOperator(AccountId(), ECDSAsecp256k1PrivateKey::generatePrivateKey()); }
+
+  [[nodiscard]] inline const Client& getTestClient() const { return mClient; }
+  [[nodiscard]] inline const AccountId& getTestDeleteAccountId() const { return mDeleteAccountId; }
+  [[nodiscard]] inline const AccountId& getTestTransferAccountId() const { return mTransferAccountId; }
+
+private:
+  Client mClient;
+  const AccountId mDeleteAccountId = AccountId(1ULL);
+  const AccountId mTransferAccountId = AccountId(2ULL);
+};
+
+//-----
+TEST_F(AccountDeleteTransactionTest, ConstructAccountDeleteTransaction)
+{
+  AccountDeleteTransaction transaction;
+  EXPECT_EQ(transaction.getDeleteAccountId(), AccountId());
+  EXPECT_EQ(transaction.getTransferAccountId(), AccountId());
+}
+
+//-----
+TEST_F(AccountDeleteTransactionTest, ConstructAccountCreateTransactionFromTransactionBodyProtobuf)
+{
+  // Given
+  auto body = std::make_unique<proto::CryptoDeleteTransactionBody>();
+  body->set_allocated_deleteaccountid(getTestDeleteAccountId().toProtobuf().release());
+  body->set_allocated_transferaccountid(getTestTransferAccountId().toProtobuf().release());
+
+  proto::TransactionBody txBody;
+  txBody.set_allocated_cryptodelete(body.release());
+
+  // When
+  AccountDeleteTransaction accountDeleteTransaction(txBody);
+
+  // Then
+  EXPECT_EQ(accountDeleteTransaction.getDeleteAccountId(), getTestDeleteAccountId());
+  EXPECT_EQ(accountDeleteTransaction.getTransferAccountId(), getTestTransferAccountId());
+}
+
+//-----
+TEST_F(AccountDeleteTransactionTest, SetDeleteAccountId)
+{
+  AccountDeleteTransaction transaction;
+  transaction.setDeleteAccountId(getTestDeleteAccountId());
+  EXPECT_EQ(transaction.getDeleteAccountId(), getTestDeleteAccountId());
+
+  transaction.freezeWith(getTestClient());
+  EXPECT_THROW(transaction.setDeleteAccountId(getTestDeleteAccountId()), IllegalStateException);
+}
+
+//-----
+TEST_F(AccountDeleteTransactionTest, SetTransferAccountId)
+{
+  AccountDeleteTransaction transaction;
+  transaction.setTransferAccountId(getTestTransferAccountId());
+  EXPECT_EQ(transaction.getTransferAccountId(), getTestTransferAccountId());
+
+  transaction.freezeWith(getTestClient());
+  EXPECT_THROW(transaction.setTransferAccountId(getTestTransferAccountId()), IllegalStateException);
+}

--- a/sdk/tests/CMakeLists.txt
+++ b/sdk/tests/CMakeLists.txt
@@ -17,6 +17,7 @@ add_executable(${TEST_PROJECT_NAME}
         AccountBalanceQueryTest.cc
         AccountBalanceTest.cc
         AccountCreateTransactionTest.cc
+        AccountDeleteTransactionTest.cc
         AccountIdTest.cc
         AccountUpdateTransactionTest.cc
         ClientTest.cc

--- a/sdk/tests/TransactionTest.cc
+++ b/sdk/tests/TransactionTest.cc
@@ -19,6 +19,7 @@
  */
 #include "Transaction.h"
 #include "AccountCreateTransaction.h"
+#include "AccountDeleteTransaction.h"
 #include "AccountUpdateTransaction.h"
 #include "ECDSAsecp256k1PrivateKey.h"
 #include "TransferTransaction.h"


### PR DESCRIPTION
**Description**:
This PR adds the `AccountDeleteTransaction` APIs, allowing a user to delete an account. It also adds unit tests and an associated example for deleting an account.

**Related issue(s)**:

Fixes #230 

**Checklist**

- [x] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
