### PR TITLE
Implement `TokenDeleteTransaction`

### DIFF
--- a/sdk/main/CMakeLists.txt
+++ b/sdk/main/CMakeLists.txt
@@ -67,6 +67,7 @@ add_library(${PROJECT_NAME} STATIC
         src/StakingInfo.cc
         src/Status.cc
         src/TokenAllowance.cc
+        src/TokenDeleteTransaction.cc
         src/TokenId.cc
         src/TokenNftAllowance.cc
         src/TokenNftRemoveAllowance.cc

--- a/sdk/main/include/TokenDeleteTransaction.h
+++ b/sdk/main/include/TokenDeleteTransaction.h
@@ -1,0 +1,123 @@
+/*-
+ *
+ * Hedera C++ SDK
+ *
+ * Copyright (C) 2020 - 2022 Hedera Hashgraph, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+#ifndef HEDERA_SDK_CPP_TOKEN_DELETE_TRANSACTION_H_
+#define HEDERA_SDK_CPP_TOKEN_DELETE_TRANSACTION_H_
+
+#include "TokenId.h"
+#include "Transaction.h"
+
+#include <optional>
+
+namespace proto
+{
+class TokenDeleteTransactionBody;
+class TransactionBody;
+}
+
+namespace Hedera
+{
+/**
+ * Deleting a token marks a token as deleted, though it will remain in the ledger. The operation must be signed by the
+ * specified admin key of the token. If the admin key is not set, the transaction will result in TOKEN_IS_IMMUTABlE.
+ * Once deleted, update, mint, burn, wipe, freeze, unfreeze, grant KYC, revoke KYC and token transfer transactions will
+ * resolve to TOKEN_WAS_DELETED.
+ *
+ * For NFTs, you cannot delete a specific NFT. You can delete the class of the NFT specified by the token ID after you
+ * have burned all associated NFTs associated with the token class
+ *
+ * Transaction Signing Requirements:
+ *  - Admin key
+ *  - Transaction fee payer account key
+ */
+class TokenDeleteTransaction : public Transaction<TokenDeleteTransaction>
+{
+public:
+  TokenDeleteTransaction() = default;
+
+  /**
+   * Construct from a TransactionBody protobuf object.
+   *
+   * @param transactionBody The TransactionBody protobuf object from which to construct.
+   * @throws std::invalid_argument If the input TransactionBody does not represent a TokenDelete transaction.
+   */
+  explicit TokenDeleteTransaction(const proto::TransactionBody& transactionBody);
+
+  /**
+   * Set the ID of the token to delete.
+   *
+   * @param tokenId The ID of the token to delete.
+   * @return A reference to this TokenDeleteTransaction object with the newly-set token ID.
+   * @throws IllegalStateException If this TokenDeleteTransaction is frozen.
+   */
+  TokenDeleteTransaction& setTokenId(const TokenId& tokenId);
+
+  /**
+   * Get the ID of the token this TokenDeleteTransaction is currently configured to delete.
+   *
+   * @return The ID of the account this TokenDeleteTransaction is currently configured to delete. Uninitialized if no
+   *         token ID has been set.
+   */
+  [[nodiscard]] inline std::optional<TokenId> getTokenId() const { return mTokenId; }
+
+private:
+  /**
+   * Derived from Executable. Construct a Transaction protobuf object from this TokenDeleteTransaction object.
+   *
+   * @param client The Client trying to construct this TokenDeleteTransaction.
+   * @param node   The Node to which this TokenDeleteTransaction will be sent. This is unused.
+   * @return A Transaction protobuf object filled with this TokenDeleteTransaction object's data.
+   * @throws UninitializedException If the input client has no operator with which to sign this
+   *                                TokenDeleteTransaction.
+   */
+  [[nodiscard]] proto::Transaction makeRequest(const Client& client,
+                                               const std::shared_ptr<internal::Node>& /*node*/) const override;
+
+  /**
+   * Derived from Executable. Submit this TokenDeleteTransaction to a Node.
+   *
+   * @param client   The Client submitting this TokenDeleteTransaction.
+   * @param deadline The deadline for submitting this TokenDeleteTransaction.
+   * @param node     Pointer to the Node to which this TokenDeleteTransaction should be submitted.
+   * @param response Pointer to the TransactionResponse protobuf object that gRPC should populate with the response
+   *                 information from the gRPC server.
+   * @return The gRPC status of the submission.
+   */
+  [[nodiscard]] grpc::Status submitRequest(const Client& client,
+                                           const std::chrono::system_clock::time_point& deadline,
+                                           const std::shared_ptr<internal::Node>& node,
+                                           proto::TransactionResponse* response) const override;
+
+  /**
+   * Build a TokenDeleteTransactionBody protobuf object from this TokenDeleteTransaction object.
+   *
+   * @return A pointer to a TokenDeleteTransactionBody protobuf object filled with this TokenDeleteTransaction
+   *         object's data.
+   */
+  [[nodiscard]] proto::TokenDeleteTransactionBody* build() const;
+
+  /**
+   * The ID of the token to delete.
+   */
+  std::optional<TokenId> mTokenId;
+};
+
+} // namespace Hedera
+
+#endif // HEDERA_SDK_CPP_TOKEN_DELETE_TRANSACTION_H_

