### PR TITLE
Implement `ContractByteCodeQuery`

### DIFF
--- a/sdk/main/CMakeLists.txt
+++ b/sdk/main/CMakeLists.txt
@@ -19,7 +19,7 @@ add_library(${PROJECT_NAME} STATIC
         src/AccountUpdateTransaction.cc
         src/Client.cc
         src/ContractId.cc
-        #    src/ContractByteCodeQuery.cc
+        src/ContractByteCodeQuery.cc
         #    src/ContractCallQuery.cc
         #    src/ContractCreateTransaction.cc
         #    src/ContractDeleteTransaction.cc

--- a/sdk/main/include/ContractByteCodeQuery.h
+++ b/sdk/main/include/ContractByteCodeQuery.h
@@ -4,7 +4,7 @@
  *
  * Copyright (C) 2020 - 2022 Hedera Hashgraph, LLC
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
+ * Licensed under the Apache License, Version 2.0 (the "License")
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
@@ -17,111 +17,90 @@
  * limitations under the License.
  *
  */
-#ifndef CONTRACT_BYTE_CODE_QUERY_H_
-#define CONTRACT_BYTE_CODE_QUERY_H_
+#ifndef HEDERA_SDK_CPP_CONTRACT_BYTE_CODE_QUERY_H_
+#define HEDERA_SDK_CPP_CONTRACT_BYTE_CODE_QUERY_H_
 
 #include "ContractId.h"
 #include "Query.h"
 
-#include "helper/InitType.h"
-
-#include <string>
-
-namespace Hedera
-{
-class Client;
-}
-
-namespace proto
-{
-class Query;
-class QueryHeader;
-class Response;
-class ResponseHeader;
-}
+#include <cstddef>
+#include <vector>
 
 namespace Hedera
 {
 /**
- * Get the bytecode for a smart contract instance.
+ * A query that returns the bytecode for a smart contract instance. Anyone can request the byte code of a smart contract
+ * instance on the network. Queries do not change the state of the smart contract or require network consensus. The
+ * information is returned from a single node processing the query.
  */
-class ContractByteCodeQuery : public Query<std::string, ContractByteCodeQuery>
+using ContractByteCode = std::vector<std::byte>;
+class ContractByteCodeQuery : public Query<ContractByteCodeQuery, ContractByteCode>
 {
 public:
   /**
-   * Constructor.
-   */
-  ContractByteCodeQuery();
-
-  /**
-   * Derived from Query. Validate the checksums.
+   * Set the ID of the contract of which to request the byte code.
    *
-   * @param client The client with which to validate the checksums.
-   */
-  virtual void validateChecksums(const Client& client) const override;
-
-  /**
-   * Derived from Query. Fills query with this class's data and attaches the
-   * header.
-   *
-   * @param query  The query object to fill out.
-   * @param header The header for the query.
-   */
-  virtual void onMakeRequest(proto::Query* query,
-                             proto::QueryHeader* header) const override;
-
-  /**
-   * Derived from Query. Get the contract byte code header from the response.
-   *
-   * @param response The associated response to this query.
-   * @return         The response header for the contract byte code query.
-   */
-  virtual proto::ResponseHeader mapResponseHeader(
-    proto::Response* response) const override;
-
-  /**
-   * Derived from Query. Grab the contract byte code query header.
-   *
-   * @param query  The query of which to extract the header.
-   * @return       The account info query header.
-   */
-  virtual proto::QueryHeader mapRequestHeader(
-    const proto::Query& query) const override;
-
-  /**
-   * Derived from Query. Extract the contract byte code data from the response
-   * object.
-   *
-   * @param response  The received response from Hedera.
-   * @param accountId The account ID that made the request.
-   * @param query     The original query.
-   * @return          The contract byte code data.
-   */
-  virtual std::string mapResponse(const proto::Response& response,
-                                  const AccountId& accountId,
-                                  const proto::Query& query) const override;
-
-  /**
-   * Sets the contract ID for which information is requested.
-   *
-   * @param contractId The contract ID to be set.
-   * @return           Reference to this ContractByteCodeQuery object.
+   * @param contractId The ID of the contract of which to request the byte code.
+   * @return A reference to this ContractByteCodeQuery object with the newly-set contract ID.
    */
   ContractByteCodeQuery& setContractId(const ContractId& contractId);
 
   /**
-   * Extract the contract ID.
+   * Get the ID of the contract of which this query is currently configured to get the byte code.
    *
-   * @return The contract ID. Can be invalid if not set.
+   * @return The ID of the contract for which this query is meant.
    */
-  inline InitType<ContractId> getContractId() { return mContractId; }
+  [[nodiscard]] inline ContractId getContractId() const { return mContractId; }
 
 private:
   /**
-   * The contract ID of the contract for which information is requested.
+   * Derived from Executable. Construct a Query protobuf object from this ContractByteCodeQuery object.
+   *
+   * @param client The Client trying to construct this ContractByteCodeQuery.
+   * @param node   The Node to which this ContractByteCodeQuery will be sent.
+   * @return A Query protobuf object filled with this ContractByteCodeQuery object's data.
    */
-  InitType<ContractId> mContractId;
+  [[nodiscard]] proto::Query makeRequest(const Client& client,
+                                         const std::shared_ptr<internal::Node>& node) const override;
+
+  /**
+   * Derived from Executable. Construct an ContractByteCode object from a Response protobuf object.
+   *
+   * @param response The Response protobuf object from which to construct an ContractByteCode object.
+   * @return An ContractByteCode object filled with the Response protobuf object's data
+   */
+  [[nodiscard]] ContractByteCode mapResponse(const proto::Response& response) const override;
+
+  /**
+   * Derived from Executable. Get the status response code for a submitted ContractByteCodeQuery from a Response
+   * protobuf object.
+   *
+   * @param response The Response protobuf object from which to grab the ContractByteCodeQuery status response code.
+   * @return The ContractByteCodeQuery status response code of the input Response protobuf object.
+   */
+  [[nodiscard]] Status mapResponseStatus(const proto::Response& response) const override;
+
+  /**
+   * Derived from Executable. Submit this ContractByteCodeQuery to a Node.
+   *
+   * @param client   The Client submitting this ContractByteCodeQuery.
+   * @param deadline The deadline for submitting this ContractByteCodeQuery.
+   * @param node     Pointer to the Node to which this ContractByteCodeQuery should be submitted.
+   * @param response Pointer to the Response protobuf object that gRPC should populate with the response information
+   *                 from the gRPC server.
+   * @return The gRPC status of the submission.
+   */
+  [[nodiscard]] grpc::Status submitRequest(const Client& client,
+                                           const std::chrono::system_clock::time_point& deadline,
+                                           const std::shared_ptr<internal::Node>& node,
+                                           proto::Response* response) const override;
+
+  /**
+   * The ID of the contract of which this query should get the byte code.
+   */
+  ContractId mContractId;
 };
+
 } // namespace Hedera
 
-#endif // CONTRACT_BYTE_CODE_QUERY_H_
+#endif // HEDERA_SDK_CPP_CONTRACT_BYTE_CODE_QUERY_H_

--- a/sdk/main/include/TransferTransaction.h
+++ b/sdk/main/include/TransferTransaction.h
@@ -197,6 +197,7 @@ private:
    * Allow queries that are not free to create Transaction protobuf objects from TransferTransactions.
    */
   friend class AccountRecordsQuery;
+  friend class ContractByteCodeQuery;
   friend class TransactionRecordQuery;
 
   /**

--- a/sdk/main/include/impl/Node.h
+++ b/sdk/main/include/impl/Node.h
@@ -21,6 +21,7 @@
 #define HEDERA_SDK_CPP_IMPL_NODE_H_
 
 #include <proto/crypto_service.grpc.pb.h>
+#include <proto/smart_contract_service.grpc.pb.h>
 
 #include "Defaults.h"
 #include "impl/NodeAddress.h"
@@ -194,6 +195,11 @@ private:
    * Pointer to the gRPC stub used to communicate with the cryptography service living on the remote node.
    */
   std::unique_ptr<proto::CryptoService::Stub> mCryptoStub = nullptr;
+
+  /**
+   * Pointer to the gRPC stub used to communicate with the smart contract service living on the remote node.
+   */
+  std::unique_ptr<proto::SmartContractService::Stub> mSmartContractSub = nullptr;
 
   /**
    * The TLS behavior this Node should use to communicate with its remote node.

--- a/sdk/main/src/ContractByteCodeQuery.cc
+++ b/sdk/main/src/ContractByteCodeQuery.cc
@@ -18,8 +18,11 @@
  *
  */
 #include "ContractByteCodeQuery.h"
-
-#include "ContractId.h"
+#include "Client.h"
+#include "Status.h"
+#include "TransferTransaction.h"
+#include "impl/Node.h"
+#include "impl/Utilities.h"
 
 #include <proto/contract_get_bytecode.pb.h>
 #include <proto/query.pb.h>
@@ -29,67 +32,56 @@
 namespace Hedera
 {
 //-----
-ContractByteCodeQuery::ContractByteCodeQuery()
-  : mContractId()
+ContractByteCodeQuery& ContractByteCodeQuery::setContractId(const ContractId& contractId)
 {
-}
-
-//-----
-void
-ContractByteCodeQuery::validateChecksums(const Client& client) const
-{
-  if (mContractId.isValid())
-  {
-    mContractId.getValue().validateChecksum(client);
-  }
-}
-
-//-----
-void
-ContractByteCodeQuery::onMakeRequest(proto::Query* query,
-                                     proto::QueryHeader* header) const
-{
-  proto::ContractGetBytecodeQuery* getByteCodeQuery =
-    query->mutable_contractgetbytecode();
-
-  if (mContractId.isValid())
-  {
-    getByteCodeQuery->set_allocated_contractid(
-      mContractId.getValue().toProtobuf());
-  }
-
-  getByteCodeQuery->set_allocated_header(header);
-}
-
-//-----
-proto::ResponseHeader
-ContractByteCodeQuery::mapResponseHeader(proto::Response* response) const
-{
-  return response->contractgetbytecoderesponse().header();
-}
-
-//-----
-proto::QueryHeader
-ContractByteCodeQuery::mapRequestHeader(const proto::Query& query) const
-{
-  return query.contractgetbytecode().header();
-}
-
-//-----
-std::string
-ContractByteCodeQuery::mapResponse(const proto::Response& response,
-                                   const AccountId& accountId,
-                                   const proto::Query& query) const
-{
-  return response.contractgetbytecoderesponse().bytecode();
-}
-
-//-----
-ContractByteCodeQuery&
-ContractByteCodeQuery::setContractId(const ContractId& contractId)
-{
-  mContractId.setValue(contractId);
+  mContractId = contractId;
   return *this;
+}
+
+//-----
+proto::Query ContractByteCodeQuery::makeRequest(const Client& client, const std::shared_ptr<internal::Node>& node) const
+{
+  proto::Query query;
+  proto::ContractGetBytecodeQuery* getByteCodeQuery = query.mutable_contractgetbytecode();
+
+  proto::QueryHeader* header = getByteCodeQuery->mutable_header();
+  header->set_responsetype(proto::ANSWER_ONLY);
+
+  TransferTransaction tx = TransferTransaction()
+                             .setTransactionId(TransactionId::generate(*client.getOperatorAccountId()))
+                             .setNodeAccountIds({ node->getAccountId() })
+                             .setMaxTransactionFee(Hbar(1LL))
+                             .addHbarTransfer(*client.getOperatorAccountId(), Hbar(-1LL))
+                             .addHbarTransfer(node->getAccountId(), Hbar(1LL));
+  tx.onSelectNode(node);
+  header->set_allocated_payment(new proto::Transaction(tx.makeRequest(client, node)));
+
+  getByteCodeQuery->set_allocated_contractid(mContractId.toProtobuf().release());
+
+  return query;
+}
+
+//-----
+ContractByteCode ContractByteCodeQuery::mapResponse(const proto::Response& response) const
+{
+  return internal::Utilities::stringToByteVector(response.contractgetbytecoderesponse().bytecode());
+}
+
+//-----
+Status ContractByteCodeQuery::mapResponseStatus(const proto::Response& response) const
+{
+  return gProtobufResponseCodeToStatus.at(
+    response.contractgetbytecoderesponse().header().nodetransactionprecheckcode());
+}
+
+//-----
+grpc::Status ContractByteCodeQuery::submitRequest(const Client& client,
+                                                  const std::chrono::system_clock::time_point& deadline,
+                                                  const std::shared_ptr<internal::Node>& node,
+                                                  proto::Response* response) const
+{
+  return node->submitQuery(
+    proto::Query::QueryCase::kContractGetBytecode, makeRequest(client, node), deadline, response);
 }
 
 } // namespace Hedera

--- a/sdk/main/src/Executable.cc
+++ b/sdk/main/src/Executable.cc
@@ -28,6 +28,7 @@
 #include "AccountRecordsQuery.h"
 #include "AccountUpdateTransaction.h"
 #include "Client.h"
+#include "ContractByteCodeQuery.h"
 #include "TransactionReceipt.h"
 #include "TransactionReceiptQuery.h"
 #include "TransactionRecord.h"
@@ -297,6 +298,7 @@ template class Executable<AccountUpdateTransaction,
                           proto::Transaction,
                           proto::TransactionResponse,
                           TransactionResponse>;
+template class Executable<ContractByteCodeQuery, proto::Query, proto::Response, ContractByteCode>;
 template class Executable<TransactionReceiptQuery, proto::Query, proto::Response, TransactionReceipt>;
 template class Executable<TransactionRecordQuery, proto::Query, proto::Response, TransactionRecord>;
 template class Executable<TransferTransaction, proto::Transaction, proto::TransactionResponse, TransactionResponse>;

--- a/sdk/main/src/impl/Node.cc
+++ b/sdk/main/src/impl/Node.cc
@@ -71,6 +71,11 @@ void Node::shutdown()
     mCryptoStub.reset();
   }
 
