### PR TITLE
Add `FileUpdateTransaction` to `Transaction::fromBytes()` and add unit tests

### DIFF
--- a/sdk/main/include/Transaction.h
+++ b/sdk/main/include/Transaction.h
@@ -47,6 +47,7 @@ class ContractUpdateTransaction;
 class EthereumTransaction;
 class FileCreateTransaction;
 class FileDeleteTransaction;
+class FileUpdateTransaction;
 class PrivateKey;
 class TransactionResponse;
 class TransferTransaction;
@@ -116,7 +117,8 @@ public:
                                               FileDeleteTransaction,
                                               ContractExecuteTransaction,
                                               ContractUpdateTransaction,
-                                              EthereumTransaction>>
+                                              EthereumTransaction,
+                                              FileUpdateTransaction>>
   fromBytes(const std::vector<std::byte>& bytes);
 
   /**

--- a/sdk/main/src/Transaction.cc
+++ b/sdk/main/src/Transaction.cc
@@ -68,7 +68,8 @@ std::pair<int,
                        FileDeleteTransaction,
                        ContractExecuteTransaction,
                        ContractUpdateTransaction,
-                       EthereumTransaction>>
+                       EthereumTransaction,
+                       FileUpdateTransaction>>
 Transaction<SdkRequestType>::fromBytes(const std::vector<std::byte>& bytes)
 {
   proto::TransactionBody txBody;
@@ -136,6 +137,8 @@ Transaction<SdkRequestType>::fromBytes(const std::vector<std::byte>& bytes)
       return { 11, ContractUpdateTransaction(txBody) };
     case proto::TransactionBody::kEthereumTransaction:
       return { 12, EthereumTransaction(txBody) };
+    case proto::TransactionBody::kFileUpdate:
+      return { 13, FileUpdateTransaction(txBody) };
     default:
       throw std::invalid_argument("Type of transaction cannot be determined from input bytes");
   }

--- a/sdk/tests/unit/TransactionTest.cc
+++ b/sdk/tests/unit/TransactionTest.cc
@@ -30,6 +30,7 @@
 #include "EthereumTransaction.h"
 #include "FileCreateTransaction.h"
 #include "FileDeleteTransaction.h"
+#include "FileUpdateTransaction.h"
 #include "TransferTransaction.h"
 #include "impl/Utilities.h"
 
@@ -809,4 +810,63 @@ TEST_F(TransactionTest, EthereumTransactionFromTransactionBytes)
   // Then
   ASSERT_EQ(index, 12);
   EXPECT_NO_THROW(const EthereumTransaction ethereumTransaction = std::get<12>(txVariant));
+}
+
+//-----
+TEST_F(TransactionTest, FileUpdateTransactionFromTransactionBodyBytes)
+{
+  // Given
+  proto::TransactionBody txBody;
+  txBody.set_allocated_fileupdate(new proto::FileUpdateTransactionBody);
+
+  // When
+  const auto [index, txVariant] =
+    Transaction<FileUpdateTransaction>::fromBytes(internal::Utilities::stringToByteVector(txBody.SerializeAsString()));
+
+  // Then
+  ASSERT_EQ(index, 13);
+  EXPECT_NO_THROW(const FileUpdateTransaction fileUpdateTransaction = std::get<13>(txVariant));
+}
+
+//-----
+TEST_F(TransactionTest, FileUpdateTransactionFromSignedTransactionBytes)
+{
+  // Given
+  proto::TransactionBody txBody;
+  txBody.set_allocated_fileupdate(new proto::FileUpdateTransactionBody);
+
+  proto::SignedTransaction signedTx;
+  signedTx.set_bodybytes(txBody.SerializeAsString());
+  // SignatureMap not required
+
+  // When
+  const auto [index, txVariant] =
+    Transaction<FileUpdateTransaction>::fromBytes(internal::Utilities::stringToByteVector(txBody.SerializeAsString()));
+
+  // Then
+  ASSERT_EQ(index, 13);
+  EXPECT_NO_THROW(const FileUpdateTransaction fileUpdateTransaction = std::get<13>(txVariant));
+}
+
+//-----
+TEST_F(TransactionTest, FileUpdateTransactionFromTransactionBytes)
+{
+  // Given
+  proto::TransactionBody txBody;
+  txBody.set_allocated_fileupdate(new proto::FileUpdateTransactionBody);
+
+  proto::SignedTransaction signedTx;
+  signedTx.set_bodybytes(txBody.SerializeAsString());
+  // SignatureMap not required
+
+  proto::Transaction tx;
+  tx.set_signedtransactionbytes(signedTx.SerializeAsString());
+
+  // When
+  const auto [index, txVariant] =
+    Transaction<FileUpdateTransaction>::fromBytes(internal::Utilities::stringToByteVector(txBody.SerializeAsString()));
+
+  // Then
+  ASSERT_EQ(index, 13);
+  EXPECT_NO_THROW(const FileUpdateTransaction fileUpdateTransaction = std::get<13>(txVariant));
 }


### PR DESCRIPTION
**Description**:
This PR adds `FileUpdateTransaction` as a possible return type for `Transaction::fromBytes()`, as all `Transaction`s should be able to be created from bytes.

**Related issue(s)**:

Fixes #335 

**Checklist**

- [x] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
