### PR TITLE
Implement `EthereumFlow`

### DIFF
--- a/sdk/main/CMakeLists.txt
+++ b/sdk/main/CMakeLists.txt
@@ -31,6 +31,7 @@ add_library(${PROJECT_NAME} STATIC
         src/ECDSAsecp256k1PublicKey.cc
         src/ED25519PrivateKey.cc
         src/ED25519PublicKey.cc
+        src/EthereumFlow.cc
         src/EthereumTransaction.cc
         src/EthereumTransactionData.cc
         src/EthereumTransactionDataEip1559.cc

--- a/sdk/main/include/EthereumFlow.h
+++ b/sdk/main/include/EthereumFlow.h
@@ -1,0 +1,131 @@
+/*-
+ *
+ * Hedera C++ SDK
+ *
+ * Copyright (C) 2020 - 2022 Hedera Hashgraph, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+#ifndef HEDERA_SDK_CPP_ETHEREUM_FLOW_H_
+#define HEDERA_SDK_CPP_ETHEREUM_FLOW_H_
+
+#include "EthereumTransactionData.h"
+#include "Hbar.h"
+
+#include <chrono>
+#include <memory>
+#include <optional>
+
+namespace Hedera
+{
+class Client;
+class TransactionResponse;
+}
+
+namespace Hedera
+{
+/**
+ * A helper class to execute an EthereumTransaction. This will use FileCreateTransaction and FileAppendTransaction as
+ * necessary to create the file followed by an EthereumTransaction to execute the EthereumData.
+ */
+class EthereumFlow
+{
+public:
+  /**
+   * Execute the Transactions in this flow (FileCreateTransaction and FileAppendTransaction (if needed), and an
+   * EthereumTransaction).
+   *
+   * @param client The Client to use to submit these Transactions.
+   * @return The TransactionResponse object of the EthereumTransaction.
+   * @throws MaxAttemptsExceededException If any Transaction attempts to execute past the number of allowable attempts.
+   * @throws PrecheckStatusException      If any Transaction fails its pre-check.
+   * @throws UninitializedException       If the input Client has not yet been initialized.
+   */
+  TransactionResponse execute(const Client& client);
+
+  /**
+   * Execute the Transactions in this flow (FileCreateTransaction and FileAppendTransaction (if needed), and an
+   * EthereumTransaction) with a specified timeout.
+   *
+   * @param client  The Client to use to submit these Transactions.
+   * @param timeout The desired timeout for the execution of these Transactions.
+   * @return The TransactionResponse object of the EthereumTransaction.
+   * @throws IllegalStateException        If the EthereumData is not set.
+   * @throws MaxAttemptsExceededException If any Transaction attempts to execute past the number of allowable attempts.
+   * @throws PrecheckStatusException      If any Transaction fails its pre-check.
+   * @throws UninitializedException       If the input Client has not yet been initialized.
+   */
+  TransactionResponse execute(const Client& client, const std::chrono::duration<double>& timeout);
+
+  /**
+   * Set the bytes of the raw EthereumTransaction (RLP encoded type 0, 1, or 2).
+   *
+   * @param data The ethereum data to set.
+   * @return A reference to this EthereumFlow object with the newly-set ethereum data.
+   */
+  EthereumFlow& setEthereumData(const std::vector<std::byte>& data);
+
+  /**
+   * Set the maximum amount that the payer of the Hedera transaction is willing to pay to complete the
+   * EthereumTransaction.
+   *
+   * @param maxGasAllowance The maximum amount that the payer of the Hedera transaction is willing to pay to complete
+   *                        the EthereumTransaction.
+   * @return A reference to this EthereumFlow object with the newly-set maximum gas allowance.
+   */
+  EthereumFlow& setMaxGasAllowance(const Hbar& maxGasAllowance);
+
+  /**
+   * Get the raw EthereumTransaction data.
+   *
+   * @return The raw EthereumTransaction data.
+   */
+  [[nodiscard]] inline std::shared_ptr<EthereumTransactionData> getEthereumData() const { return mEthereumData; }
+
+  /**
+   * Get the maximum amount that the payer of the Hedera transaction is willing to pay to complete the
+   * EthereumTransaction.
+   *
+   * @return The maximum amount that the payer of the Hedera transaction is willing to pay to complete the
+   *         EthereumTransaction. Returns uninitialized in no max gas allowance has been set.
+   */
+  [[nodiscard]] inline std::optional<Hbar> getMaxGasAllowance() const { return mMaxGasAllowance; }
+
+private:
+  /**
+   * The maximum size for a EthereumTransaction call data.
+   */
+  static constexpr unsigned int MAX_ETHEREUM_DATA_SIZE = 5120U;
+
+  /**
+   * The data to be submitted as a part of the EthereumTransaction.
+   */
+  std::shared_ptr<EthereumTransactionData> mEthereumData = nullptr;
+
+  /**
+   * The maximum amount that the payer of the Hedera transaction is willing to pay to complete the transaction.
+   *
+   * Ordinarily the account with the ECDSA alias corresponding to the public key that is extracted from the
+   * ethereum data signature is responsible for fees that result from the execution of the transaction. If that amount
+   * of authorized fees is not sufficient then the payer of the transaction can be charged, up to but not exceeding this
+   * amount. If the ethereum data transaction authorized an amount that was insufficient then the payer will only be
+   * charged the amount needed to make up the difference. If the gas price in the transaction was set to zero then the
+   * payer will be assessed the entire fee.
+   */
+  std::optional<Hbar> mMaxGasAllowance;
+};
+
+} // namespace Hedera
+
+#endif // HEDERA_SDK_CPP_ETHEREUM_FLOW_H_