+  if (mSmartContractSub)
+  {
+    mSmartContractSub.reset();
+  }
+
   if (mChannel)
   {
     mChannel.reset();
@@ -95,6 +100,8 @@ grpc::Status Node::submitQuery(proto::Query::QueryCase funcEnum,
 
   switch (funcEnum)
   {
+    case proto::Query::QueryCase::kContractGetBytecode:
+      return mSmartContractSub->ContractGetBytecode(&context, query, response);
     case proto::Query::QueryCase::kCryptogetAccountBalance:
       return mCryptoStub->cryptoGetBalance(&context, query, response);
     case proto::Query::QueryCase::kCryptoGetAccountRecords:

--- a/sdk/tests/CMakeLists.txt
+++ b/sdk/tests/CMakeLists.txt
@@ -25,6 +25,7 @@ add_executable(${TEST_PROJECT_NAME}
         AccountRecordsTest.cc
         AccountUpdateTransactionTest.cc
         ClientTest.cc
+        ContractByteCodeQueryTest.cc
         ContractIdTest.cc
         ECDSAsecp256k1PrivateKeyTest.cc
         ECDSAsecp256k1PublicKeyTest.cc

--- a/sdk/tests/ContractByteCodeQueryTest.cc
+++ b/sdk/tests/ContractByteCodeQueryTest.cc
@@ -1,0 +1,47 @@
+/*-
+ *
+ * Hedera C++ SDK
+ *
+ * Copyright (C) 2020 - 2022 Hedera Hashgraph, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+#include "ContractByteCodeQuery.h"
+#include "ContractId.h"
+
+#include <gtest/gtest.h>
+
+using namespace Hedera;
+
+class ContractByteCodeQueryTest : public ::testing::Test
+{
+protected:
+  [[nodiscard]] inline const ContractId& getTestContractId() const { return mTestContractId; }
+
+private:
+  const ContractId mTestContractId = ContractId(1ULL);
+};
+
+//-----
+TEST_F(ContractByteCodeQueryTest, GetSetContractId)
+{
+  // Given
+  ContractByteCodeQuery query;
+
+  // When
+  query.setContractId(getTestContractId());
+
+  // Then
+  EXPECT_EQ(query.getContractId(), getTestContractId());
+}


### PR DESCRIPTION
**Description**:
This PR implements the `ContractByteCodeQuery`, which allows users to get the byte code of a smart contract.

**Related issue(s)**:

Fixes #247 

**Checklist**

- [x] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
