### PR TITLE
Fix failure of test `LedgerIdTest.FromBadStrings` (PR)

### DIFF
--- a/sdk/tests/unit/LedgerIdTest.cc
+++ b/sdk/tests/unit/LedgerIdTest.cc
@@ -128,15 +128,15 @@ TEST_F(LedgerIdTest, FromString)
 }
 
 //-----
-// TEST_F(LedgerIdTest, FromBadStrings)
-// {
-//   // Given / When / Then
-//   EXPECT_THROW(const LedgerId ledgerId = LedgerId::fromString("mainet"), std::invalid_argument);
-//   EXPECT_THROW(const LedgerId ledgerId = LedgerId::fromString("this is a bad string"), std::invalid_argument);
-//   EXPECT_THROW(const LedgerId ledgerId = LedgerId::fromString("1234567890abcdefg"), std::invalid_argument);
-//   EXPECT_THROW(const LedgerId ledgerId = LedgerId::fromString("TESTNET"), std::invalid_argument);
-//   EXPECT_THROW(const LedgerId ledgerId = LedgerId::fromString("Previewnet"), std::invalid_argument);
-// }
+TEST_F(LedgerIdTest, FromBadStrings)
+{
+  // Given / When / Then
+  EXPECT_THROW(const LedgerId ledgerId = LedgerId::fromString("mainet"), std::invalid_argument);
+  EXPECT_THROW(const LedgerId ledgerId = LedgerId::fromString("this is a bad string"), std::invalid_argument);
+  EXPECT_THROW(const LedgerId ledgerId = LedgerId::fromString("1234567890abcdefg"), std::invalid_argument);
+  EXPECT_THROW(const LedgerId ledgerId = LedgerId::fromString("TESTNET"), std::invalid_argument);
+  EXPECT_THROW(const LedgerId ledgerId = LedgerId::fromString("Previewnet"), std::invalid_argument);
+}
 
 //-----
 TEST_F(LedgerIdTest, ToString)


### PR DESCRIPTION
**Description**:

After we enabled running tests during the PR checks (in [PR #258](https://github.com/hashgraph/hedera-sdk-cpp/pull/258)), test `LedgerIdTest.FromBadStrings` started to fail.
When we fixed the failing `PR Checks` in [PR #267](https://github.com/hashgraph/hedera-sdk-cpp/pull/267), I added test `LedgerIdTest.FromBadStrings` once again to be part of the workflow to see if it will pass successfully. 
Fortunately it passed successfully!

**Related issue(s)**:

**Fixes:** [Fix failure of test LedgerIdTest.FromBadStrings](https://github.com/hashgraph/hedera-sdk-cpp/issues/259)

**Notes for reviewer**:

The only change I made was to remove comments for test `LedgerIdTest.FromBadStrings`.

**Checklist**

- [x] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
