### PR TITLE
Add `Transaction::fromBytes()` tests for `AccountUpdateTransaction` and `AccountDeleteTransaction`

### DIFF
--- a/sdk/tests/TransactionTest.cc
+++ b/sdk/tests/TransactionTest.cc
@@ -24,6 +24,7 @@
 #include "ECDSAsecp256k1PrivateKey.h"
 #include "TransferTransaction.h"
 #include "impl/DurationConverter.h"
+#include "impl/TimestampConverter.h"
 #include "impl/Utilities.h"
 
 #include <gtest/gtest.h>
@@ -79,6 +80,35 @@ protected:
     nft->set_allocated_receiveraccountid(getTestAccountId().toProtobuf().release());
     nft->set_serialnumber(static_cast<int64_t>(getTestNftId().getSerialNum()));
     nft->set_is_approval(getTestApproval());
+
+    // Initialize the CryptoUpdate unique_ptr
+    mCryptoUpdateTransactionBody->set_allocated_accountidtoupdate(mAccountId.toProtobuf().release());
+    mCryptoUpdateTransactionBody->set_allocated_key(mPublicKey->toProtobuf().release());
+    mCryptoUpdateTransactionBody->set_allocated_autorenewperiod(
+      internal::DurationConverter::toProtobuf(mAutoRenewPeriod));
+    mCryptoUpdateTransactionBody->set_allocated_expirationtime(
+      internal::TimestampConverter::toProtobuf(mExpirationTime));
+    mCryptoUpdateTransactionBody->set_staked_node_id(static_cast<int64_t>(mNodeId));
+
+    auto boolValue = std::make_unique<google::protobuf::BoolValue>();
+    boolValue->set_value(mReceiverSignatureRequired);
+    mCryptoUpdateTransactionBody->set_allocated_receiversigrequiredwrapper(boolValue.release());
+
+    auto strValue = std::make_unique<google::protobuf::StringValue>();
+    strValue->set_value(mAccountMemo);
+    mCryptoUpdateTransactionBody->set_allocated_memo(strValue.release());
+
+    auto uInt32Value = std::make_unique<google::protobuf::Int32Value>();
+    uInt32Value->set_value(static_cast<int32_t>(mMaxTokenAssociations));
+    mCryptoUpdateTransactionBody->set_allocated_max_automatic_token_associations(uInt32Value.release());
+
+    boolValue = std::make_unique<google::protobuf::BoolValue>();
+    boolValue->set_value(mDeclineStakingReward);
+    mCryptoUpdateTransactionBody->set_allocated_decline_reward(boolValue.release());
+
+    // Initialize the CryptoDelete unique_ptr
+    mCryptoDeleteTransactionBody->set_allocated_deleteaccountid(getTestAccountId().toProtobuf().release());
+    mCryptoDeleteTransactionBody->set_allocated_transferaccountid(getTestAccountId().toProtobuf().release());
   }
 
   [[nodiscard]] inline const std::unique_ptr<proto::CryptoCreateTransactionBody>& getTestCryptoCreateTransactionBody()
@@ -90,6 +120,16 @@ protected:
   getTestCryptoTransferTransactionBody() const
   {
     return mCryptoTransferTransactionBody;
+  }
+  [[nodiscard]] inline const std::unique_ptr<proto::CryptoUpdateTransactionBody>& getTestCryptoUpdateTransactionBody()
+    const
+  {
+    return mCryptoUpdateTransactionBody;
+  }
+  [[nodiscard]] inline const std::unique_ptr<proto::CryptoDeleteTransactionBody>& getTestCryptoDeleteTransactionBody()
+    const
+  {
+    return mCryptoDeleteTransactionBody;
   }
   [[nodiscard]] inline const std::shared_ptr<PublicKey>& getTestPublicKey() const { return mPublicKey; }
   [[nodiscard]] inline const Hbar& getTestInitialBalance() const { return mInitialBalance; }
@@ -106,12 +146,20 @@ protected:
   [[nodiscard]] inline const Hbar& getTestAmount() const { return mAmount; }
   [[nodiscard]] inline uint32_t getTestExpectedDecimals() const { return mExpectedDecimals; }
   [[nodiscard]] inline bool getTestApproval() const { return mApproval; }
