### PR TITLE
Implement `FileContentsQuery`

### DIFF
--- a/sdk/examples/CMakeLists.txt
+++ b/sdk/examples/CMakeLists.txt
@@ -6,6 +6,7 @@ set(DELETE_ACCOUNT_EXAMPLE_NAME ${PROJECT_NAME}-delete-account-example)
 set(DELETE_FILE_EXAMPLE_NAME ${PROJECT_NAME}-delete-file-example)
 set(GENERATE_PRIVATE_KEY_FROM_MNEMONIC_EXAMPLE_NAME ${PROJECT_NAME}-generate-private-key-from-mnemonic-example)
 set(GET_ACCOUNT_BALANCE_EXAMPLE_NAME ${PROJECT_NAME}-get-account-balance-example)
+set(GET_FILE_CONTENTS_EXAMPLE_NAME ${PROJECT_NAME}-get-file-contents-example)
 set(STAKING_EXAMPLE_NAME ${PROJECT_NAME}-staking-example)
 set(TRANSFER_CRYPTO_EXAMPLE_NAME ${PROJECT_NAME}-transfer-crypto-example)
 set(TRANSFER_TOKENS_EXAMPLE_NAME ${PROJECT_NAME}-transfer-tokens-example)
@@ -19,6 +20,7 @@ add_executable(${DELETE_ACCOUNT_EXAMPLE_NAME} DeleteAccountExample.cc)
 add_executable(${DELETE_FILE_EXAMPLE_NAME} DeleteFileExample.cc)
 add_executable(${GENERATE_PRIVATE_KEY_FROM_MNEMONIC_EXAMPLE_NAME} GeneratePrivateKeyFromMnemonic.cc)
 add_executable(${GET_ACCOUNT_BALANCE_EXAMPLE_NAME} GetAccountBalanceExample.cc)
+add_executable(${GET_FILE_CONTENTS_EXAMPLE_NAME} GetFileContentsExample.cc)
 add_executable(${STAKING_EXAMPLE_NAME} StakingExample.cc)
 add_executable(${TRANSFER_CRYPTO_EXAMPLE_NAME} TransferCryptoExample.cc)
 add_executable(${TRANSFER_TOKENS_EXAMPLE_NAME} TransferTokensExample.cc)
@@ -50,6 +52,7 @@ target_link_libraries(${DELETE_ACCOUNT_EXAMPLE_NAME} PUBLIC ${PROJECT_NAME})
 target_link_libraries(${DELETE_FILE_EXAMPLE_NAME} PUBLIC ${PROJECT_NAME})
 target_link_libraries(${GENERATE_PRIVATE_KEY_FROM_MNEMONIC_EXAMPLE_NAME} PUBLIC ${PROJECT_NAME})
 target_link_libraries(${GET_ACCOUNT_BALANCE_EXAMPLE_NAME} PUBLIC ${PROJECT_NAME})
+target_link_libraries(${GET_FILE_CONTENTS_EXAMPLE_NAME} PUBLIC ${PROJECT_NAME})
 target_link_libraries(${STAKING_EXAMPLE_NAME} PUBLIC ${PROJECT_NAME})
 target_link_libraries(${TRANSFER_CRYPTO_EXAMPLE_NAME} PUBLIC ${PROJECT_NAME})
 target_link_libraries(${TRANSFER_TOKENS_EXAMPLE_NAME} PUBLIC ${PROJECT_NAME})
