### PR TITLE
Implement `AccountRecordsQuery`

### DIFF
--- a/sdk/main/CMakeLists.txt
+++ b/sdk/main/CMakeLists.txt
@@ -13,7 +13,8 @@ add_library(${PROJECT_NAME} STATIC
         src/AccountId.cc
         #    src/AccountInfo.cc
         #    src/AccountInfoQuery.cc
-        #    src/AccountRecordsQuery.cc
+        src/AccountRecords.cc
+        src/AccountRecordsQuery.cc
         #    src/AccountStakersQuery.cc
         src/AccountUpdateTransaction.cc
         src/Client.cc

--- a/sdk/main/include/AccountBalance.h
+++ b/sdk/main/include/AccountBalance.h
@@ -30,7 +30,7 @@ class CryptoGetAccountBalanceResponse;
 namespace Hedera
 {
 /**
- * Response when the client sends a node an AccountBalanceQuery.
+ * Response from a Hedera network when the client sends an AccountBalanceQuery.
  */
 class AccountBalance
 {
@@ -41,7 +41,7 @@ public:
    * @param proto The CryptoGetAccountBalance protobuf object from which to construct an AccountBalance object.
    * @return The constructed AccountBalance object.
    */
-  static AccountBalance fromProtobuf(const proto::CryptoGetAccountBalanceResponse& proto);
+  [[nodiscard]] static AccountBalance fromProtobuf(const proto::CryptoGetAccountBalanceResponse& proto);
 
   /**
    * Get the balance of the queried account or contract.

--- a/sdk/main/include/AccountRecords.h
+++ b/sdk/main/include/AccountRecords.h
@@ -1,0 +1,77 @@
+/*-
+ *
+ * Hedera C++ SDK
+ *
+ * Copyright (C) 2020 - 2022 Hedera Hashgraph, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+#ifndef HEDERA_SDK_CPP_ACCOUNT_RECORDS_H_
+#define HEDERA_SDK_CPP_ACCOUNT_RECORDS_H_
+
+#include "AccountId.h"
+#include "TransactionRecord.h"
+
+#include <vector>
+
+namespace proto
+{
+class CryptoGetAccountRecordsResponse;
+}
+
+namespace Hedera
+{
+/**
+ * Response from a Hedera network when the client sends an AccountRecordsQuery.
+ */
+class AccountRecords
+{
+public:
+  /**
+   * Construct an AccountRecords object from a CryptoGetAccountRecordsResponse protobuf object.
+   *
+   * @param proto The CryptoGetAccountRecordsResponse protobuf object from which to construct an AccountRecords object.
+   * @return The constructed AccountRecords object.
+   */
+  [[nodiscard]] static AccountRecords fromProtobuf(const proto::CryptoGetAccountRecordsResponse& proto);
+
+  /**
+   * Get the ID of the queried account.
+   *
+   * @return The ID of the queried account.
+   */
+  [[nodiscard]] inline AccountId getAccountId() const { return mAccountId; }
+
+  /**
+   * Get the TransactionRecords of the queried account.
+   *
+   * @return The TransactionRecords of the queried account.
+   */
+  [[nodiscard]] inline std::vector<TransactionRecord> getRecords() const { return mRecords; }
+
+private:
+  /**
+   * The ID of the queried account.
+   */
+  AccountId mAccountId;
+
+  /**
+   * The list of TransactionRecords for the queried account.
+   */
+  std::vector<TransactionRecord> mRecords;
+};
+
+} // namespace Hedera
+
+#endif // HEDERA_SDK_CPP_ACCOUNT_RECORDS_H_

--- a/sdk/main/include/AccountRecordsQuery.h
+++ b/sdk/main/include/AccountRecordsQuery.h
@@ -4,7 +4,7 @@
  *
  * Copyright (C) 2020 - 2022 Hedera Hashgraph, LLC
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
+ * Licensed under the Apache License, Version 2.0 (the "License")
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
@@ -17,111 +17,93 @@
  * limitations under the License.
  *
  */
-#ifndef ACCOUNT_RECORDS_QUERY_H_
-#define ACCOUNT_RECORDS_QUERY_H_
+#ifndef HEDERA_SDK_CPP_ACCOUNT_RECORDS_QUERY_H_
+#define HEDERA_SDK_CPP_ACCOUNT_RECORDS_QUERY_H_
 
 #include "AccountId.h"
 #include "Query.h"
 
-#include "helper/InitType.h"
-
 #include <vector>
-
-namespace proto
-{
-class Query;
-class QueryHeader;
-class Response;
-class ResponseHeader;
-}
 
 namespace Hedera
 {
-class Client;
+class AccountRecords;
 class TransactionRecord;
 }
 
 namespace Hedera
 {
 /**
- * Get all the records for an account for any transfers into it and out of it,
- * that were above the threshold, during the last 25 hours.
+ * Get all the records for an account for any transfers into it and out of it, that were above the threshold, during the
+ * last 25 hours.
  */
-class AccountRecordsQuery : public Query<std::vector<TransactionRecord>, AccountRecordsQuery>
+class AccountRecordsQuery : public Query<AccountRecordsQuery, AccountRecords>
 {
 public:
   /**
-   * Constructor
-   */
-  AccountRecordsQuery();
-
-  /**
-   * Derived from Query. Validate the checksums of the account ID.
+   * Set the ID of the account of which to request the records.
    *
-   * @param client  The client with which to validate the checksums
-   */
-  virtual void validateChecksums(const Client& client) const override;
-
-  /**
-   * Derived from Query. Fills query with this class's data and attaches the
-   * header.
-   *
-   * @param query  The query object to fill out.
-   * @param header The header for the query.
-   */
-  virtual void onMakeRequest(proto::Query* query, proto::QueryHeader* header) const override;
-
-  /**
-   * Derived from Query. Get the account records header from the response.
-   *
-   * @param response The associated response to this query.
-   * @return         The response header for the derived class's query.
-   */
-  virtual proto::ResponseHeader mapResponseHeader(proto::Response* response) const override;
-
-  /**
-   * Derived from Query. Grab the account records query header.
-   *
-   * @param query  The query of which to extract the header.
-   * @return       The account records query header.
-   */
-  virtual proto::QueryHeader mapRequestHeader(const proto::Query& query) const override;
-
-  /**
-   * Derived from Query. Extract the account records data from the response
-   * object.
-   *
-   * @param response  The received response from Hedera.
-   * @param accountId The account ID that made the request.
-   * @param query     The original query.
-   * @return          The account records data.
-   */
-  virtual std::vector<TransactionRecord> mapResponse(const proto::Response& response,
-                                                     const AccountId& accountId,
-                                                     const proto::Query& query) const override;
-
-  /**
-   * Sets the account ID for which information is requested.
-   *
-   * @param accountId The AccountId to be set
-   * @return          The account records query.
+   * @param accountId The ID of the desired account of which to request the records.
+   * @return A reference to this AccountRecordsQuery object with the newly-set account ID.
    */
   AccountRecordsQuery& setAccountId(const AccountId& accountId);
 
   /**
-   * Extract the account id.
+   * Get the ID of the account of which this query is currently configured to get the records.
    *
-   * @return The account id.
+   * @return The ID of the account for which this query is meant.
    */
-  inline InitType<AccountId> getAccountId() { return mAccountId; }
+  [[nodiscard]] inline AccountId getAccountId() const { return mAccountId; }
 
 private:
   /**
-   * The account ID of the account of which to get the account information.
+   * Derived from Executable. Construct a Query protobuf object from this AccountRecordsQuery object.
+   *
+   * @param client The Client trying to construct this AccountRecordsQuery.
+   * @param node   The Node to which this AccountRecordsQuery will be sent.
+   * @return A Query protobuf object filled with this AccountRecordsQuery object's data.
    */
-  InitType<AccountId> mAccountId;
+  [[nodiscard]] proto::Query makeRequest(const Client& client,
+                                         const std::shared_ptr<internal::Node>& node) const override;
+
+  /**
+   * Derived from Executable. Construct an AccountRecords object from a Response protobuf object.
+   *
+   * @param response The Response protobuf object from which to construct an AccountRecords object.
+   * @return An AccountRecords object filled with the Response protobuf object's data.
+   */
+  [[nodiscard]] AccountRecords mapResponse(const proto::Response& response) const override;
+
+  /**
+   * Derived from Executable. Get the status response code for a submitted AccountRecordsQuery from a Response protobuf
+   * object.
+   *
+   * @param response The Response protobuf object from which to grab the AccountRecordsQuery status response code.
+   * @return The AccountRecordsQuery status response code of the input Response protobuf object.
+   */
+  [[nodiscard]] Status mapResponseStatus(const proto::Response& response) const override;
+
+  /**
+   * Derived from Executable. Submit this AccountRecordsQuery to a Node.
+   *
+   * @param client   The Client submitting this AccountRecordsQuery.
+   * @param deadline The deadline for submitting this AccountRecordsQuery.
+   * @param node     Pointer to the Node to which this AccountRecordsQuery should be submitted.
+   * @param response Pointer to the Response protobuf object that gRPC should populate with the response information
+   *                 from the gRPC server.
+   * @return The gRPC status of the submission.
+   */
+  [[nodiscard]] grpc::Status submitRequest(const Client& client,
+                                           const std::chrono::system_clock::time_point& deadline,
+                                           const std::shared_ptr<internal::Node>& node,
+                                           proto::Response* response) const override;
+
+  /**
+   * The ID of the account of which this query should get the records.
+   */
+  AccountId mAccountId;
 };
 
 } // namespace Hedera
 
-#endif // ACCOUNT_RECORDS_QUERY_H_
+#endif // HEDERA_SDK_CPP_ACCOUNT_RECORDS_QUERY_H_

--- a/sdk/main/include/Query.h
+++ b/sdk/main/include/Query.h
@@ -26,6 +26,8 @@ namespace Hedera
 {
 class AccountBalance;
 class AccountBalanceQuery;
+class AccountRecords;
+class AccountRecordsQuery;
 class AccountId;
 class TransactionReceipt;
 class TransactionReceiptQuery;
@@ -75,6 +77,7 @@ protected:
  * Explicit template instantiations.
  */
 template class Query<AccountBalanceQuery, AccountBalance>;
+template class Query<AccountRecordsQuery, AccountRecords>;
 template class Query<TransactionReceiptQuery, TransactionReceipt>;
 template class Query<TransactionRecordQuery, TransactionRecord>;
 

--- a/sdk/main/include/TransferTransaction.h
+++ b/sdk/main/include/TransferTransaction.h
@@ -196,6 +196,7 @@ private:
   /**
    * Allow queries that are not free to create Transaction protobuf objects from TransferTransactions.
    */
+  friend class AccountRecordsQuery;
   friend class TransactionRecordQuery;
 
   /**

--- a/sdk/main/src/AccountRecords.cc
+++ b/sdk/main/src/AccountRecords.cc
@@ -1,0 +1,41 @@
+/*-
+ *
+ * Hedera C++ SDK
+ *
+ * Copyright (C) 2020 - 2022 Hedera Hashgraph, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+#include "AccountRecords.h"
+#include "TransactionRecord.h"
+
+#include <proto/crypto_get_account_records.pb.h>
+
+namespace Hedera
+{
+//-----
+AccountRecords AccountRecords::fromProtobuf(const proto::CryptoGetAccountRecordsResponse& proto)
+{
+  AccountRecords records;
+  records.mAccountId = AccountId::fromProtobuf(proto.accountid());
+
+  for (int i = 0; i < proto.records_size(); ++i)
+  {
+    records.mRecords.push_back(TransactionRecord::fromProtobuf(proto.records(i)));
+  }
+
+  return records;
+}
+
+} // namespace Hedera

--- a/sdk/main/src/Executable.cc
+++ b/sdk/main/src/Executable.cc
@@ -22,6 +22,8 @@
 #include "AccountBalanceQuery.h"
 #include "AccountCreateTransaction.h"
 #include "AccountDeleteTransaction.h"
+#include "AccountRecords.h"
+#include "AccountRecordsQuery.h"
 #include "AccountUpdateTransaction.h"
 #include "Client.h"
 #include "TransactionReceipt.h"
@@ -280,6 +282,7 @@ template class Executable<AccountDeleteTransaction,
                           proto::Transaction,
                           proto::TransactionResponse,
                           TransactionResponse>;
+template class Executable<AccountRecordsQuery, proto::Query, proto::Response, AccountRecords>;
 template class Executable<AccountUpdateTransaction,
                           proto::Transaction,
                           proto::TransactionResponse,

--- a/sdk/tests/AccountBalanceQueryTest.cc
+++ b/sdk/tests/AccountBalanceQueryTest.cc
@@ -19,6 +19,7 @@
  */
 #include "AccountBalanceQuery.h"
 #include "AccountId.h"
+#include "ContractId.h"
 
 #include <gtest/gtest.h>
 
@@ -35,38 +36,55 @@ private:
   const ContractId mTestContractId = ContractId(3ULL);
 };
 
+//-----
 TEST_F(AccountBalanceQueryTest, ConstructAccountBalanceQuery)
 {
+  // Given \ When
   AccountBalanceQuery query;
+
+  // Then
   EXPECT_FALSE(query.getAccountId());
   EXPECT_FALSE(query.getContractId());
 }
 
+//-----
 TEST_F(AccountBalanceQueryTest, SetAccountId)
 {
+  // Given
   AccountBalanceQuery query;
+
+  // When
   query.setAccountId(getTestAccountId());
 
+  // Then
   EXPECT_EQ(*query.getAccountId(), getTestAccountId());
 }
 
+//-----
 TEST_F(AccountBalanceQueryTest, SetContractId)
 {
+  // Given
   AccountBalanceQuery query;
+
+  // When
   query.setContractId(getTestContractId());
 
+  // Then
   EXPECT_EQ(*query.getContractId(), getTestContractId());
 }
 
+//-----
 TEST_F(AccountBalanceQueryTest, ResetMutuallyExclusiveIds)
 {
+  // Given
   AccountBalanceQuery query;
   query.setAccountId(getTestAccountId());
   query.setContractId(getTestContractId());
-
   EXPECT_FALSE(query.getAccountId());
 
+  // When
   query.setAccountId(getTestAccountId());
 
+  // Then
   EXPECT_FALSE(query.getContractId());
 }

--- a/sdk/tests/AccountRecordsQueryTest.cc
+++ b/sdk/tests/AccountRecordsQueryTest.cc
@@ -17,32 +17,40 @@
  * limitations under the License.
  *
  */
-#include "AccountBalance.h"
+#include "AccountRecordsQuery.h"
 
 #include <gtest/gtest.h>
-#include <proto/crypto_get_account_balance.pb.h>
 
 using namespace Hedera;
 
-class AccountBalanceTest : public ::testing::Test
+class AccountRecordsQueryTest : public ::testing::Test
 {
 protected:
-  [[nodiscard]] inline const Hbar& getTestBalance() const { return mBalance; }
+  [[nodiscard]] inline const AccountId& getTestAccountId() const { return mTestAccountId; }
 
 private:
-  const Hbar mBalance = Hbar(100LL);
+  const AccountId mTestAccountId = AccountId(1ULL);
 };
 
 //-----
-TEST_F(AccountBalanceTest, DeserializeAccountBalanceFromProtobuf)
+TEST_F(AccountRecordsQueryTest, ConstructAccountRecordsQuery)
 {
-  // Given
-  proto::CryptoGetAccountBalanceResponse testProtoAccountBalance;
-  testProtoAccountBalance.set_balance(static_cast<unsigned long long>(getTestBalance().toTinybars()));
-
-  // When
-  const AccountBalance accountBalance = AccountBalance::fromProtobuf(testProtoAccountBalance);
+  // Given / When
+  AccountRecordsQuery query;
 
   // Then
-  EXPECT_EQ(accountBalance.getBalance().toTinybars(), getTestBalance().toTinybars());
+  EXPECT_EQ(query.getAccountId(), AccountId());
+}
+
+//-----
+TEST_F(AccountRecordsQueryTest, SetAccountId)
+{
+  // Given
+  AccountRecordsQuery query;
+
+  // When
+  query.setAccountId(getTestAccountId());
+
+  // Then
+  EXPECT_EQ(query.getAccountId(), getTestAccountId());
 }

--- a/sdk/tests/AccountRecordsTest.cc
+++ b/sdk/tests/AccountRecordsTest.cc
@@ -1,0 +1,52 @@
+/*-
+ *
+ * Hedera C++ SDK
+ *
+ * Copyright (C) 2020 - 2022 Hedera Hashgraph, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+#include "AccountRecords.h"
+
+#include <gtest/gtest.h>
+#include <proto/crypto_get_account_records.pb.h>
+
+using namespace Hedera;
+
+class AccountRecordsTest : public ::testing::Test
+{
+protected:
+  [[nodiscard]] inline const AccountId& getTestAccountId() const { return mTestAccountId; }
+
+private:
+  const AccountId mTestAccountId = AccountId(3ULL);
+};
+
+//-----
+TEST_F(AccountRecordsTest, DeserializeAccountRecordsFromProtobuf)
+{
+  // Given
+  proto::CryptoGetAccountRecordsResponse accountRecordsResponse;
+  accountRecordsResponse.set_allocated_accountid(getTestAccountId().toProtobuf().release());
+  accountRecordsResponse.add_records();
+  accountRecordsResponse.add_records();
+
+  // When
+  const AccountRecords accountRecords = AccountRecords::fromProtobuf(accountRecordsResponse);
+
+  // Then
+  EXPECT_EQ(accountRecords.getAccountId(), getTestAccountId());
+  // Don't bother testing records data as that's already tested in TransactionRecordTest
+  EXPECT_EQ(accountRecords.getRecords().size(), 2);
+}

--- a/sdk/tests/CMakeLists.txt
+++ b/sdk/tests/CMakeLists.txt
@@ -19,6 +19,8 @@ add_executable(${TEST_PROJECT_NAME}
         AccountCreateTransactionTest.cc
         AccountDeleteTransactionTest.cc
         AccountIdTest.cc
+        AccountRecordsQueryTest.cc
+        AccountRecordsTest.cc
         AccountUpdateTransactionTest.cc
         ClientTest.cc
         ContractIdTest.cc


### PR DESCRIPTION
**Description**:
This PR implements the functionality for CryptoGetAccountRecords (i.e. `AccountRecordsQuery`). It also conforms some functionality for `AccountBalance` and `AccountBalanceQuery`, as the `AccountRecords` and `AccountRecordsQuery` was largely based off of those objects.

**Related issue(s)**:

Fixes #239 

**Notes for reviewer**:
This was tested with the added unit tests and connected with the network with a separately-made executable, however no example was added as the Java SDK (which this SDK is being modeled after) contains no `AccountRecordsQuery` example.

**Checklist**

- [x] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