+  [[nodiscard]] inline const std::chrono::system_clock::time_point& getTestExpirationTime() const
+  {
+    return mExpirationTime;
+  }
 
 private:
   std::unique_ptr<proto::CryptoCreateTransactionBody> mCryptoCreateTransactionBody =
     std::make_unique<proto::CryptoCreateTransactionBody>();
   std::unique_ptr<proto::CryptoTransferTransactionBody> mCryptoTransferTransactionBody =
     std::make_unique<proto::CryptoTransferTransactionBody>();
+  std::unique_ptr<proto::CryptoUpdateTransactionBody> mCryptoUpdateTransactionBody =
+    std::make_unique<proto::CryptoUpdateTransactionBody>();
+  std::unique_ptr<proto::CryptoDeleteTransactionBody> mCryptoDeleteTransactionBody =
+    std::make_unique<proto::CryptoDeleteTransactionBody>();
 
   const std::shared_ptr<PublicKey> mPublicKey = ECDSAsecp256k1PrivateKey::generatePrivateKey()->getPublicKey();
   const Hbar mInitialBalance = Hbar(1LL);
@@ -128,6 +176,7 @@ private:
   const Hbar mAmount = Hbar(8ULL);
   const uint32_t mExpectedDecimals = 9U;
   const bool mApproval = true;
+  const std::chrono::system_clock::time_point mExpirationTime = std::chrono::system_clock::now();
 };
 
 //-----
@@ -147,7 +196,7 @@ TEST_F(TransactionTest, AccountCreateTransactionFromTransactionBodyBytes)
   // Then
   ASSERT_EQ(index, 0);
 
-  AccountCreateTransaction accountCreateTransaction = std::get<0>(txVariant);
+  const AccountCreateTransaction accountCreateTransaction = std::get<0>(txVariant);
   EXPECT_EQ(accountCreateTransaction.getKey()->toStringDer(), getTestPublicKey()->toStringDer());
   EXPECT_EQ(accountCreateTransaction.getInitialBalance(), getTestInitialBalance());
   EXPECT_EQ(accountCreateTransaction.getReceiverSignatureRequired(), getTestReceiverSignatureRequired());
@@ -184,7 +233,7 @@ TEST_F(TransactionTest, AccountCreateTransactionFromSignedTransactionBytes)
   // Then
   ASSERT_EQ(index, 0);
 
-  AccountCreateTransaction accountCreateTransaction = std::get<0>(txVariant);
+  const AccountCreateTransaction accountCreateTransaction = std::get<0>(txVariant);
   EXPECT_EQ(accountCreateTransaction.getKey()->toStringDer(), getTestPublicKey()->toStringDer());
   EXPECT_EQ(accountCreateTransaction.getInitialBalance(), getTestInitialBalance());
   EXPECT_EQ(accountCreateTransaction.getReceiverSignatureRequired(), getTestReceiverSignatureRequired());
@@ -224,7 +273,7 @@ TEST_F(TransactionTest, AccountCreateTransactionFromTransactionBytes)
   // Then
   ASSERT_EQ(index, 0);
 
-  AccountCreateTransaction accountCreateTransaction = std::get<0>(txVariant);
+  const AccountCreateTransaction accountCreateTransaction = std::get<0>(txVariant);
   EXPECT_EQ(accountCreateTransaction.getKey()->toStringDer(), getTestPublicKey()->toStringDer());
   EXPECT_EQ(accountCreateTransaction.getInitialBalance(), getTestInitialBalance());
   EXPECT_EQ(accountCreateTransaction.getReceiverSignatureRequired(), getTestReceiverSignatureRequired());
@@ -257,7 +306,7 @@ TEST_F(TransactionTest, TransferTransactionFromTransactionBodyBytes)
   // Then
   ASSERT_EQ(index, 1);
 