--- a/sdk/main/include/Transaction.h
+++ b/sdk/main/include/Transaction.h
@@ -50,6 +50,7 @@ class FileCreateTransaction;
 class FileDeleteTransaction;
 class FileUpdateTransaction;
 class PrivateKey;
+class TokenCreateTransaction;
 class TokenDeleteTransaction;
 class TransactionResponse;
 class TransferTransaction;
@@ -122,6 +123,7 @@ public:
                                               EthereumTransaction,
                                               FileUpdateTransaction,
                                               FileAppendTransaction,
+                                              TokenCreateTransaction,
                                               TokenDeleteTransaction>>
   fromBytes(const std::vector<std::byte>& bytes);
 

--- a/sdk/main/include/Transaction.h
+++ b/sdk/main/include/Transaction.h
@@ -50,6 +50,7 @@ class FileCreateTransaction;
 class FileDeleteTransaction;
 class FileUpdateTransaction;
 class PrivateKey;
+class TokenDeleteTransaction;
 class TransactionResponse;
 class TransferTransaction;
 }
@@ -120,7 +121,8 @@ public:
                                               ContractUpdateTransaction,
                                               EthereumTransaction,
                                               FileUpdateTransaction,
-                                              FileAppendTransaction>>
+                                              FileAppendTransaction,
+                                              TokenDeleteTransaction>>
   fromBytes(const std::vector<std::byte>& bytes);
 
   /**

--- a/sdk/main/src/Executable.cc
+++ b/sdk/main/src/Executable.cc
@@ -47,6 +47,7 @@
 #include "FileInfo.h"
 #include "FileInfoQuery.h"
 #include "FileUpdateTransaction.h"
+#include "TokenDeleteTransaction.h"
 #include "TransactionReceipt.h"
 #include "TransactionReceiptQuery.h"
 #include "TransactionRecord.h"
@@ -345,6 +346,7 @@ template class Executable<FileCreateTransaction, proto::Transaction, proto::Tran
 template class Executable<FileDeleteTransaction, proto::Transaction, proto::TransactionResponse, TransactionResponse>;
 template class Executable<FileInfoQuery, proto::Query, proto::Response, FileInfo>;
 template class Executable<FileUpdateTransaction, proto::Transaction, proto::TransactionResponse, TransactionResponse>;
+template class Executable<TokenDeleteTransaction, proto::Transaction, proto::TransactionResponse, TransactionResponse>;
 template class Executable<TransactionReceiptQuery, proto::Query, proto::Response, TransactionReceipt>;
 template class Executable<TransactionRecordQuery, proto::Query, proto::Response, TransactionRecord>;
 template class Executable<TransferTransaction, proto::Transaction, proto::TransactionResponse, TransactionResponse>;

--- a/sdk/main/src/TokenDeleteTransaction.cc
+++ b/sdk/main/src/TokenDeleteTransaction.cc
@@ -1,0 +1,88 @@
+/*-
+ *
+ * Hedera C++ SDK
+ *
+ * Copyright (C) 2020 - 2022 Hedera Hashgraph, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+#include "TokenDeleteTransaction.h"
+#include "impl/Node.h"
+
+#include <grpcpp/client_context.h>
+#include <proto/token_delete.pb.h>
+#include <proto/transaction.pb.h>
+#include <stdexcept>
+
+namespace Hedera
+{
+//-----
+TokenDeleteTransaction::TokenDeleteTransaction(const proto::TransactionBody& transactionBody)
+  : Transaction<TokenDeleteTransaction>(transactionBody)
+{
+  if (!transactionBody.has_tokendeletion())
+  {
+    throw std::invalid_argument("Transaction body doesn't contain TokenDelete data");
+  }
+
+  const proto::TokenDeleteTransactionBody& body = transactionBody.tokendeletion();
+
+  if (body.has_token())
+  {
+    mTokenId = TokenId::fromProtobuf(body.token());
+  }
+}
+
+//-----
+TokenDeleteTransaction& TokenDeleteTransaction::setTokenId(const TokenId& tokenId)
+{
+  requireNotFrozen();
+  mTokenId = tokenId;
+  return *this;
+}
+
+//-----
+proto::Transaction TokenDeleteTransaction::makeRequest(const Client& client,
+                                                       const std::shared_ptr<internal::Node>&) const
+{
+  proto::TransactionBody transactionBody = generateTransactionBody(client);
+  transactionBody.set_allocated_tokendeletion(build());
+
+  return signTransaction(transactionBody, client);
+}
+
+//-----
+grpc::Status TokenDeleteTransaction::submitRequest(const Client& client,
+                                                   const std::chrono::system_clock::time_point& deadline,
+                                                   const std::shared_ptr<internal::Node>& node,
+                                                   proto::TransactionResponse* response) const
+{
+  return node->submitTransaction(
+    proto::TransactionBody::DataCase::kTokenDeletion, makeRequest(client, node), deadline, response);
+}
+
+//-----
+proto::TokenDeleteTransactionBody* TokenDeleteTransaction::build() const
+{
+  auto body = std::make_unique<proto::TokenDeleteTransactionBody>();
+
+  if (mTokenId.has_value())
+  {
+    body->set_allocated_token(mTokenId->toProtobuf().release());
+  }
+
+  return body.release();
+}
+
+} // namespace Hedera

--- a/sdk/main/src/Transaction.cc
+++ b/sdk/main/src/Transaction.cc
@@ -36,6 +36,7 @@
 #include "FileUpdateTransaction.h"
 #include "PrivateKey.h"
 #include "Status.h"
+#include "TokenDeleteTransaction.h"
 #include "TransactionId.h"
 #include "TransactionResponse.h"
 #include "TransferTransaction.h"
@@ -71,7 +72,8 @@ std::pair<int,
                        ContractUpdateTransaction,
                        EthereumTransaction,
                        FileUpdateTransaction,
-                       FileAppendTransaction>>
+                       FileAppendTransaction,
+                       TokenDeleteTransaction>>
 Transaction<SdkRequestType>::fromBytes(const std::vector<std::byte>& bytes)
 {
   proto::TransactionBody txBody;
@@ -143,6 +145,8 @@ Transaction<SdkRequestType>::fromBytes(const std::vector<std::byte>& bytes)
       return { 13, FileUpdateTransaction(txBody) };
     case proto::TransactionBody::kFileAppend:
       return { 14, FileAppendTransaction(txBody) };
+    case proto::TransactionBody::kTokenDeletion:
+      return { 15, TokenDeleteTransaction(txBody) };
     default:
       throw std::invalid_argument("Type of transaction cannot be determined from input bytes");
   }
@@ -458,6 +462,7 @@ template class Transaction<FileAppendTransaction>;
 template class Transaction<FileCreateTransaction>;
 template class Transaction<FileDeleteTransaction>;
 template class Transaction<FileUpdateTransaction>;
+template class Transaction<TokenDeleteTransaction>;
 template class Transaction<TransferTransaction>;
 
 } // namespace Hedera

--- a/sdk/main/src/Transaction.cc
+++ b/sdk/main/src/Transaction.cc
@@ -74,6 +74,7 @@ std::pair<int,
                        EthereumTransaction,
                        FileUpdateTransaction,
                        FileAppendTransaction,
+                       TokenCreateTransaction,
                        TokenDeleteTransaction>>
 Transaction<SdkRequestType>::fromBytes(const std::vector<std::byte>& bytes)
 {
@@ -146,8 +147,10 @@ Transaction<SdkRequestType>::fromBytes(const std::vector<std::byte>& bytes)
       return { 13, FileUpdateTransaction(txBody) };
     case proto::TransactionBody::kFileAppend:
       return { 14, FileAppendTransaction(txBody) };
+    case proto::TransactionBody::kTokenCreation:
+      return { 15, TokenCreateTransaction(txBody) };
     case proto::TransactionBody::kTokenDeletion:
-      return { 15, TokenDeleteTransaction(txBody) };
+      return { 16, TokenDeleteTransaction(txBody) };
     default:
       throw std::invalid_argument("Type of transaction cannot be determined from input bytes");
   }

--- a/sdk/main/src/impl/Node.cc
+++ b/sdk/main/src/impl/Node.cc
@@ -192,6 +192,8 @@ grpc::Status Node::submitTransaction(proto::TransactionBody::DataCase funcEnum,
       return mFileStub->updateFile(&context, transaction, response);
     case proto::TransactionBody::DataCase::kTokenCreation:
       return mTokenStub->createToken(&context, transaction, response);
+    case proto::TransactionBody::DataCase::kTokenDeletion:
+      return mTokenStub->deleteToken(&context, transaction, response);
     default:
       // This should never happen
       throw std::invalid_argument("Unrecognized gRPC transaction method case");

--- a/sdk/tests/integration/CMakeLists.txt
+++ b/sdk/tests/integration/CMakeLists.txt
@@ -25,6 +25,7 @@ add_executable(${TEST_PROJECT_NAME}
         FileUpdateTransactionIntegrationTests.cc
         JSONIntegrationTest.cc
         TokenCreateTransactionIntegrationTests.cc
+        TokenDeleteTransactionIntegrationTests.cc
         TransactionIntegrationTest.cc
         TransactionReceiptIntegrationTest.cc
         TransactionReceiptQueryIntegrationTest.cc

--- a/sdk/tests/integration/TokenCreateTransactionIntegrationTests.cc
+++ b/sdk/tests/integration/TokenCreateTransactionIntegrationTests.cc
@@ -28,6 +28,7 @@
 #include "ED25519PrivateKey.h"
 #include "PrivateKey.h"
 #include "TokenCreateTransaction.h"
+#include "TokenDeleteTransaction.h"
 #include "TransactionReceipt.h"
 #include "TransactionResponse.h"
 #include "exceptions/PrecheckStatusException.h"
@@ -75,7 +76,8 @@ TEST_F(TokenCreateTransactionIntegrationTest, ExecuteTokenCreateTransaction)
   EXPECT_NO_THROW(tokenId = txReceipt.getTokenId().value());
 
   // Clean up
-  // TODO: TokenDeleteTransaction
+  ASSERT_NO_THROW(txReceipt =
+                    TokenDeleteTransaction().setTokenId(tokenId).execute(getTestClient()).getReceipt(getTestClient()));
 }
 
 //-----
@@ -93,9 +95,6 @@ TEST_F(TokenCreateTransactionIntegrationTest, CanCreateTokenWithMinimalPropertie
   // Then
   TokenId tokenId;
   EXPECT_NO_THROW(tokenId = txReceipt.getTokenId().value());
-
-  // Clean up
-  // TODO: TokenDeleteTransaction
 }
 
 //-----
@@ -213,9 +212,6 @@ TEST_F(TokenCreateTransactionIntegrationTest, CanCreateTokenWithCustomFees)
   // Then
   TokenId tokenId;
   EXPECT_NO_THROW(tokenId = txReceipt.getTokenId().value());
-
-  // Clean up
-  // TODO: TokenDeleteTransaction
 }
 
 //-----
@@ -274,7 +270,8 @@ TEST_F(TokenCreateTransactionIntegrationTest, CanCreateTokenWithListOfTenCustomF
   EXPECT_NO_THROW(tokenId = txReceipt.getTokenId().value());
 
   // Clean up
-  // TODO: TokenDeleteTransaction
+  ASSERT_NO_THROW(txReceipt =
+                    TokenDeleteTransaction().setTokenId(tokenId).execute(getTestClient()).getReceipt(getTestClient()));
 }
 
 //-----
@@ -313,7 +310,8 @@ TEST_F(TokenCreateTransactionIntegrationTest, CanCreateTokenWithListOfTenCustomF
   EXPECT_NO_THROW(tokenId = txReceipt.getTokenId().value());
 
   // Clean up
-  // TODO: TokenDeleteTransaction
+  ASSERT_NO_THROW(txReceipt =
+                    TokenDeleteTransaction().setTokenId(tokenId).execute(getTestClient()).getReceipt(getTestClient()));
 }
 
 //-----
@@ -426,7 +424,8 @@ TEST_F(TokenCreateTransactionIntegrationTest, CanCreateNft)
   EXPECT_NO_THROW(tokenId = txReceipt.getTokenId().value());
 
   // Clean up
-  // TODO: TokenDeleteTransaction
+  ASSERT_NO_THROW(txReceipt =
+                    TokenDeleteTransaction().setTokenId(tokenId).execute(getTestClient()).getReceipt(getTestClient()));
 }
 
 //-----
@@ -464,5 +463,6 @@ TEST_F(TokenCreateTransactionIntegrationTest, CanCreateNftWithRoyaltyFee)
   EXPECT_NO_THROW(tokenId = txReceipt.getTokenId().value());
 
   // Clean up
-  // TODO: TokenDeleteTransaction
+  ASSERT_NO_THROW(txReceipt =
+                    TokenDeleteTransaction().setTokenId(tokenId).execute(getTestClient()).getReceipt(getTestClient()));
 }

--- a/sdk/tests/unit/CMakeLists.txt
+++ b/sdk/tests/unit/CMakeLists.txt
@@ -58,6 +58,7 @@ add_executable(${TEST_PROJECT_NAME}
         NodeAddressTest.cc
         StakingInfoTest.cc
         TokenAllowanceTest.cc
+        TokenDeleteTransactionTest.cc
         TokenIdTest.cc
         TokenNftAllowanceTest.cc
         TokenNftRemoveAllowanceTest.cc

--- a/sdk/tests/unit/TokenDeleteTransactionTest.cc
+++ b/sdk/tests/unit/TokenDeleteTransactionTest.cc
@@ -1,0 +1,92 @@
+/*-
+ *
+ * Hedera C++ SDK
+ *
+ * Copyright (C) 2020 - 2022 Hedera Hashgraph, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+#include "TokenDeleteTransaction.h"
+#include "Client.h"
+#include "ECDSAsecp256k1PrivateKey.h"
+#include "exceptions/IllegalStateException.h"
+
+#include <gtest/gtest.h>
+#include <proto/transaction_body.pb.h>
+
+using namespace Hedera;
+
+class TokenDeleteTransactionTest : public ::testing::Test
+{
+protected:
+  void SetUp() override { mClient.setOperator(AccountId(), ECDSAsecp256k1PrivateKey::generatePrivateKey().get()); }
+
+  [[nodiscard]] inline const Client& getTestClient() const { return mClient; }
+  [[nodiscard]] inline const TokenId& getTestTokenId() const { return mTestTokenId; }
+
+private:
+  Client mClient;
+  const TokenId mTestTokenId = TokenId(1ULL);
+};
+
+//-----
+TEST_F(TokenDeleteTransactionTest, ConstructTokenDeleteTransaction)
+{
+  // Given / When
+  TokenDeleteTransaction transaction;
+
+  // Then
+  EXPECT_FALSE(transaction.getTokenId().has_value());
+}
+
+//-----
+TEST_F(TokenDeleteTransactionTest, ConstructTokenDeleteTransactionFromTransactionBodyProtobuf)
+{
+  // Given
+  auto body = std::make_unique<proto::TokenDeleteTransactionBody>();
+  body->set_allocated_token(getTestTokenId().toProtobuf().release());
+
+  proto::TransactionBody txBody;
+  txBody.set_allocated_tokendeletion(body.release());
+
+  // When
+  const TokenDeleteTransaction tokenDeleteTransaction(txBody);
+
+  // Then
+  EXPECT_EQ(tokenDeleteTransaction.getTokenId(), getTestTokenId());
+}
+
+//-----
+TEST_F(TokenDeleteTransactionTest, GetSetTokenId)
+{
+  // Given
+  TokenDeleteTransaction transaction;
+
+  // When
+  EXPECT_NO_THROW(transaction.setTokenId(getTestTokenId()));
+
+  // Then
+  EXPECT_EQ(transaction.getTokenId(), getTestTokenId());
+}
+
+//-----
+TEST_F(TokenDeleteTransactionTest, GetSetTokenIdFrozen)
+{
+  // Given
+  TokenDeleteTransaction transaction;
+  ASSERT_NO_THROW(transaction.freezeWith(getTestClient()));
+
+  // When / Then
+  EXPECT_THROW(transaction.setTokenId(getTestTokenId()), IllegalStateException);
+}

--- a/sdk/tests/unit/TransactionTest.cc
+++ b/sdk/tests/unit/TransactionTest.cc
@@ -32,6 +32,7 @@
 #include "FileCreateTransaction.h"
 #include "FileDeleteTransaction.h"
 #include "FileUpdateTransaction.h"
+#include "TokenDeleteTransaction.h"
 #include "TransferTransaction.h"
 #include "impl/Utilities.h"
 
@@ -928,4 +929,62 @@ TEST_F(TransactionTest, FileAppendTransactionFromTransactionBytes)
   // Then
   ASSERT_EQ(index, 14);
   EXPECT_NO_THROW(const FileAppendTransaction fileAppendTransaction = std::get<14>(txVariant));
+}
+
+TEST_F(TransactionTest, TokenDeleteTransactionFromTransactionBodyBytes)
+{
+  // Given
+  proto::TransactionBody txBody;
+  txBody.set_allocated_tokendeletion(new proto::TokenDeleteTransactionBody);
+
+  // When
+  const auto [index, txVariant] =
+    Transaction<TokenDeleteTransaction>::fromBytes(internal::Utilities::stringToByteVector(txBody.SerializeAsString()));
+
+  // Then
+  ASSERT_EQ(index, 15);
+  EXPECT_NO_THROW(const TokenDeleteTransaction tokenDeleteTransaction = std::get<15>(txVariant));
+}
+
+//-----
+TEST_F(TransactionTest, TokenDeleteTransactionFromSignedTransactionBytes)
+{
+  // Given
+  proto::TransactionBody txBody;
+  txBody.set_allocated_tokendeletion(new proto::TokenDeleteTransactionBody);
+
+  proto::SignedTransaction signedTx;
+  signedTx.set_bodybytes(txBody.SerializeAsString());
+  // SignatureMap not required
+
+  // When
+  const auto [index, txVariant] =
+    Transaction<TokenDeleteTransaction>::fromBytes(internal::Utilities::stringToByteVector(txBody.SerializeAsString()));
+
+  // Then
+  ASSERT_EQ(index, 15);
+  EXPECT_NO_THROW(const TokenDeleteTransaction tokenDeleteTransaction = std::get<15>(txVariant));
+}
+
+//-----
+TEST_F(TransactionTest, TokenDeleteTransactionFromTransactionBytes)
+{
+  // Given
+  proto::TransactionBody txBody;
+  txBody.set_allocated_tokendeletion(new proto::TokenDeleteTransactionBody);
+
+  proto::SignedTransaction signedTx;
+  signedTx.set_bodybytes(txBody.SerializeAsString());
+  // SignatureMap not required
+
+  proto::Transaction tx;
+  tx.set_signedtransactionbytes(signedTx.SerializeAsString());
+
+  // When
+  const auto [index, txVariant] =
+    Transaction<TokenDeleteTransaction>::fromBytes(internal::Utilities::stringToByteVector(txBody.SerializeAsString()));
+
+  // Then
+  ASSERT_EQ(index, 15);
+  EXPECT_NO_THROW(const TokenDeleteTransaction tokenDeleteTransaction = std::get<15>(txVariant));
 }

--- a/sdk/tests/unit/TransactionTest.cc
+++ b/sdk/tests/unit/TransactionTest.cc
@@ -32,6 +32,7 @@
 #include "FileCreateTransaction.h"
 #include "FileDeleteTransaction.h"
 #include "FileUpdateTransaction.h"
+#include "TokenCreateTransaction.h"
 #include "TokenDeleteTransaction.h"
 #include "TransferTransaction.h"
 #include "impl/Utilities.h"
@@ -931,6 +932,64 @@ TEST_F(TransactionTest, FileAppendTransactionFromTransactionBytes)
   EXPECT_NO_THROW(const FileAppendTransaction fileAppendTransaction = std::get<14>(txVariant));
 }
 
+TEST_F(TransactionTest, TokenCreateTransactionFromTransactionBodyBytes)
+{
+  // Given
+  proto::TransactionBody txBody;
+  txBody.set_allocated_tokencreation(new proto::TokenCreateTransactionBody);
+
+  // When
+  const auto [index, txVariant] =
+    Transaction<TokenCreateTransaction>::fromBytes(internal::Utilities::stringToByteVector(txBody.SerializeAsString()));
+
+  // Then
+  ASSERT_EQ(index, 15);
+  EXPECT_NO_THROW(const TokenCreateTransaction tokenCreateTransaction = std::get<15>(txVariant));
+}
+
+//-----
+TEST_F(TransactionTest, TokenCreateTransactionFromSignedTransactionBytes)
+{
+  // Given
+  proto::TransactionBody txBody;
+  txBody.set_allocated_tokencreation(new proto::TokenCreateTransactionBody);
+
+  proto::SignedTransaction signedTx;
+  signedTx.set_bodybytes(txBody.SerializeAsString());
+  // SignatureMap not required
+
+  // When
+  const auto [index, txVariant] =
+    Transaction<TokenCreateTransaction>::fromBytes(internal::Utilities::stringToByteVector(txBody.SerializeAsString()));
+
+  // Then
+  ASSERT_EQ(index, 15);
+  EXPECT_NO_THROW(const TokenCreateTransaction tokenCreateTransaction = std::get<15>(txVariant));
+}
+
+//-----
+TEST_F(TransactionTest, TokenCreateTransactionFromTransactionBytes)
+{
+  // Given
+  proto::TransactionBody txBody;
+  txBody.set_allocated_tokencreation(new proto::TokenCreateTransactionBody);
+
+  proto::SignedTransaction signedTx;
+  signedTx.set_bodybytes(txBody.SerializeAsString());
+  // SignatureMap not required
+
+  proto::Transaction tx;
+  tx.set_signedtransactionbytes(signedTx.SerializeAsString());
+
+  // When
+  const auto [index, txVariant] =
+    Transaction<TokenCreateTransaction>::fromBytes(internal::Utilities::stringToByteVector(txBody.SerializeAsString()));
+
+  // Then
+  ASSERT_EQ(index, 15);
+  EXPECT_NO_THROW(const TokenCreateTransaction tokenCreateTransaction = std::get<15>(txVariant));
+}
+
 TEST_F(TransactionTest, TokenDeleteTransactionFromTransactionBodyBytes)
 {
   // Given
@@ -942,8 +1001,8 @@ TEST_F(TransactionTest, TokenDeleteTransactionFromTransactionBodyBytes)
     Transaction<TokenDeleteTransaction>::fromBytes(internal::Utilities::stringToByteVector(txBody.SerializeAsString()));
 
   // Then
-  ASSERT_EQ(index, 15);
-  EXPECT_NO_THROW(const TokenDeleteTransaction tokenDeleteTransaction = std::get<15>(txVariant));
+  ASSERT_EQ(index, 16);
+  EXPECT_NO_THROW(const TokenDeleteTransaction tokenDeleteTransaction = std::get<16>(txVariant));
 }
 
 //-----
@@ -962,8 +1021,8 @@ TEST_F(TransactionTest, TokenDeleteTransactionFromSignedTransactionBytes)
     Transaction<TokenDeleteTransaction>::fromBytes(internal::Utilities::stringToByteVector(txBody.SerializeAsString()));
 
   // Then
-  ASSERT_EQ(index, 15);
-  EXPECT_NO_THROW(const TokenDeleteTransaction tokenDeleteTransaction = std::get<15>(txVariant));
+  ASSERT_EQ(index, 16);
+  EXPECT_NO_THROW(const TokenDeleteTransaction tokenDeleteTransaction = std::get<16>(txVariant));
 }
 
 //-----
@@ -985,6 +1044,6 @@ TEST_F(TransactionTest, TokenDeleteTransactionFromTransactionBytes)
     Transaction<TokenDeleteTransaction>::fromBytes(internal::Utilities::stringToByteVector(txBody.SerializeAsString()));
 
   // Then
-  ASSERT_EQ(index, 15);
-  EXPECT_NO_THROW(const TokenDeleteTransaction tokenDeleteTransaction = std::get<15>(txVariant));
+  ASSERT_EQ(index, 16);
+  EXPECT_NO_THROW(const TokenDeleteTransaction tokenDeleteTransaction = std::get<16>(txVariant));
 }


### PR DESCRIPTION
**Description**:
This PR implements the APIs associated with the `TokenDeleteTransaction`.

This also adds `TokenCreateTransaction` to `Transaction::fromBytes()`, as that was missed in #391.

**Related issue(s)**:

Fixes #376 

**Checklist**

- [x] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
