### PR TITLE
Fix compiler warnings for AccountIdTest and EvmAddressTest

### DIFF
--- a/sdk/tests/AccountIdTest.cc
+++ b/sdk/tests/AccountIdTest.cc
@@ -228,42 +228,44 @@ TEST_F(AccountIdTest, ConstructFromString)
   EXPECT_TRUE(accountId.getAccountNum().has_value());
   EXPECT_EQ(*accountId.getAccountNum(), getTestAccountNum());
 
-  EXPECT_THROW(AccountId::fromString(testShardNumStr + testRealmNumStr + testAccountNumStr), std::invalid_argument);
-  EXPECT_THROW(AccountId::fromString('.' + testShardNumStr + testRealmNumStr + testAccountNumStr),
+  EXPECT_THROW(accountId = AccountId::fromString(testShardNumStr + testRealmNumStr + testAccountNumStr),
                std::invalid_argument);
-  EXPECT_THROW(AccountId::fromString(testShardNumStr + '.' + testRealmNumStr + testAccountNumStr),
+  EXPECT_THROW(accountId = AccountId::fromString('.' + testShardNumStr + testRealmNumStr + testAccountNumStr),
                std::invalid_argument);
-  EXPECT_THROW(AccountId::fromString(testShardNumStr + testRealmNumStr + '.' + testAccountNumStr),
+  EXPECT_THROW(accountId = AccountId::fromString(testShardNumStr + '.' + testRealmNumStr + testAccountNumStr),
                std::invalid_argument);
-  EXPECT_THROW(AccountId::fromString(testShardNumStr + testRealmNumStr + testAccountNumStr + '.'),
+  EXPECT_THROW(accountId = AccountId::fromString(testShardNumStr + testRealmNumStr + '.' + testAccountNumStr),
                std::invalid_argument);
-  EXPECT_THROW(AccountId::fromString(".." + testShardNumStr + testRealmNumStr + testAccountNumStr),
+  EXPECT_THROW(accountId = AccountId::fromString(testShardNumStr + testRealmNumStr + testAccountNumStr + '.'),
                std::invalid_argument);
-  EXPECT_THROW(AccountId::fromString('.' + testShardNumStr + '.' + testRealmNumStr + testAccountNumStr),
+  EXPECT_THROW(accountId = AccountId::fromString(".." + testShardNumStr + testRealmNumStr + testAccountNumStr),
                std::invalid_argument);
-  EXPECT_THROW(AccountId::fromString('.' + testShardNumStr + testRealmNumStr + '.' + testAccountNumStr),
+  EXPECT_THROW(accountId = AccountId::fromString('.' + testShardNumStr + '.' + testRealmNumStr + testAccountNumStr),
                std::invalid_argument);
-  EXPECT_THROW(AccountId::fromString('.' + testShardNumStr + testRealmNumStr + testAccountNumStr + '.'),
+  EXPECT_THROW(accountId = AccountId::fromString('.' + testShardNumStr + testRealmNumStr + '.' + testAccountNumStr),
                std::invalid_argument);
-  EXPECT_THROW(AccountId::fromString(testShardNumStr + ".." + testRealmNumStr + testAccountNumStr),
+  EXPECT_THROW(accountId = AccountId::fromString('.' + testShardNumStr + testRealmNumStr + testAccountNumStr + '.'),
                std::invalid_argument);
-  EXPECT_THROW(AccountId::fromString(testShardNumStr + '.' + testRealmNumStr + testAccountNumStr + '.'),
+  EXPECT_THROW(accountId = AccountId::fromString(testShardNumStr + ".." + testRealmNumStr + testAccountNumStr),
                std::invalid_argument);
-  EXPECT_THROW(AccountId::fromString(testShardNumStr + testRealmNumStr + ".." + testAccountNumStr),
+  EXPECT_THROW(accountId = AccountId::fromString(testShardNumStr + '.' + testRealmNumStr + testAccountNumStr + '.'),
                std::invalid_argument);
-  EXPECT_THROW(AccountId::fromString(testShardNumStr + testRealmNumStr + '.' + testAccountNumStr + '.'),
+  EXPECT_THROW(accountId = AccountId::fromString(testShardNumStr + testRealmNumStr + ".." + testAccountNumStr),
                std::invalid_argument);
-  EXPECT_THROW(AccountId::fromString('.' + testShardNumStr + '.' + testRealmNumStr + '.' + testAccountNumStr + '.'),
+  EXPECT_THROW(accountId = AccountId::fromString(testShardNumStr + testRealmNumStr + '.' + testAccountNumStr + '.'),
+               std::invalid_argument);
+  EXPECT_THROW(accountId =
+                 AccountId::fromString('.' + testShardNumStr + '.' + testRealmNumStr + '.' + testAccountNumStr + '.'),
                std::invalid_argument);
 
-  EXPECT_THROW(AccountId::fromString("abc"), std::invalid_argument);
-  EXPECT_THROW(AccountId::fromString("o.o.e"), std::invalid_argument);
-  EXPECT_THROW(AccountId::fromString("0.0.1!"), std::invalid_argument);
-  EXPECT_THROW(AccountId::fromString(testNumTooBigStr + '.' + testRealmNumStr + '.' + testAccountNumStr),
+  EXPECT_THROW(accountId = AccountId::fromString("abc"), std::invalid_argument);
+  EXPECT_THROW(accountId = AccountId::fromString("o.o.e"), std::invalid_argument);
+  EXPECT_THROW(accountId = AccountId::fromString("0.0.1!"), std::invalid_argument);
+  EXPECT_THROW(accountId = AccountId::fromString(testNumTooBigStr + '.' + testRealmNumStr + '.' + testAccountNumStr),
                std::invalid_argument);
-  EXPECT_THROW(AccountId::fromString(testShardNumStr + '.' + testNumTooBigStr + '.' + testAccountNumStr),
+  EXPECT_THROW(accountId = AccountId::fromString(testShardNumStr + '.' + testNumTooBigStr + '.' + testAccountNumStr),
                std::invalid_argument);
-  EXPECT_THROW(AccountId::fromString(testShardNumStr + '.' + testRealmNumStr + '.' + testNumTooBigStr),
+  EXPECT_THROW(accountId = AccountId::fromString(testShardNumStr + '.' + testRealmNumStr + '.' + testNumTooBigStr),
                std::invalid_argument);
 
   const std::string ed25519AliasStr = getTestEd25519Alias()->toStringDer();
@@ -273,9 +275,9 @@ TEST_F(AccountIdTest, ConstructFromString)
   EXPECT_NE(accountId.getAlias(), nullptr);
   EXPECT_EQ(accountId.getAlias()->toStringDer(), ed25519AliasStr);
 
-  EXPECT_THROW(AccountId::fromString(ed25519AliasStr + '.' + testRealmNumStr + '.' + testAccountNumStr),
+  EXPECT_THROW(accountId = AccountId::fromString(ed25519AliasStr + '.' + testRealmNumStr + '.' + testAccountNumStr),
                std::invalid_argument);
-  EXPECT_THROW(AccountId::fromString(testShardNumStr + '.' + ed25519AliasStr + '.' + testAccountNumStr),
+  EXPECT_THROW(accountId = AccountId::fromString(testShardNumStr + '.' + ed25519AliasStr + '.' + testAccountNumStr),
                std::invalid_argument);
 
   const std::string ecdsaAliasStr = getTestEcdsaSecp256k1Alias()->toStringDer();
@@ -285,9 +287,9 @@ TEST_F(AccountIdTest, ConstructFromString)
   EXPECT_NE(accountId.getAlias(), nullptr);
   EXPECT_EQ(accountId.getAlias()->toStringDer(), ecdsaAliasStr);
 
-  EXPECT_THROW(AccountId::fromString(ecdsaAliasStr + '.' + testRealmNumStr + '.' + testAccountNumStr),
+  EXPECT_THROW(accountId = AccountId::fromString(ecdsaAliasStr + '.' + testRealmNumStr + '.' + testAccountNumStr),
                std::invalid_argument);
-  EXPECT_THROW(AccountId::fromString(testShardNumStr + '.' + ecdsaAliasStr + '.' + testAccountNumStr),
+  EXPECT_THROW(accountId = AccountId::fromString(testShardNumStr + '.' + ecdsaAliasStr + '.' + testAccountNumStr),
                std::invalid_argument);
 
   const std::string evmAddressStr = getTestEvmAddress().toString();
@@ -297,9 +299,9 @@ TEST_F(AccountIdTest, ConstructFromString)
   EXPECT_TRUE(accountId.getEvmAddress());
   EXPECT_EQ(accountId.getEvmAddress()->toString(), evmAddressStr);
 
-  EXPECT_THROW(AccountId::fromString(evmAddressStr + '.' + testRealmNumStr + '.' + testAccountNumStr),
+  EXPECT_THROW(accountId = AccountId::fromString(evmAddressStr + '.' + testRealmNumStr + '.' + testAccountNumStr),
                std::invalid_argument);
-  EXPECT_THROW(AccountId::fromString(testShardNumStr + '.' + evmAddressStr + '.' + testAccountNumStr),
+  EXPECT_THROW(accountId = AccountId::fromString(testShardNumStr + '.' + evmAddressStr + '.' + testAccountNumStr),
                std::invalid_argument);
 }
 

--- a/sdk/tests/EvmAddressTest.cc
+++ b/sdk/tests/EvmAddressTest.cc
@@ -42,42 +42,42 @@ private:
 
 TEST_F(EvmAddressTest, StringConstructor)
 {
-  EXPECT_NO_THROW(EvmAddress::fromString(getTestString()));
-  EXPECT_NO_THROW(EvmAddress::fromString("0x" + getTestString()));
+  EXPECT_NO_THROW(auto evmAddress = EvmAddress::fromString(getTestString()));
+  EXPECT_NO_THROW(auto evmAddress = EvmAddress::fromString("0x" + getTestString()));
 
   // String too short
   std::string badString = getTestString();
   badString.pop_back();
-  EXPECT_THROW(EvmAddress::fromString(badString), std::invalid_argument);
-  EXPECT_THROW(EvmAddress::fromString("0x" + badString), std::invalid_argument);
+  EXPECT_THROW(auto evmAddress = EvmAddress::fromString(badString), std::invalid_argument);
+  EXPECT_THROW(auto evmAddress = EvmAddress::fromString("0x" + badString), std::invalid_argument);
 
   // String contains non-hex characters
   badString.push_back('x');
-  EXPECT_THROW(EvmAddress::fromString(badString), std::invalid_argument);
-  EXPECT_THROW(EvmAddress::fromString("0x" + badString), std::invalid_argument);
+  EXPECT_THROW(auto evmAddress = EvmAddress::fromString(badString), std::invalid_argument);
+  EXPECT_THROW(auto evmAddress = EvmAddress::fromString("0x" + badString), std::invalid_argument);
 
   // String contains prefix not at beginning of string
   badString.pop_back();
   badString.pop_back();
   badString.insert(badString.size() / 2, "0x");
-  EXPECT_THROW(EvmAddress::fromString(badString), std::invalid_argument);
-  EXPECT_THROW(EvmAddress::fromString("0x" + badString), std::invalid_argument);
+  EXPECT_THROW(auto evmAddress = EvmAddress::fromString(badString), std::invalid_argument);
+  EXPECT_THROW(auto evmAddress = EvmAddress::fromString("0x" + badString), std::invalid_argument);
 }
 
 TEST_F(EvmAddressTest, ByteConstructor)
 {
-  EXPECT_NO_THROW(EvmAddress::fromBytes(getTestBytes()));
+  EXPECT_NO_THROW(auto evmAddress = EvmAddress::fromBytes(getTestBytes()));
 
   std::vector<std::byte> badBytes = getTestBytes();
 
   // Byte array too small
   badBytes.pop_back();
-  EXPECT_THROW(EvmAddress::fromBytes(badBytes), std::invalid_argument);
+  EXPECT_THROW(auto evmAddress = EvmAddress::fromBytes(badBytes), std::invalid_argument);
 
   // Byte array too big
   badBytes.push_back(std::byte(255));
   badBytes.push_back(std::byte(172));
-  EXPECT_THROW(EvmAddress::fromBytes(badBytes), std::invalid_argument);
+  EXPECT_THROW(auto evmAddress = EvmAddress::fromBytes(badBytes), std::invalid_argument);
 }
 
 TEST_F(EvmAddressTest, StringByteEquality)


### PR DESCRIPTION
**Description**:
This PR fixes some missed compiler warning when marking some `AccountId` and `EvmAddress` as `[[nodiscard]]`.

**Related issue(s)**:

Fixes #232 

**Checklist**

- [x] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