-  TransferTransaction transferTransaction = std::get<1>(txVariant);
+  const TransferTransaction transferTransaction = std::get<1>(txVariant);
   const std::unordered_map<AccountId, Hbar> hbarTransfers = transferTransaction.getHbarTransfers();
   const std::unordered_map<TokenId, std::unordered_map<AccountId, int64_t>> tokenTransfers =
     transferTransaction.getTokenTransfers();
@@ -303,7 +352,7 @@ TEST_F(TransactionTest, TransferTransactionFromSignedTransactionBytes)
   // Then
   ASSERT_EQ(index, 1);
 
-  TransferTransaction transferTransaction = std::get<1>(txVariant);
+  const TransferTransaction transferTransaction = std::get<1>(txVariant);
   const std::unordered_map<AccountId, Hbar> hbarTransfers = transferTransaction.getHbarTransfers();
   const std::unordered_map<TokenId, std::unordered_map<AccountId, int64_t>> tokenTransfers =
     transferTransaction.getTokenTransfers();
@@ -352,7 +401,7 @@ TEST_F(TransactionTest, TransferTransactionFromTransactionBytes)
   // Then
   ASSERT_EQ(index, 1);
 
-  TransferTransaction transferTransaction = std::get<1>(txVariant);
+  const TransferTransaction transferTransaction = std::get<1>(txVariant);
   const std::unordered_map<AccountId, Hbar> hbarTransfers = transferTransaction.getHbarTransfers();
   const std::unordered_map<TokenId, std::unordered_map<AccountId, int64_t>> tokenTransfers =
     transferTransaction.getTokenTransfers();
@@ -375,4 +424,185 @@ TEST_F(TransactionTest, TransferTransactionFromTransactionBytes)
   EXPECT_EQ(nftTransfers.cbegin()->second.cbegin()->getSenderAccountId(), getTestAccountId());
   EXPECT_EQ(nftTransfers.cbegin()->second.cbegin()->getReceiverAccountId(), getTestAccountId());
   EXPECT_EQ(nftTransfers.cbegin()->second.cbegin()->getApproval(), getTestApproval());