@@ -66,6 +69,7 @@ install(TARGETS
         ${DELETE_FILE_EXAMPLE_NAME}
         ${GENERATE_PRIVATE_KEY_FROM_MNEMONIC_EXAMPLE_NAME}
         ${GET_ACCOUNT_BALANCE_EXAMPLE_NAME}
+        ${GET_FILE_CONTENTS_EXAMPLE_NAME}
         ${STAKING_EXAMPLE_NAME}
         ${TRANSFER_CRYPTO_EXAMPLE_NAME}
         ${TRANSFER_TOKENS_EXAMPLE_NAME}

--- a/sdk/examples/GetFileContentsExample.cc
+++ b/sdk/examples/GetFileContentsExample.cc
@@ -1,0 +1,65 @@
+/*-
+ *
+ * Hedera C++ SDK
+ *
+ * Copyright (C) 2020 - 2022 Hedera Hashgraph, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+#include "Client.h"
+#include "ED25519PrivateKey.h"
+#include "FileContentsQuery.h"
+#include "FileCreateTransaction.h"
+#include "FileId.h"
+#include "PublicKey.h"
+#include "TransactionReceipt.h"
+#include "TransactionResponse.h"
+#include "impl/Utilities.h"
+
+#include <iostream>
+
+using namespace Hedera;
+
+int main(int argc, char** argv)
+{
+  if (argc < 3)
+  {
+    std::cout << "Please input account ID and private key" << std::endl;
+    return 1;
+  }
+
+  // Get a client for the Hedera testnet, and set the operator account ID and key such that all generated transactions
+  // will be paid for by this account and be signed by this key.
+  Client client = Client::forTestnet();
+  client.setOperator(AccountId::fromString(argv[1]), ED25519PrivateKey::fromString(argv[2]));
+
+  // Content to be stored in the file
+  const std::vector<std::byte> contents = internal::Utilities::stringToByteVector("Hedera is great!");
+
+  // Create a new file with the contents
+  FileId fileId = FileCreateTransaction()
+                    .setKey(client.getOperatorPublicKey())
+                    .setContents(contents)
+                    .execute(client)
+                    .getReceipt(client)
+                    .getFileId()
+                    .value();
+  std::cout << "The created file ID is: " << fileId.toString() << std::endl;
+
+  // Get the file contents
+  FileContents fileContents = FileContentsQuery().setFileId(fileId).execute(client);
+  std::cout << "The file contains the message: " << internal::Utilities::byteVectorToString(fileContents) << std::endl;
+
+  return 0;
+}

--- a/sdk/examples/GetFileContentsExample.cc
+++ b/sdk/examples/GetFileContentsExample.cc
@@ -22,7 +22,6 @@
 #include "FileContentsQuery.h"
 #include "FileCreateTransaction.h"
 #include "FileId.h"
-#include "PublicKey.h"
 #include "TransactionReceipt.h"
 #include "TransactionResponse.h"
 #include "impl/Utilities.h"
@@ -42,14 +41,14 @@ int main(int argc, char** argv)
   // Get a client for the Hedera testnet, and set the operator account ID and key such that all generated transactions
   // will be paid for by this account and be signed by this key.
   Client client = Client::forTestnet();
-  client.setOperator(AccountId::fromString(argv[1]), ED25519PrivateKey::fromString(argv[2]));
+  client.setOperator(AccountId::fromString(argv[1]), ED25519PrivateKey::fromString(argv[2]).get());
 
   // Content to be stored in the file
   const std::vector<std::byte> contents = internal::Utilities::stringToByteVector("Hedera is great!");
 
   // Create a new file with the contents
   FileId fileId = FileCreateTransaction()
-                    .setKey(client.getOperatorPublicKey())
+                    .setKeys({ client.getOperatorPublicKey().get() })
                     .setContents(contents)
                     .execute(client)
                     .getReceipt(client)

--- a/sdk/main/CMakeLists.txt
+++ b/sdk/main/CMakeLists.txt
@@ -58,7 +58,7 @@ add_library(${PROJECT_NAME} STATIC
         src/ExchangeRateSet.cc
         src/Executable.cc
         #    src/FileAppendTransaction.cc
-        #    src/FileContentsQuery.cc
+        src/FileContentsQuery.cc
         src/FileCreateTransaction.cc
         src/FileDeleteTransaction.cc
         src/FileId.cc

--- a/sdk/main/include/FileContentsQuery.h
+++ b/sdk/main/include/FileContentsQuery.h
@@ -24,6 +24,7 @@
 #include "Query.h"
 
 #include <cstddef>
+#include <optional>
 #include <vector>
 
 namespace Hedera

--- a/sdk/main/include/TransferTransaction.h
+++ b/sdk/main/include/TransferTransaction.h
@@ -201,6 +201,7 @@ private:
   friend class ContractByteCodeQuery;
   friend class ContractCallQuery;
   friend class ContractInfoQuery;
+  friend class FileContentsQuery;
   friend class FileInfoQuery;
   friend class TransactionRecordQuery;
 

--- a/sdk/main/src/Executable.cc
+++ b/sdk/main/src/Executable.cc
@@ -40,6 +40,7 @@
 #include "ContractInfoQuery.h"
 #include "ContractUpdateTransaction.h"
 #include "EthereumTransaction.h"
+#include "FileContentsQuery.h"
 #include "FileCreateTransaction.h"
 #include "FileDeleteTransaction.h"
 #include "FileInfo.h"
@@ -336,6 +337,7 @@ template class Executable<ContractUpdateTransaction,
                           proto::TransactionResponse,
                           TransactionResponse>;
 template class Executable<EthereumTransaction, proto::Transaction, proto::TransactionResponse, TransactionResponse>;
+template class Executable<FileContentsQuery, proto::Query, proto::Response, FileContents>;
 template class Executable<FileCreateTransaction, proto::Transaction, proto::TransactionResponse, TransactionResponse>;
 template class Executable<FileDeleteTransaction, proto::Transaction, proto::TransactionResponse, TransactionResponse>;
 template class Executable<FileInfoQuery, proto::Query, proto::Response, FileInfo>;

--- a/sdk/main/src/FileContentsQuery.cc
+++ b/sdk/main/src/FileContentsQuery.cc
@@ -57,7 +57,7 @@ proto::Query FileContentsQuery::makeRequest(const Client& client, const std::sha
   header->set_allocated_payment(new proto::Transaction(tx.makeRequest(client, node)));
 
   getFileContentsQuery->set_allocated_fileid(mFileId.toProtobuf().release());
-
+  
   return query;
 }
 

--- a/sdk/main/src/FileContentsQuery.cc
+++ b/sdk/main/src/FileContentsQuery.cc
@@ -57,7 +57,7 @@ proto::Query FileContentsQuery::makeRequest(const Client& client, const std::sha
   header->set_allocated_payment(new proto::Transaction(tx.makeRequest(client, node)));
 
   getFileContentsQuery->set_allocated_fileid(mFileId.toProtobuf().release());
-  
+
   return query;
 }
 

--- a/sdk/main/src/Query.cc
+++ b/sdk/main/src/Query.cc
@@ -26,6 +26,7 @@
 #include "ContractFunctionResult.h"
 #include "ContractInfo.h"
 #include "ContractInfoQuery.h"
+#include "FileContentsQuery.h"
 #include "FileInfo.h"
 #include "FileInfoQuery.h"
 #include "TransactionReceipt.h"
@@ -42,6 +43,7 @@ template class Query<AccountBalanceQuery, AccountBalance>;
 template class Query<AccountRecordsQuery, AccountRecords>;
 template class Query<ContractCallQuery, ContractFunctionResult>;
 template class Query<ContractInfoQuery, ContractInfo>;
+template class Query<FileContentsQuery, FileContents>;
 template class Query<FileInfoQuery, FileInfo>;
 template class Query<TransactionReceiptQuery, TransactionReceipt>;
 template class Query<TransactionRecordQuery, TransactionRecord>;

--- a/sdk/main/src/impl/Node.cc
+++ b/sdk/main/src/impl/Node.cc
@@ -121,6 +121,8 @@ grpc::Status Node::submitQuery(proto::Query::QueryCase funcEnum,
       return mCryptoStub->getLiveHash(&context, query, response);
     case proto::Query::QueryCase::kCryptoGetProxyStakers:
       return mCryptoStub->getStakersByAccountID(&context, query, response);
+    case proto::Query::QueryCase::kFileGetContents:
+      return mFileStub->getFileContent(&context, query, response);
     case proto::Query::QueryCase::kFileGetInfo:
       return mFileStub->getFileInfo(&context, query, response);
     case proto::Query::QueryCase::kTransactionGetReceipt:

--- a/sdk/tests/integration/CMakeLists.txt
+++ b/sdk/tests/integration/CMakeLists.txt
@@ -15,6 +15,7 @@ add_executable(${TEST_PROJECT_NAME}
         ContractUpdateTransactionIntegrationTests.cc
         ClientIntegrationTest.cc
         ContractInfoQueryIntegrationTests.cc
+        FileContentsQueryIntegrationTest.cc
         FileCreateTransactionIntegrationTests.cc
         FileDeleteTransactionIntegrationTests.cc
         FileInfoQueryIntegrationTests.cc

--- a/sdk/tests/integration/FileContentsQueryIntegrationTest.cc
+++ b/sdk/tests/integration/FileContentsQueryIntegrationTest.cc
@@ -1,0 +1,148 @@
+/*-
+ *
+ * Hedera C++ SDK
+ *
+ * Copyright (C) 2020 - 2022 Hedera Hashgraph, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+#include "AccountId.h"
+#include "Client.h"
+#include "ED25519PrivateKey.h"
+#include "FileContentsQuery.h"
+#include "FileCreateTransaction.h"
+#include "FileDeleteTransaction.h"
+#include "FileId.h"
+#include "PrivateKey.h"
+#include "PublicKey.h"
+#include "TransactionReceipt.h"
+#include "TransactionResponse.h"
+#include "exceptions/PrecheckStatusException.h"
+#include "impl/Utilities.h"
+
+#include <filesystem>
+#include <fstream>
+#include <gtest/gtest.h>
+#include <nlohmann/json.hpp>
+#include <string>
+#include <string_view>
+#include <unordered_map>
+
+using json = nlohmann::json;
+using namespace Hedera;
+
+class FileContentsQueryIntegrationTest : public ::testing::Test
+{
+protected:
+  [[nodiscard]] inline const Client& getTestClient() const { return mClient; }
+  [[nodiscard]] inline const std::vector<std::byte>& getTestFileContents() const { return mTestFileContents; }
+
+  void SetUp() override
+  {
+    const auto accountId = AccountId::fromString("0.0.3");
+    const std::string_view accountIdStr = "0.0.3";
+    const std::string_view networkTag = "network";
+    const std::string_view operatorTag = "operator";
+    const std::string_view accountIdTag = "accountId";
+    const std::string_view privateKeyTag = "privateKey";
+
+    const std::string testPathToJSON = (std::filesystem::current_path() / "local_node.json").string();
+    const std::unique_ptr<PrivateKey> testPrivateKey = ED25519PrivateKey::generatePrivateKey();
+    const std::shared_ptr<PublicKey> testPublicKey = testPrivateKey->getPublicKey();
+
+    AccountId operatorAccountId;
+    std::string operatorAccountPrivateKey;
+    std::ifstream testInputFile(testPathToJSON, std::ios::in);
+    std::string nodeAddressString;
+    json jsonData = json::parse(testInputFile);
+
+    if (jsonData[networkTag][accountIdStr].is_string())
+    {
+      nodeAddressString = jsonData[networkTag][accountIdStr];
+    }
+
+    if (jsonData[operatorTag][accountIdTag].is_string() && jsonData[operatorTag][privateKeyTag].is_string())
+    {
+      std::string operatorAccountIdStr = jsonData[operatorTag][accountIdTag];
+
+      operatorAccountId = AccountId::fromString(operatorAccountIdStr);
+      operatorAccountPrivateKey = jsonData[operatorTag][privateKeyTag];
+    }
+
+    testInputFile.close();
+
+    std::unordered_map<std::string, AccountId> networkMap;
+    networkMap.try_emplace(nodeAddressString, accountId);
+
+    mClient = Client::forNetwork(networkMap);
+    mClient.setOperator(operatorAccountId, ED25519PrivateKey::fromString(operatorAccountPrivateKey));
+  }
+
+private:
+  Client mClient;
+  const std::vector<std::byte> mTestFileContents = { std::byte(0x01), std::byte(0x02), std::byte(0x03) };
+};
+
+//-----
+TEST_F(FileContentsQueryIntegrationTest, ExecuteFileContentsQuery)
+{
+  // Given
+  const std::unique_ptr<PrivateKey> operatorKey = ED25519PrivateKey::fromString(
+    "302e020100300506032b65700422042091132178e72057a1d7528025956fe39b0b847f200ab59b2fdd367017f3087137");
+  FileId fileId;
+  ASSERT_NO_THROW(fileId = FileCreateTransaction()
+                             .setKey(operatorKey->getPublicKey())
+                             .setContents(getTestFileContents())
+                             .execute(getTestClient())
+                             .getReceipt(getTestClient())
+                             .getFileId()
+                             .value());
+
+  // When
+  FileContents fileContents;
+  EXPECT_NO_THROW(fileContents = FileContentsQuery().setFileId(fileId).execute(getTestClient()));
+
+  // Then
+  EXPECT_EQ(fileContents, getTestFileContents());
+
+  // Clean up
+  ASSERT_NO_THROW(const TransactionReceipt txReceipt =
+                    FileDeleteTransaction().setFileId(fileId).execute(getTestClient()).getReceipt(getTestClient()));
+}
+
+//-----
+TEST_F(FileContentsQueryIntegrationTest, CanQueryEmptyFileContents)
+{
+  // Given
+  const std::unique_ptr<PrivateKey> operatorKey = ED25519PrivateKey::fromString(
+    "302e020100300506032b65700422042091132178e72057a1d7528025956fe39b0b847f200ab59b2fdd367017f3087137");
+  FileId fileId;
+  ASSERT_NO_THROW(fileId = FileCreateTransaction()
+                             .setKey(operatorKey->getPublicKey())
+                             .execute(getTestClient())
+                             .getReceipt(getTestClient())
+                             .getFileId()
+                             .value());
+
+  // When
+  FileContents fileContents;
+  EXPECT_NO_THROW(fileContents = FileContentsQuery().setFileId(fileId).execute(getTestClient()));
+
+  // Then
+  EXPECT_TRUE(fileContents.empty());
+
+  // Clean up
+  ASSERT_NO_THROW(const TransactionReceipt txReceipt =
+                    FileDeleteTransaction().setFileId(fileId).execute(getTestClient()).getReceipt(getTestClient()));
+}

--- a/sdk/tests/integration/FileContentsQueryIntegrationTest.cc
+++ b/sdk/tests/integration/FileContentsQueryIntegrationTest.cc
@@ -86,7 +86,7 @@ protected:
     networkMap.try_emplace(nodeAddressString, accountId);
 
     mClient = Client::forNetwork(networkMap);
-    mClient.setOperator(operatorAccountId, ED25519PrivateKey::fromString(operatorAccountPrivateKey));
+    mClient.setOperator(operatorAccountId, ED25519PrivateKey::fromString(operatorAccountPrivateKey).get());
   }
 
 private:
@@ -102,7 +102,7 @@ TEST_F(FileContentsQueryIntegrationTest, ExecuteFileContentsQuery)
     "302e020100300506032b65700422042091132178e72057a1d7528025956fe39b0b847f200ab59b2fdd367017f3087137");
   FileId fileId;
   ASSERT_NO_THROW(fileId = FileCreateTransaction()
-                             .setKey(operatorKey->getPublicKey())
+                             .setKeys({ operatorKey->getPublicKey().get() })
                              .setContents(getTestFileContents())
                              .execute(getTestClient())
                              .getReceipt(getTestClient())
@@ -129,7 +129,7 @@ TEST_F(FileContentsQueryIntegrationTest, CanQueryEmptyFileContents)
     "302e020100300506032b65700422042091132178e72057a1d7528025956fe39b0b847f200ab59b2fdd367017f3087137");
   FileId fileId;
   ASSERT_NO_THROW(fileId = FileCreateTransaction()
-                             .setKey(operatorKey->getPublicKey())
+                             .setKeys({ operatorKey->getPublicKey().get() })
                              .execute(getTestClient())
                              .getReceipt(getTestClient())
                              .getFileId()

--- a/sdk/tests/unit/CMakeLists.txt
+++ b/sdk/tests/unit/CMakeLists.txt
@@ -35,6 +35,7 @@ add_executable(${TEST_PROJECT_NAME}
         EthereumTransactionDataLegacyTest.cc
         EvmAddressTest.cc
         ExchangeRateTest.cc
+        FileContentsQueryTest.cc
         FileCreateTransactionTest.cc
         FileDeleteTransactionTest.cc
         FileIdTest.cc

--- a/sdk/tests/unit/FileContentsQueryTest.cc
+++ b/sdk/tests/unit/FileContentsQueryTest.cc
@@ -1,0 +1,47 @@
+/*-
+ *
+ * Hedera C++ SDK
+ *
+ * Copyright (C) 2020 - 2022 Hedera Hashgraph, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+#include "FileContentsQuery.h"
+#include "FileId.h"
+
+#include <gtest/gtest.h>
+
+using namespace Hedera;
+
+class FileContentsQueryTest : public ::testing::Test
+{
+protected:
+  [[nodiscard]] inline const FileId& getTestFileId() const { return mTestFileId; }
+
+private:
+  const FileId mTestFileId = FileId(1ULL);
+};
+
+//-----
+TEST_F(FileContentsQueryTest, GetSetFileId)
+{
+  // Given
+  FileContentsQuery query;
+
+  // When
+  query.setFileId(getTestFileId());
+
+  // Then
+  EXPECT_EQ(query.getFileId(), getTestFileId());
+}


### PR DESCRIPTION
**Description**:
This PR adds the APIs associated with GetFileContents (aka `FileContentsQuery`), as well as tests and an accompanying example (`GetFileContentsExample.cc`).

**Related issue(s)**:

Fixes #322 

**Checklist**

- [x] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