--- a/sdk/main/include/EthereumFlow.h
+++ b/sdk/main/include/EthereumFlow.h
@@ -37,7 +37,7 @@ namespace Hedera
 {
 /**
  * A helper class to execute an EthereumTransaction. This will use FileCreateTransaction and FileAppendTransaction as
- * necessary to create the file followed by an EthereumTransaction to execute the EthereumData.
+ * necessary to create a file with the call data followed by an EthereumTransaction to execute the EthereumData.
  */
 class EthereumFlow
 {

--- a/sdk/main/include/EthereumFlow.h
+++ b/sdk/main/include/EthereumFlow.h
@@ -73,6 +73,7 @@ public:
    *
    * @param data The ethereum data to set.
    * @return A reference to this EthereumFlow object with the newly-set ethereum data.
+   * @throws std::invalid_argument If the input data is not RLP-encoded Ethereum data.
    */
   EthereumFlow& setEthereumData(const std::vector<std::byte>& data);
 

--- a/sdk/main/include/EthereumTransaction.h
+++ b/sdk/main/include/EthereumTransaction.h
@@ -57,8 +57,7 @@ public:
   explicit EthereumTransaction(const proto::TransactionBody& transactionBody);
 
   /**
-   * Set the raw Ethereum transaction (RLP encoded type 0, 1, and 2). This is mutually exclusive with mCallDataFileId
-   * and will reset the value of mCallDataFileId if it is set.
+   * Set the raw Ethereum transaction (RLP encoded type 0, 1, and 2).
    *
    * @param ethereumData The raw Ethereum transaction.
    * @return A reference to this EthereumTransaction object with the newly-set ethereum data.
@@ -67,8 +66,7 @@ public:
   EthereumTransaction& setEthereumData(const std::vector<std::byte>& ethereumData);
 
   /**
-   * Set the ID of the file that contains the call data. This is mutually exclusive with mEthereumData and will reset
-   * the value of mEthereumData if it is set.
+   * Set the ID of the file that contains the call data.
    *
    * @param fileId The ID of the file that contains the call data.
    * @return A reference to this EthereumTransaction object with the newly-set call data file ID.
@@ -90,16 +88,14 @@ public:
   /**
    * Get the raw Ethereum transaction.
    *
-   * @return The raw Ethereum transaction. Returns uninitialized if a value has not yet been set, or if a call data file
-   *         ID has been set most recently.
+   * @return The raw Ethereum transaction.
    */
-  [[nodiscard]] inline std::optional<std::vector<std::byte>> getEthereumData() const { return mEthereumData; }
+  [[nodiscard]] inline std::vector<std::byte> getEthereumData() const { return mEthereumData; }
 
   /**
    * Get the ID of the file that contains the call data.
    *
-   * @return The ID of the file that contains the call data. Returns uninitialized if a value has not yet been set, or
-   *         if ethereum data has been set most recently.
+   * @return The ID of the file that contains the call data. Returns uninitialized if a value has not been set.
    */
   [[nodiscard]] inline std::optional<FileId> getCallDataFileId() const { return mCallDataFileId; }
 
@@ -150,7 +146,7 @@ private:
   /**
    * The raw Ethereum transaction (RLP encoded type 0, 1, and 2).
    */
-  std::optional<std::vector<std::byte>> mEthereumData;
+  std::vector<std::byte> mEthereumData;
 
   /**
    * The ID of the file that contains the call data.

--- a/sdk/main/include/FileAppendTransaction.h
+++ b/sdk/main/include/FileAppendTransaction.h
@@ -46,6 +46,11 @@ class FileAppendTransaction : public ChunkedTransaction<FileAppendTransaction>
 {
 public:
   /**
+   * The default chunk size for a FileAppendTransaction.
+   */
+  static constexpr unsigned int DEFAULT_CHUNK_SIZE = 4096U;
+   
+  /**
    * Default constructor. Sets the maximum transaction fee to 5 Hbars, chunk size to 2048 bytes, and sets the receipt
    * retrieval policy to always retrieve receipts between chunk submissions.
    */

--- a/sdk/main/src/EthereumFlow.cc
+++ b/sdk/main/src/EthereumFlow.cc
@@ -1,0 +1,99 @@
+/*-
+ *
+ * Hedera C++ SDK
+ *
+ * Copyright (C) 2020 - 2022 Hedera Hashgraph, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+#include "EthereumFlow.h"
+#include "Client.h"
+#include "EthereumTransaction.h"
+#include "FileAppendTransaction.h"
+#include "FileCreateTransaction.h"
+#include "TransactionReceipt.h"
+#include "TransactionResponse.h"
+#include "exceptions/IllegalStateException.h"
+
+namespace Hedera
+{
+//-----
+TransactionResponse EthereumFlow::execute(const Client& client)
+{
+  return execute(client, client.getRequestTimeout());
+}
+
+//-----
+TransactionResponse EthereumFlow::execute(const Client& client, const std::chrono::duration<double>& timeout)
+{
+  // Make sure the ethereum data has been set. There is nothing to do if there is no ethereum data.
+  if (!mEthereumData)
+  {
+    throw IllegalStateException("Cannot execute EthereumTransaction with no EthereumTransactionData");
+  }
+
+  // Create the transaction.
+  EthereumTransaction ethereumTransaction;
+  if (mMaxGasAllowance.has_value())
+  {
+    ethereumTransaction.setMaxGasAllowance(mMaxGasAllowance.value());
+  }
+
+  // Create a file to hold the Ethereum call data if the data is too large.
+  if (const std::vector<std::byte> ethereumDataBytes = mEthereumData->toBytes();
+      ethereumDataBytes.size() > MAX_ETHEREUM_DATA_SIZE)
+  {
+    // Put the Ethereum call data into a file.
+    const FileId fileId =
+      FileCreateTransaction()
+        .setContents({ mEthereumData->mCallData.cbegin(),
+                       mEthereumData->mCallData.cbegin() + FileAppendTransaction::DEFAULT_CHUNK_SIZE })
+        .execute(client, timeout)
+        .getReceipt(client, timeout)
+        .getFileId()
+        .value();
+
+    FileAppendTransaction()
+      .setFileId(fileId)
+      .setContents({ mEthereumData->mCallData.cbegin() + FileAppendTransaction::DEFAULT_CHUNK_SIZE,
+                     mEthereumData->mCallData.cend() })
+      .execute(client, timeout);
+
+    // Set the ethereum data without the call data, and reference the file ID that contains the call data.
+    mEthereumData->mCallData.clear();
+    ethereumTransaction.setEthereumData(mEthereumData->toBytes()).setCallDataFileId(fileId);
+  }
+  else
+  {
+    ethereumTransaction.setEthereumData(ethereumDataBytes);
+  }
+
+  return ethereumTransaction.execute(client, timeout);
+}
+
+//-----
+EthereumFlow& EthereumFlow::setEthereumData(const std::vector<std::byte>& data)
+{
+  mEthereumData = std::shared_ptr<EthereumTransactionData>(EthereumTransactionData::fromBytes(data).release());
+  return *this;
+}
+
+//-----
+EthereumFlow& EthereumFlow::setMaxGasAllowance(const Hbar& maxGasAllowance)
+{
+  mMaxGasAllowance = maxGasAllowance;
+  return *this;
+}
+
+} // namespace Hedera

--- a/sdk/main/src/EthereumTransaction.cc
+++ b/sdk/main/src/EthereumTransaction.cc
@@ -38,14 +38,11 @@ EthereumTransaction::EthereumTransaction(const proto::TransactionBody& transacti
 
   const proto::EthereumTransactionBody& body = transactionBody.ethereumtransaction();
 
+  mEthereumData = internal::Utilities::stringToByteVector(body.ethereum_data());
+
   if (body.has_call_data())
   {
     mCallDataFileId = FileId::fromProtobuf(body.call_data());
-  }
-
-  else if (!body.ethereum_data().empty())
-  {
-    mEthereumData = internal::Utilities::stringToByteVector(body.ethereum_data());
   }
 
   mMaxGasAllowance = Hbar(body.max_gas_allowance(), HbarUnit::TINYBAR());

--- a/sdk/main/src/EthereumTransaction.cc
+++ b/sdk/main/src/EthereumTransaction.cc
@@ -56,7 +56,6 @@ EthereumTransaction& EthereumTransaction::setEthereumData(const std::vector<std:
 {
   requireNotFrozen();
   mEthereumData = ethereumData;
-  mCallDataFileId.reset();
   return *this;
 }
 
@@ -65,7 +64,6 @@ EthereumTransaction& EthereumTransaction::setCallDataFileId(const FileId& fileId
 {
   requireNotFrozen();
   mCallDataFileId = fileId;
-  mEthereumData.reset();
   return *this;
 }
 
@@ -101,12 +99,9 @@ proto::EthereumTransactionBody* EthereumTransaction::build() const
 {
   auto body = std::make_unique<proto::EthereumTransactionBody>();
 
-  if (mEthereumData.has_value())
-  {
-    body->set_ethereum_data(internal::Utilities::byteVectorToString(mEthereumData.value()));
-  }
+  body->set_ethereum_data(internal::Utilities::byteVectorToString(mEthereumData));
 
-  else if (mCallDataFileId.has_value())
+  if (mCallDataFileId.has_value())
   {
     body->set_allocated_call_data(mCallDataFileId->toProtobuf().release());
   }

--- a/sdk/main/src/FileAppendTransaction.cc
+++ b/sdk/main/src/FileAppendTransaction.cc
@@ -32,7 +32,7 @@ namespace Hedera
 FileAppendTransaction::FileAppendTransaction()
 {
   setMaxTransactionFee(Hbar(5LL));
-  setChunkSize(2048U);
+  setChunkSize(DEFAULT_CHUNK_SIZE);
   setShouldGetReceipt(true);
 }
 

--- a/sdk/tests/unit/CMakeLists.txt
+++ b/sdk/tests/unit/CMakeLists.txt
@@ -31,6 +31,7 @@ add_executable(${TEST_PROJECT_NAME}
         ECDSAsecp256k1PublicKeyTest.cc
         ED25519PrivateKeyTest.cc
         ED25519PublicKeyTest.cc
+        EthereumFlowTest.cc
         EthereumTransactionTest.cc
         EthereumTransactionDataEip1559Test.cc
         EthereumTransactionDataLegacyTest.cc

--- a/sdk/tests/unit/EthereumFlowTest.cc
+++ b/sdk/tests/unit/EthereumFlowTest.cc
@@ -1,0 +1,79 @@
+/*-
+ *
+ * Hedera C++ SDK
+ *
+ * Copyright (C) 2020 - 2022 Hedera Hashgraph, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+#include "EthereumFlow.h"
+#include "AccountId.h"
+#include "Client.h"
+#include "ECDSAsecp256k1PrivateKey.h"
+#include "FileId.h"
+#include "Hbar.h"
+#include "impl/HexConverter.h"
+
+#include <cstddef>
+#include <gtest/gtest.h>
+#include <vector>
+
+using namespace Hedera;
+
+class EthereumFlowTest : public ::testing::Test
+{
+protected:
+  void SetUp() override
+  {
+    mClient.setOperator(AccountId(), ECDSAsecp256k1PrivateKey::generatePrivateKey().get());
+    mTestEthereumData = internal::HexConverter::hexToBytes(
+      "02f87082012a022f2f83018000947e3a9eaf9bcc39e2ffa38eb30bf7a93feacbc181880de0b6b3a"
+      "7640000831234568001a0df48f2efd10421811de2bfb125ab75b2d3c44139c4642837fb1fccce91"
+      "1fd479a01aaf7ae92bee896651dfc9d99ae422a296bf5d9f1ca49b2d96d82b79eb112d66");
+  }
+
+  [[nodiscard]] inline const std::vector<std::byte>& getTestEthereumData() const { return mTestEthereumData; }
+  [[nodiscard]] inline const Hbar& getTestMaxGasAllowance() const { return mTestMaxGasAllowance; }
+
+private:
+  Client mClient;
+  std::vector<std::byte> mTestEthereumData;
+  const Hbar mTestMaxGasAllowance = Hbar(1LL);
+};
+
+//-----
+TEST_F(EthereumFlowTest, GetSetEthereumData)
+{
+  // Given
+  EthereumFlow flow;
+
+  // When
+  EXPECT_NO_THROW(flow.setEthereumData(getTestEthereumData()));
+
+  // Then
+  EXPECT_EQ(flow.getEthereumData()->toBytes(), getTestEthereumData());
+}
+
+//-----
+TEST_F(EthereumFlowTest, GetSetMaxGasAllowance)
+{
+  // Given
+  EthereumFlow flow;
+
+  // When
+  flow.setMaxGasAllowance(getTestMaxGasAllowance());
+
+  // Then
+  EXPECT_EQ(flow.getMaxGasAllowance(), getTestMaxGasAllowance());
+}

--- a/sdk/tests/unit/EthereumTransactionTest.cc
+++ b/sdk/tests/unit/EthereumTransactionTest.cc
@@ -55,35 +55,22 @@ private:
 TEST_F(EthereumTransactionTest, ConstructEthereumTransactionFromTransactionBodyProtobuf)
 {
   // Given
-  auto bodyWithEthereumData = std::make_unique<proto::EthereumTransactionBody>();
-  auto bodyWithCallDataFileId = std::make_unique<proto::EthereumTransactionBody>();
+  auto body = std::make_unique<proto::EthereumTransactionBody>();
+  body->set_ethereum_data(internal::Utilities::byteVectorToString(getTestEthereumData()));
+  body->set_allocated_call_data(getTestCallDataFileId().toProtobuf().release());
+  body->set_max_gas_allowance(getTestMaxGasAllowance().toTinybars());
 
-  bodyWithEthereumData->set_max_gas_allowance(getTestMaxGasAllowance().toTinybars());
-  bodyWithCallDataFileId->set_max_gas_allowance(getTestMaxGasAllowance().toTinybars());
-
-  bodyWithEthereumData->set_ethereum_data(internal::Utilities::byteVectorToString(getTestEthereumData()));
-  bodyWithCallDataFileId->set_allocated_call_data(getTestCallDataFileId().toProtobuf().release());
-
-  proto::TransactionBody txBodyEthereumData;
-  proto::TransactionBody txBodyCallDataFileId;
-
-  txBodyEthereumData.set_allocated_ethereumtransaction(bodyWithEthereumData.release());
-  txBodyCallDataFileId.set_allocated_ethereumtransaction(bodyWithCallDataFileId.release());
+  proto::TransactionBody txBody;
+  txBody.set_allocated_ethereumtransaction(body.release());
 
   // When
-  const EthereumTransaction ethereumTransactionEthereumData(txBodyEthereumData);
-  const EthereumTransaction ethereumTransactionCallDataFileId(txBodyCallDataFileId);
+  const EthereumTransaction ethereumTransaction(txBody);
 
   // Then
-  ASSERT_TRUE(ethereumTransactionEthereumData.getEthereumData().has_value());
-  EXPECT_EQ(ethereumTransactionEthereumData.getEthereumData(), getTestEthereumData());
-  EXPECT_FALSE(ethereumTransactionEthereumData.getCallDataFileId().has_value());
-  EXPECT_EQ(ethereumTransactionEthereumData.getMaxGasAllowance(), getTestMaxGasAllowance());
-
-  EXPECT_FALSE(ethereumTransactionCallDataFileId.getEthereumData().has_value());
-  ASSERT_TRUE(ethereumTransactionCallDataFileId.getCallDataFileId().has_value());
-  EXPECT_EQ(ethereumTransactionCallDataFileId.getCallDataFileId(), getTestCallDataFileId());
-  EXPECT_EQ(ethereumTransactionCallDataFileId.getMaxGasAllowance(), getTestMaxGasAllowance());
+  EXPECT_EQ(ethereumTransaction.getEthereumData(), getTestEthereumData());
+  ASSERT_TRUE(ethereumTransaction.getCallDataFileId().has_value());
+  EXPECT_EQ(ethereumTransaction.getCallDataFileId(), getTestCallDataFileId());
+  EXPECT_EQ(ethereumTransaction.getMaxGasAllowance(), getTestMaxGasAllowance());
 }
 
 //-----
@@ -96,7 +83,6 @@ TEST_F(EthereumTransactionTest, GetSetEthereumData)
   EXPECT_NO_THROW(transaction.setEthereumData(getTestEthereumData()));
 
   // Then
-  ASSERT_TRUE(transaction.getEthereumData().has_value());
   EXPECT_EQ(transaction.getEthereumData(), getTestEthereumData());
 }
 
@@ -109,7 +95,6 @@ TEST_F(EthereumTransactionTest, GetSetEthereumDataFrozen)
 
   // When / Then
   EXPECT_THROW(transaction.setEthereumData(getTestEthereumData()), IllegalStateException);
-  EXPECT_FALSE(transaction.getEthereumData().has_value());
 }
 
 //-----
@@ -122,7 +107,6 @@ TEST_F(EthereumTransactionTest, GetSetCallDataFileId)
   EXPECT_NO_THROW(transaction.setCallDataFileId(getTestCallDataFileId()));
 
   // Then
-  ASSERT_TRUE(transaction.getCallDataFileId().has_value());
   EXPECT_EQ(transaction.getCallDataFileId(), getTestCallDataFileId());
 }
 
@@ -135,7 +119,6 @@ TEST_F(EthereumTransactionTest, GetSetCallDataFileIdFrozen)
 
   // When / Then
   EXPECT_THROW(transaction.setCallDataFileId(getTestCallDataFileId()), IllegalStateException);
-  EXPECT_FALSE(transaction.getCallDataFileId().has_value());
 }
 
 //-----
@@ -160,34 +143,4 @@ TEST_F(EthereumTransactionTest, GetSetMaxGasAllowanceFrozen)
 
   // When / Then
   EXPECT_THROW(transaction.setMaxGasAllowance(getTestMaxGasAllowance()), IllegalStateException);
-}
-
-//-----
-TEST_F(EthereumTransactionTest, ResetEthereumData)
-{
-  // Given
-  EthereumTransaction transaction;
-  ASSERT_NO_THROW(transaction.setEthereumData(getTestEthereumData()));
-
-  // When
-  EXPECT_NO_THROW(transaction.setCallDataFileId(getTestCallDataFileId()));
-
-  // Then
-  EXPECT_FALSE(transaction.getEthereumData().has_value());
-  EXPECT_TRUE(transaction.getCallDataFileId().has_value());
-}
-
-//-----
-TEST_F(EthereumTransactionTest, ResetCallDataFileId)
-{
-  // Given
-  EthereumTransaction transaction;
-  ASSERT_NO_THROW(transaction.setCallDataFileId(getTestCallDataFileId()));
-
-  // When
-  EXPECT_NO_THROW(transaction.setEthereumData(getTestEthereumData()));
-
-  // Then
-  EXPECT_TRUE(transaction.getEthereumData().has_value());
-  EXPECT_FALSE(transaction.getCallDataFileId().has_value());
 }


### PR DESCRIPTION
**Description**:
This PR adds the helper `EthereumFlow` class. This is also fixes some issues seen with the `EthereumTransaction` class, namely that `mEthereumData` and `mCallDataFileId` are not mutually exclusive.

**Related issue(s)**:

Fixes #346 

**Notes for reviewer**:
Integration tests were not included as I could not find any example integration tests from which to start. These will need to be added at a later time.

**Checklist**

- [x] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