+}
+
+//-----
+TEST_F(TransactionTest, AccountUpdateTransactionFromTransactionBodyByte)
+{
+  // Given
+  proto::TransactionBody txBody;
+  txBody.set_allocated_cryptoupdateaccount(
+    std::make_unique<proto::CryptoUpdateTransactionBody>(*getTestCryptoUpdateTransactionBody()).release());
+
+  const std::string serialized = txBody.SerializeAsString();
+
+  // When
+  const auto [index, txVariant] =
+    Transaction<AccountUpdateTransaction>::fromBytes(internal::Utilities::stringToByteVector(serialized));
+
+  // Then
+  ASSERT_EQ(index, 2);
+
+  const AccountUpdateTransaction accountUpdateTransaction = std::get<2>(txVariant);
+  EXPECT_EQ(accountUpdateTransaction.getAccountId(), getTestAccountId());
+  EXPECT_EQ(accountUpdateTransaction.getKey()->toStringDer(), getTestPublicKey()->toStringDer());
+  EXPECT_EQ(accountUpdateTransaction.getReceiverSignatureRequired(), getTestReceiverSignatureRequired());
+  EXPECT_EQ(accountUpdateTransaction.getAutoRenewPeriod(), getTestAutoRenewPeriod());
+  EXPECT_EQ(accountUpdateTransaction.getExpirationTime(), getTestExpirationTime());
+  EXPECT_EQ(accountUpdateTransaction.getAccountMemo(), getTestAccountMemo());
+  EXPECT_EQ(accountUpdateTransaction.getMaxAutomaticTokenAssociations(), getTestMaximumTokenAssociations());
+  EXPECT_FALSE(accountUpdateTransaction.getStakedAccountId().has_value());
+  ASSERT_TRUE(accountUpdateTransaction.getStakedNodeId().has_value());
+  EXPECT_EQ(*accountUpdateTransaction.getStakedNodeId(), getTestNodeId());
+  EXPECT_EQ(accountUpdateTransaction.getDeclineStakingReward(), getTestDeclineStakingReward());
+}
+
+//-----
+TEST_F(TransactionTest, AccountUpdateTransactionFromSignedTransactionBytes)
+{
+  // Given
+  proto::TransactionBody txBody;
+  txBody.set_allocated_cryptoupdateaccount(
+    std::make_unique<proto::CryptoUpdateTransactionBody>(*getTestCryptoUpdateTransactionBody()).release());
+
+  proto::SignedTransaction signedTx;
+  signedTx.set_allocated_bodybytes(new std::string(txBody.SerializeAsString()));
+  // SignatureMap not required
+
+  const std::string serialized = signedTx.SerializeAsString();
+
+  // When
+  const auto [index, txVariant] =
+    Transaction<AccountUpdateTransaction>::fromBytes(internal::Utilities::stringToByteVector(serialized));
+
+  // Then
+  ASSERT_EQ(index, 2);
+
+  const AccountUpdateTransaction accountUpdateTransaction = std::get<2>(txVariant);
+  EXPECT_EQ(accountUpdateTransaction.getAccountId(), getTestAccountId());
+  EXPECT_EQ(accountUpdateTransaction.getKey()->toStringDer(), getTestPublicKey()->toStringDer());
+  EXPECT_EQ(accountUpdateTransaction.getReceiverSignatureRequired(), getTestReceiverSignatureRequired());
+  EXPECT_EQ(accountUpdateTransaction.getAutoRenewPeriod(), getTestAutoRenewPeriod());
+  EXPECT_EQ(accountUpdateTransaction.getExpirationTime(), getTestExpirationTime());
+  EXPECT_EQ(accountUpdateTransaction.getAccountMemo(), getTestAccountMemo());
+  EXPECT_EQ(accountUpdateTransaction.getMaxAutomaticTokenAssociations(), getTestMaximumTokenAssociations());
+  EXPECT_FALSE(accountUpdateTransaction.getStakedAccountId().has_value());
+  ASSERT_TRUE(accountUpdateTransaction.getStakedNodeId().has_value());
+  EXPECT_EQ(*accountUpdateTransaction.getStakedNodeId(), getTestNodeId());
+  EXPECT_EQ(accountUpdateTransaction.getDeclineStakingReward(), getTestDeclineStakingReward());
+}
+
+//-----
+TEST_F(TransactionTest, AccountUpdateTransactionFromTransactionBytes)
+{
+  // Given
+  proto::TransactionBody txBody;
+  txBody.set_allocated_cryptoupdateaccount(
+    std::make_unique<proto::CryptoUpdateTransactionBody>(*getTestCryptoUpdateTransactionBody()).release());
+
+  proto::SignedTransaction signedTx;
+  signedTx.set_allocated_bodybytes(new std::string(txBody.SerializeAsString()));
+  // SignatureMap not required
+
+  proto::Transaction tx;
+  tx.set_allocated_signedtransactionbytes(new std::string(signedTx.SerializeAsString()));
+
+  const std::string serialized = tx.SerializeAsString();
+
+  // When
+  const auto [index, txVariant] =
+    Transaction<AccountUpdateTransaction>::fromBytes(internal::Utilities::stringToByteVector(serialized));
+
+  // Then
+  ASSERT_EQ(index, 2);
+
+  const AccountUpdateTransaction accountUpdateTransaction = std::get<2>(txVariant);
+  EXPECT_EQ(accountUpdateTransaction.getAccountId(), getTestAccountId());
+  EXPECT_EQ(accountUpdateTransaction.getKey()->toStringDer(), getTestPublicKey()->toStringDer());
+  EXPECT_EQ(accountUpdateTransaction.getReceiverSignatureRequired(), getTestReceiverSignatureRequired());
+  EXPECT_EQ(accountUpdateTransaction.getAutoRenewPeriod(), getTestAutoRenewPeriod());
+  EXPECT_EQ(accountUpdateTransaction.getExpirationTime(), getTestExpirationTime());
+  EXPECT_EQ(accountUpdateTransaction.getAccountMemo(), getTestAccountMemo());
+  EXPECT_EQ(accountUpdateTransaction.getMaxAutomaticTokenAssociations(), getTestMaximumTokenAssociations());
+  EXPECT_FALSE(accountUpdateTransaction.getStakedAccountId().has_value());
+  ASSERT_TRUE(accountUpdateTransaction.getStakedNodeId().has_value());
+  EXPECT_EQ(*accountUpdateTransaction.getStakedNodeId(), getTestNodeId());
+  EXPECT_EQ(accountUpdateTransaction.getDeclineStakingReward(), getTestDeclineStakingReward());
+}
+
+//-----
+TEST_F(TransactionTest, AccountDeleteTransactionFromTransactionBodyBytes)
+{
+  // Given
+  proto::TransactionBody txBody;
+  txBody.set_allocated_cryptodelete(
+    std::make_unique<proto::CryptoDeleteTransactionBody>(*getTestCryptoDeleteTransactionBody()).release());
+
+  const std::string serialized = txBody.SerializeAsString();
+
+  // When
+  const auto [index, txVariant] =
+    Transaction<AccountDeleteTransaction>::fromBytes(internal::Utilities::stringToByteVector(serialized));
+
+  // Then
+  ASSERT_EQ(index, 3);
+
+  const AccountDeleteTransaction accountDeleteTransaction = std::get<3>(txVariant);
+  EXPECT_EQ(accountDeleteTransaction.getDeleteAccountId(), getTestAccountId());
+  EXPECT_EQ(accountDeleteTransaction.getTransferAccountId(), getTestAccountId());
+}
+
+//-----
+TEST_F(TransactionTest, AccountDeleteTransactionFromSignedTransactionBytes)
+{
+  // Given
+  proto::TransactionBody txBody;
+  txBody.set_allocated_cryptodelete(
+    std::make_unique<proto::CryptoDeleteTransactionBody>(*getTestCryptoDeleteTransactionBody()).release());
+
+  proto::SignedTransaction signedTx;
+  signedTx.set_allocated_bodybytes(new std::string(txBody.SerializeAsString()));
+  // SignatureMap not required
+
+  const std::string serialized = signedTx.SerializeAsString();
+
+  // When
+  const auto [index, txVariant] =
+    Transaction<AccountDeleteTransaction>::fromBytes(internal::Utilities::stringToByteVector(serialized));
+
+  // Then
+  ASSERT_EQ(index, 3);
+
+  const AccountDeleteTransaction accountDeleteTransaction = std::get<3>(txVariant);
+  EXPECT_EQ(accountDeleteTransaction.getDeleteAccountId(), getTestAccountId());
+  EXPECT_EQ(accountDeleteTransaction.getTransferAccountId(), getTestAccountId());
+}
+
+//-----
+TEST_F(TransactionTest, AccountDeleteTransactionFromTransactionBytes)
+{
+  // Given
+  proto::TransactionBody txBody;
+  txBody.set_allocated_cryptodelete(
+    std::make_unique<proto::CryptoDeleteTransactionBody>(*getTestCryptoDeleteTransactionBody()).release());
+
+  proto::SignedTransaction signedTx;
+  signedTx.set_allocated_bodybytes(new std::string(txBody.SerializeAsString()));
+  // SignatureMap not required
+
+  proto::Transaction tx;
+  tx.set_allocated_signedtransactionbytes(new std::string(signedTx.SerializeAsString()));
+
+  const std::string serialized = tx.SerializeAsString();
+
+  // When
+  const auto [index, txVariant] =
+    Transaction<AccountDeleteTransaction>::fromBytes(internal::Utilities::stringToByteVector(serialized));
+
+  // Then
+  ASSERT_EQ(index, 3);
+
+  const AccountDeleteTransaction accountDeleteTransaction = std::get<3>(txVariant);
+  EXPECT_EQ(accountDeleteTransaction.getDeleteAccountId(), getTestAccountId());
+  EXPECT_EQ(accountDeleteTransaction.getTransferAccountId(), getTestAccountId());
 }


### PR DESCRIPTION
**Description**:
This PR adds missed tests for `AccountUpdateTransaction` and `AccountDeleteTransaction`.

**Related issue(s)**:

Fixes #235 

**Checklist**

- [x] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
