### PR TITLE
`RLPValue` library throws when a value is empty

### DIFF
--- a/sdk/main/CMakeLists.txt
+++ b/sdk/main/CMakeLists.txt
@@ -3,20 +3,6 @@ FetchContent_Declare(valuable
         GIT_REPOSITORY https://github.com/LoopPerfect/valuable.git)
 FetchContent_MakeAvailable(valuable)
 
-FetchContent_Declare(rlpvalue
-        GIT_REPOSITORY https://github.com/bloq/rlpvalue.git
-        GIT_TAG master)
-FetchContent_GetProperties(rlpvalue)
-if (NOT rlpvalue_POPULATED)
-    FetchContent_Populate(rlpvalue)
-    add_library(rlpvalue STATIC
-            ${rlpvalue_SOURCE_DIR}/lib/rlpvalue.cpp
-            ${rlpvalue_SOURCE_DIR}/lib/rlpvalue_get.cpp
-            ${rlpvalue_SOURCE_DIR}/lib/rlpvalue_read.cpp
-            ${rlpvalue_SOURCE_DIR}/lib/rlpvalue_write.cpp)
-    target_include_directories(rlpvalue PUBLIC ${rlpvalue_SOURCE_DIR}/include)
-endif ()
-
 add_library(${PROJECT_NAME} STATIC
         src/AccountAllowanceApproveTransaction.cc
         src/AccountAllowanceDeleteTransaction.cc
@@ -101,6 +87,7 @@ add_library(${PROJECT_NAME} STATIC
         src/impl/NodeAddress.cc
         src/impl/NodeAddressBook.cc
         src/impl/OpenSSLUtils.cc
+        src/impl/RLPItem.cc
         src/impl/TimestampConverter.cc
         src/impl/Utilities.cc)
 
@@ -109,7 +96,6 @@ target_include_directories(${PROJECT_NAME} PUBLIC ${HAPI_INCLUDE_DIR})
 target_include_directories(${PROJECT_NAME} PUBLIC ${ZLIB_INCLUDE_DIRS})
 target_include_directories(${PROJECT_NAME} PUBLIC ${OPENSSL_INCLUDE_DIR})
 target_include_directories(${PROJECT_NAME} PUBLIC ${valuable_SOURCE_DIR}/include)
-target_include_directories(${PROJECT_NAME} PUBLIC ${rlpvalue_SOURCE_DIR}/include)
 
 if (APPLE)
     target_link_libraries(${PROJECT_NAME} PRIVATE ${OSX_CORE_FOUNDATION})
@@ -117,7 +103,6 @@ if (APPLE)
 endif ()
 
 target_link_libraries(${PROJECT_NAME} PRIVATE hapi::proto)
-target_link_libraries(${PROJECT_NAME} PRIVATE rlpvalue)
 
 if (NOT WIN32)
     target_link_libraries(${PROJECT_NAME} PRIVATE sys::resolv)

--- a/sdk/main/include/impl/RLPItem.h
+++ b/sdk/main/include/impl/RLPItem.h
@@ -121,6 +121,8 @@ public:
 
   /**
    * Encode this RLPItem to a byte array.
+   *
+   * @return This RLPItem RLP-encoded to a byte array.
    */
   [[nodiscard]] std::vector<std::byte> write() const;
 

--- a/sdk/main/include/impl/RLPItem.h
+++ b/sdk/main/include/impl/RLPItem.h
@@ -128,10 +128,19 @@ public:
    * Decode a byte array to to this RLPItem.
    *
    * @param bytes The byte array to decode.
+   * @throws std::invalid_argument If the input byte array is malformed and cannot be decoded.
    */
   void read(const std::vector<std::byte>& bytes);
 
 private:
+  /**
+   * Decode a byte array and put its values in this RLPItem. Helper function used by 'read()'.
+   *
+   * @param bytes The byte array to decode.
+   * @param index The index to begin decoding.
+   */
+  void decodeBytes(const std::vector<std::byte>& bytes, long& index);
+
   /**
    * The type of RLPItem this RLPItem is.
    */

--- a/sdk/main/include/impl/RLPItem.h
+++ b/sdk/main/include/impl/RLPItem.h
@@ -1,0 +1,153 @@
+/*-
+ *
+ * Hedera C++ SDK
+ *
+ * Copyright (C) 2020 - 2022 Hedera Hashgraph, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+#ifndef HEDERA_SDK_CPP_IMPL_RLP_ITEM_H_
+#define HEDERA_SDK_CPP_IMPL_RLP_ITEM_H_
+
+#include <cstddef>
+#include <string_view>
+#include <vector>
+
+namespace Hedera
+{
+/**
+ * Helper class used to hold RLP data and do RLP serialization for Ethereum data and transactions.
+ */
+class RLPItem
+{
+public:
+  /**
+   * Enumeration of possible RLP items. An RLPItem is defined as follows:
+   *  - A value (i.e. a string or byte array) is an item
+   *  - A list of items is an item
+   */
+  enum class RLPType
+  {
+    VALUE_TYPE,
+    LIST_TYPE
+  };
+
+  RLPItem() = default;
+
+  /**
+   * Construct with a specified RLPType.
+   *
+   * @param type The type of RLPItem to set.
+   */
+  explicit RLPItem(RLPType type);
+
+  /**
+   * Construct with a specified RLPItem value.
+   *
+   * @param value The value of the RLPItem to set.
+   */
+  explicit RLPItem(std::vector<std::byte> value);
+  explicit RLPItem(std::string_view value);
+
+  /**
+   * Clear this RLPItem.
+   */
+  void clear();
+
+  /**
+   * Assign the value of this RLPItem.
+   *
+   * @param value The value to assign to this RLPItem.
+   */
+  void assign(const std::vector<std::byte>& value);
+  void assign(std::string_view value);
+
+  /**
+   * Set the type of this RLPItem. This will clear values if a different type is set.
+   *
+   * @param type The RLPType to assign to this RLPItem.
+   */
+  void setType(RLPType type);
+
+  /**
+   * Determine if this RLPItem is a certain type.
+   *
+   * @param type The type to which to compare this RLPItem.
+   * @return \c TRUE if this RLPItem is input type, otherwise \c FALSE.
+   */
+  [[nodiscard]] inline bool isType(RLPType type) const { return mType == type; }
+
+  /**
+   * Get the value of this RLPItem.
+   *
+   * @return The value of this RLPItem. Returns empty if this RLPItem is of RLPType::LIST_TYPE.
+   */
+  [[nodiscard]] inline std::vector<std::byte> getValue() const { return mValue; }
+
+  /**
+   * Get the RLPItem values of this RLPItem.
+   *
+   * @return The RLPItems of this RLPItem. Returns empty if this RLPItem is of RLPType::VALUE_TYPE.
+   */
+  [[nodiscard]] inline std::vector<RLPItem> getValues() const { return mValues; }
+
+  /**
+   * Add a value to this RLPItem's values.
+   *
+   * @param value The RLPItem to add to this RLPItem.
+   */
+  void pushBack(const RLPItem& value);
+  void pushBack(const std::vector<std::byte>& value);
+  void pushBack(std::string_view value);
+
+  /**
+   * Get the total size in bytes of this RLPItem. This will be either the size of mValue, or the size of all the
+   * RLPItems in mValues added together, depending on the type of this RLPItem.
+   *
+   * @return The size of this RLPItem, in bytes.
+   */
+  [[nodiscard]] size_t size() const;
+
+  /**
+   * Encode this RLPItem to a byte array.
+   */
+  [[nodiscard]] std::vector<std::byte> write() const;
+
+  /**
+   * Decode a byte array to to this RLPItem.
+   *
+   * @param bytes The byte array to decode.
+   */
+  void read(const std::vector<std::byte>& bytes);
+
+private:
+  /**
+   * The type of RLPItem this RLPItem is.
+   */
+  RLPType mType = RLPType::VALUE_TYPE;
+
+  /**
+   * The value of this RLPItem.
+   */
+  std::vector<std::byte> mValue;
+
+  /**
+   * The list of values of this RLPItem.
+   */
+  std::vector<RLPItem> mValues;
+};
+
+} // namespace Hedera
+
+#endif // HEDERA_SDK_CPP_IMPL_RLP_ITEM_H_

--- a/sdk/main/src/EthereumTransactionData.cc
+++ b/sdk/main/src/EthereumTransactionData.cc
@@ -20,9 +20,7 @@
 #include "EthereumTransactionData.h"
 #include "EthereumTransactionDataEip1559.h"
 #include "EthereumTransactionDataLegacy.h"
-#include "impl/Utilities.h"
-
-#include <rlpvalue.h>
+#include "impl/RLPItem.h"
 
 namespace Hedera
 {
@@ -35,12 +33,10 @@ EthereumTransactionData::EthereumTransactionData(std::vector<std::byte> callData
 //-----
 std::unique_ptr<EthereumTransactionData> EthereumTransactionData::fromBytes(const std::vector<std::byte>& bytes)
 {
-  RLPValue rlpValue;
-  size_t consumed;
-  size_t wanted;
-  rlpValue.read(internal::Utilities::toTypePtr<const unsigned char>(bytes.data()), bytes.size(), consumed, wanted);
+  RLPItem rlpItem;
+  rlpItem.read(bytes);
 
-  if (rlpValue.isArray())
+  if (rlpItem.isType(RLPItem::RLPType::LIST_TYPE))
   {
     return std::make_unique<EthereumTransactionDataLegacy>(EthereumTransactionDataLegacy::fromBytes(bytes));
   }

--- a/sdk/main/src/EthereumTransactionDataEip1559.cc
+++ b/sdk/main/src/EthereumTransactionDataEip1559.cc
@@ -22,7 +22,6 @@
 #include "impl/RLPItem.h"
 #include "impl/Utilities.h"
 
-#include <iostream>
 #include <stdexcept>
 
 namespace Hedera
@@ -67,7 +66,7 @@ EthereumTransactionDataEip1559 EthereumTransactionDataEip1559::fromBytes(const s
   RLPItem item;
   item.read(internal::Utilities::removePrefix(bytes, 1));
 
-  if (!item.isType(RLPItem::RLPType::LIST_TYPE) || item.size() != 12)
+  if (!item.isType(RLPItem::RLPType::LIST_TYPE) || item.getValues().size() != 12)
   {
     throw std::invalid_argument(
       "Input byte array is malformed. It should be 0x02 followed by 12 RLP-encoded elements as a list");

--- a/sdk/main/src/impl/RLPItem.cc
+++ b/sdk/main/src/impl/RLPItem.cc
@@ -27,7 +27,12 @@ namespace Hedera
 {
 namespace
 {
-//-----
+/*
+ * Get the raw byte-representation of a number.
+ *
+ * @param num The number of which to get the byte-representation.
+ * @return The byte-representation of the input number.
+ */
 std::vector<std::byte> encodeBinary(size_t num)
 {
   std::vector<std::byte> bytes;
@@ -40,18 +45,24 @@ std::vector<std::byte> encodeBinary(size_t num)
   return bytes;
 }
 
-//-----
-std::vector<std::byte> encodeLength(size_t num, std::byte offset)
+/*
+ * Encode a number to its byte-representation, given an offset.
+ *
+ * @param num    The number to encode.
+ * @param offset The offset of the length.
+ * @return The byte-encoding of the number.
+ */
+std::vector<std::byte> encodeLength(size_t num, unsigned char offset)
 {
   if (num < 56)
   {
-    return { std::byte(static_cast<unsigned char>(offset) + num) };
+    return { std::byte(offset + num) };
   }
   else
   {
     const std::vector<std::byte> encodedLength = encodeBinary(num);
     return internal::Utilities::concatenateVectors(
-      { { std::byte(encodedLength.size() + static_cast<unsigned char>(offset) + 55) }, encodedLength });
+      { { std::byte(encodedLength.size() + offset + 55) }, encodedLength });
   }
 }
 
@@ -152,7 +163,7 @@ std::vector<std::byte> RLPItem::write() const
     }
     else
     {
-      return internal::Utilities::concatenateVectors({ { encodeLength(mValue.size(), std::byte(0x80)) }, mValue });
+      return internal::Utilities::concatenateVectors({ { encodeLength(mValue.size(), 0x80) }, mValue });
     }
   }
 
@@ -164,7 +175,7 @@ std::vector<std::byte> RLPItem::write() const
       bytes = internal::Utilities::concatenateVectors({ bytes, item.write() });
     }
 
-    return internal::Utilities::concatenateVectors({ { encodeLength(bytes.size(), std::byte(0xC0)) }, bytes });
+    return internal::Utilities::concatenateVectors({ { encodeLength(bytes.size(), 0xC0) }, bytes });
   }
 }
 

--- a/sdk/main/src/impl/RLPItem.cc
+++ b/sdk/main/src/impl/RLPItem.cc
@@ -1,0 +1,253 @@
+/*-
+ *
+ * Hedera C++ SDK
+ *
+ * Copyright (C) 2020 - 2022 Hedera Hashgraph, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+#include "impl/RLPItem.h"
+#include "impl/Utilities.h"
+
+namespace Hedera
+{
+namespace
+{
+//-----
+std::vector<std::byte> encodeBinary(size_t num)
+{
+  std::vector<std::byte> bytes;
+  while (num != 0)
+  {
+    bytes.insert(bytes.begin(), std::byte(num & 0xFF));
+    num >>= 8;
+  }
+
+  return bytes;
+}
+
+//-----
+std::vector<std::byte> encodeLength(size_t num, std::byte offset)
+{
+  if (num < 56)
+  {
+    return { std::byte(static_cast<unsigned char>(offset) + num) };
+  }
+  else
+  {
+    const std::vector<std::byte> encodedLength = encodeBinary(num);
+    return internal::Utilities::concatenateVectors(
+      { { std::byte(encodedLength.size() + static_cast<unsigned char>(offset) + 55) }, encodedLength });
+  }
+}
+
+//-----
+size_t toInteger(const std::vector<std::byte>& bytes)
+{
+  if (bytes.size() == 1)
+  {
+    return static_cast<size_t>(bytes.at(0));
+  }
+  else
+  {
+    size_t size = 0;
+    for (const std::byte& byte : bytes)
+    {
+      size <<= 8;
+      size |= static_cast<unsigned char>(byte);
+    }
+
+    return size;
+  }
+}
+
+//-----
+std::tuple<long, long, RLPItem::RLPType> decodeLength(const std::vector<std::byte>& bytes)
+{
+  if (bytes.empty())
+  {
+    return { 0, 0, RLPItem::RLPType::VALUE_TYPE };
+  }
+
+  const std::byte prefix = bytes.at(0);
+
+  if (prefix < std::byte(0x7F))
+  {
+    return { 0, 1, RLPItem::RLPType::VALUE_TYPE };
+  }
+  else if (prefix <= std::byte(0xB7))
+  {
+    return { 1, static_cast<unsigned char>(prefix) - 0x80, RLPItem::RLPType::VALUE_TYPE };
+  }
+  else if (prefix <= std::byte(0xBF))
+  {
+    const long lenOfStrLen = static_cast<unsigned char>(prefix) - 0xB7;
+    return { 1 + lenOfStrLen,
+             toInteger({ bytes.cbegin() + 1, bytes.cbegin() + 1 + lenOfStrLen }),
+             RLPItem::RLPType::VALUE_TYPE };
+  }
+  else if (prefix <= std::byte(0xF7))
+  {
+    return { 1, static_cast<unsigned char>(prefix) - 0xC0, RLPItem::RLPType::LIST_TYPE };
+  }
+  else
+  {
+    const long lenOfListLen = static_cast<unsigned char>(prefix) - 0xF7;
+    return { 1 + lenOfListLen,
+             toInteger({ bytes.cbegin() + 1, bytes.cbegin() + 1 + lenOfListLen }),
+             RLPItem::RLPType::LIST_TYPE };
+  }
+}
+
+} // namespace
+
+//-----
+RLPItem::RLPItem(RLPItem::RLPType type)
+  : mType(type)
+{
+}
+
+//-----
+RLPItem::RLPItem(std::vector<std::byte> value)
+  : mValue(std::move(value))
+{
+}
+
+//-----
+RLPItem::RLPItem(std::string_view value)
+  : mValue(internal::Utilities::stringToByteVector(value))
+{
+}
+
+//-----
+void RLPItem::clear()
+{
+  mValue.clear();
+  mValues.clear();
+}
+
+//-----
+void RLPItem::assign(const std::vector<std::byte>& value)
+{
+  clear();
+  mType = RLPType::VALUE_TYPE;
+  mValue = value;
+}
+
+//-----
+void RLPItem::assign(std::string_view value)
+{
+  clear();
+  mType = RLPType::VALUE_TYPE;
+  mValue = internal::Utilities::stringToByteVector(value);
+}
+
+//-----
+void RLPItem::setType(RLPItem::RLPType type)
+{
+  clear();
+  mType = type;
+}
+
+//-----
+void RLPItem::pushBack(const RLPItem& value)
+{
+  mValues.push_back(value);
+}
+
+//-----
+void RLPItem::pushBack(const std::vector<std::byte>& value)
+{
+  mValues.emplace_back(value);
+}
+
+//-----
+void RLPItem::pushBack(std::string_view value)
+{
+  mValues.emplace_back(value);
+}
+
+//-----
+size_t RLPItem::size() const
+{
+  if (mType == RLPType::VALUE_TYPE)
+  {
+    return mValue.size();
+  }
+  else
+  {
+    size_t size = 0;
+    std::for_each(mValues.cbegin(), mValues.cend(), [&size](const RLPItem& item) { size += item.size(); });
+    return size;
+  }
+}
+
+//-----
+std::vector<std::byte> RLPItem::write() const
+{
+  if (mType == RLPType::VALUE_TYPE)
+  {
+    if (mValue.size() == 1 && mValue.at(0) < std::byte(0x80))
+    {
+      return mValue;
+    }
+    else
+    {
+      return internal::Utilities::concatenateVectors({ { encodeLength(mValue.size(), std::byte(0x80)) }, mValue });
+    }
+  }
+
+  else
+  {
+    std::vector<std::byte> bytes;
+    for (const RLPItem& item : mValues)
+    {
+      bytes = internal::Utilities::concatenateVectors({ bytes, item.write() });
+    }
+
+    return internal::Utilities::concatenateVectors({ { encodeLength(bytes.size(), std::byte(0xC0)) }, bytes });
+  }
+}
+
+//-----
+void RLPItem::read(const std::vector<std::byte>& bytes)
+{
+  clear();
+
+  if (bytes.empty())
+  {
+    return;
+  }
+
+  const auto [offset, len, type] = decodeLength(bytes);
+  if (type == RLPType::VALUE_TYPE)
+  {
+    mValue = { bytes.cbegin() + offset, bytes.cbegin() + offset + len };
+  }
+  else
+  {
+    long bytesConsumed = offset;
+    while (bytesConsumed < len)
+    {
+      RLPItem item;
+      item.read({ bytes.cbegin() + bytesConsumed, bytes.cbegin() + len });
+      bytesConsumed -= static_cast<long>(item.size());
+      mValues.push_back(item);
+    }
+  }
+
+  mType = type;
+}
+
+} // namespace Hedera

--- a/sdk/main/src/impl/RLPItem.cc
+++ b/sdk/main/src/impl/RLPItem.cc
@@ -20,6 +20,7 @@
 #include "impl/RLPItem.h"
 #include "impl/Utilities.h"
 
+#include <algorithm>
 #include <stdexcept>
 
 namespace Hedera


### PR DESCRIPTION
**Description**:
This PR fixes a bug that was caused by a bug in the RLPValue library. Basically, the RLPValue library provided no way to check if a value was empty or not without trying to index into the first element, which throws on Windows builds. This PR removed that library and rewrites a condensed version of it that fixes this issue.

**Related issue(s)**:

Fixes #314 

**Checklist**

- [x] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
