### PR TITLE
Implement `TokenAssociateTransaction`

### DIFF
--- a/sdk/main/CMakeLists.txt
+++ b/sdk/main/CMakeLists.txt
@@ -69,6 +69,7 @@ add_library(${PROJECT_NAME} STATIC
         src/StakingInfo.cc
         src/Status.cc
         src/TokenAllowance.cc
+        src/TokenAssociateTransaction.cc
         src/TokenCreateTransaction.cc
         src/TokenId.cc
         src/TokenNftAllowance.cc

--- a/sdk/main/include/TokenAssociateTransaction.h
+++ b/sdk/main/include/TokenAssociateTransaction.h
@@ -24,6 +24,7 @@
 #include "TokenId.h"
 #include "Transaction.h"
 
+#include <optional>
 #include <vector>
 
 namespace proto
@@ -94,9 +95,10 @@ public:
   /**
    * Get the ID of the account to be associated with the provided tokens.
    *
-   * @return The ID of the account to be associated with the provided tokens.
+   * @return The ID of the account to be associated with the provided tokens. Returns uninitialized if no account ID has
+   *         been set.
    */
-  [[nodiscard]] inline AccountId getAccountId() const { return mAccountId; }
+  [[nodiscard]] inline std::optional<AccountId> getAccountId() const { return mAccountId; }
 
   /**
    * Get the IDs of the tokens to be associated with the provided account.
@@ -144,7 +146,7 @@ private:
   /**
    * The ID of the account to be associated with the provided tokens.
    */
-  AccountId mAccountId;
+  std::optional<AccountId> mAccountId;
 
   /**
    * The IDs of the tokens to be associated with the provided account.

--- a/sdk/main/include/TokenAssociateTransaction.h
+++ b/sdk/main/include/TokenAssociateTransaction.h
@@ -1,0 +1,157 @@
+/*-
+ *
+ * Hedera C++ SDK
+ *
+ * Copyright (C) 2020 - 2022 Hedera Hashgraph, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+#ifndef HEDERA_SDK_CPP_TOKEN_ASSOCIATE_TRANSACTION_H_
+#define HEDERA_SDK_CPP_TOKEN_ASSOCIATE_TRANSACTION_H_
+
+#include "AccountId.h"
+#include "TokenId.h"
+#include "Transaction.h"
+
+#include <vector>
+
+namespace proto
+{
+class TokenAssociateTransactionBody;
+class TransactionBody;
+}
+
+namespace Hedera
+{
+/**
+ * Associates the provided Hedera account with the provided Hedera token(s). Hedera accounts must be associated with a
+ * fungible or non-fungible token first before you can transfer tokens to that account. When you transfer a custom
+ * fungible or non-fungible token to the alias account ID, the token association step is skipped and the account will
+ * automatically be associated with the token upon creation. In the case of a NON_FUNGIBLE token type, once an account
+ * is associated, it can hold any number of NFTs (serial numbers) of that token type. The Hedera account that is
+ * associated with a token is required to sign the transaction.
+ *
+ *  - If the provided account is not found, the transaction will resolve to INVALID_ACCOUNT_ID.
+ *  - If the provided account has been deleted, the transaction will resolve to ACCOUNT_DELETED.
+ *  - If any of the provided tokens is not found, the transaction will resolve to INVALID_TOKEN_REF.
+ *  - If any of the provided tokens has been deleted, the transaction will resolve to TOKEN_WAS_DELETED.
+ *  - If an association between the provided account and any of the tokens already exists, the transaction will resolve
+ *    to TOKEN_ALREADY_ASSOCIATED_TO_ACCOUNT.
+ *  - If the provided account's associations count exceeds the constraint of maximum token associations per account, the
+ *    transaction will resolve to TOKENS_PER_ACCOUNT_LIMIT_EXCEEDED.
+ *  - On success, associations between the provided account and tokens are made and the account is ready to interact
+ *    with the tokens.
+ *
+ * There is currently no limit on the number of token IDs that can be associated with an account (reference HIP-367).
+ * Still, you can see TOKENS_PER_ACCOUNT_LIMIT_EXCEEDED responses for pre-HIP-367 transactions.
+ *
+ * Transaction Signing Requirements:
+ *  - The key of the account to which the token is being associated
+ *  - Transaction fee payer account key
+ */
+class TokenAssociateTransaction : public Transaction<TokenAssociateTransaction>
+{
+public:
+  TokenAssociateTransaction() = default;
+
+  /**
+   * Construct from a TransactionBody protobuf object.
+   *
+   * @param transactionBody The TransactionBody protobuf object from which to construct.
+   * @throws std::invalid_argument If the input TransactionBody does not represent a TokenAssociate transaction.
+   */
+  explicit TokenAssociateTransaction(const proto::TransactionBody& transactionBody);
+
+  /**
+   * Set the ID of the account to be associated with the provided tokens.
+   *
+   * @param accountId The ID of the account to be associated.
+   * @return A reference to this TokenAssociateTransaction object with the newly-set account ID.
+   * @throws IllegalStateException If this TokenAssociateTransaction is frozen.
+   */
+  TokenAssociateTransaction& setAccountId(const AccountId& accountId);
+
+  /**
+   * Set the IDs of the tokens to be associated with the provided account.
+   *
+   * @param tokenIds The IDs of the tokens to be associated.
+   * @return A reference to this TokenAssociateTransaction object with the newly-set token IDs.
+   * @throws IllegalStateException If this TokenAssociateTransaction is frozen.
+   */
+  TokenAssociateTransaction& setTokenIds(const std::vector<TokenId>& tokenIds);
+
+  /**
+   * Get the ID of the account to be associated with the provided tokens.
+   *
+   * @return The ID of the account to be associated with the provided tokens.
+   */
+  [[nodiscard]] inline AccountId getAccountId() const { return mAccountId; }
+
+  /**
+   * Get the IDs of the tokens to be associated with the provided account.
+   *
+   * @return The IDs of the tokens to be associated with the provided account.
+   */
+  [[nodiscard]] inline std::vector<TokenId> getTokenIds() const { return mTokenIds; }
+
+private:
+  /**
+   * Derived from Executable. Construct a Transaction protobuf object from this TokenAssociateTransaction object.
+   *
+   * @param client The Client trying to construct this TokenAssociateTransaction.
+   * @param node   The Node to which this TokenAssociateTransaction will be sent. This is unused.
+   * @return A Transaction protobuf object filled with this TokenAssociateTransaction object's data.
+   * @throws UninitializedException If the input client has no operator with which to sign this
+   *                                TokenAssociateTransaction.
+   */
+  [[nodiscard]] proto::Transaction makeRequest(const Client& client,
+                                               const std::shared_ptr<internal::Node>& /*node*/) const override;
+
+  /**
+   * Derived from Executable. Submit this TokenAssociateTransaction to a Node.
+   *
+   * @param client   The Client submitting this TokenAssociateTransaction.
+   * @param deadline The deadline for submitting this TokenAssociateTransaction.
+   * @param node     Pointer to the Node to which this TokenAssociateTransaction should be submitted.
+   * @param response Pointer to the TransactionResponse protobuf object that gRPC should populate with the response
+   *                 information from the gRPC server.
+   * @return The gRPC status of the submission.
+   */
+  [[nodiscard]] grpc::Status submitRequest(const Client& client,
+                                           const std::chrono::system_clock::time_point& deadline,
+                                           const std::shared_ptr<internal::Node>& node,
+                                           proto::TransactionResponse* response) const override;
+
+  /**
+   * Build a TokenAssociateTransactionBody protobuf object from this TokenAssociateTransaction object.
+   *
+   * @return A pointer to a TokenAssociateTransactionBody protobuf object filled with this TokenAssociateTransaction
+   *         object's data.
+   */
+  [[nodiscard]] proto::TokenAssociateTransactionBody* build() const;
+
+  /**
+   * The ID of the account to be associated with the provided tokens.
+   */
+  AccountId mAccountId;
+
+  /**
+   * The IDs of the tokens to be associated with the provided account.
+   */
+  std::vector<TokenId> mTokenIds;
+};
+
+} // namespace Hedera
+
+#endif // HEDERA_SDK_CPP_TOKEN_ASSOCIATE_TRANSACTION_H_

--- a/sdk/main/include/Transaction.h
+++ b/sdk/main/include/Transaction.h
@@ -50,6 +50,7 @@ class FileCreateTransaction;
 class FileDeleteTransaction;
 class FileUpdateTransaction;
 class PrivateKey;
+class TokenAssociateTransaction;
 class TransactionResponse;
 class TransferTransaction;
 }
@@ -120,7 +121,8 @@ public:
                                               ContractUpdateTransaction,
                                               EthereumTransaction,
                                               FileUpdateTransaction,
-                                              FileAppendTransaction>>
+                                              FileAppendTransaction,
+                                              TokenAssociateTransaction>>
   fromBytes(const std::vector<std::byte>& bytes);
 
   /**

--- a/sdk/main/src/Executable.cc
+++ b/sdk/main/src/Executable.cc
@@ -47,6 +47,7 @@
 #include "FileInfo.h"
 #include "FileInfoQuery.h"
 #include "FileUpdateTransaction.h"
+#include "TokenAssociateTransaction.h"
 #include "TokenCreateTransaction.h"
 #include "TransactionReceipt.h"
 #include "TransactionReceiptQuery.h"
@@ -346,6 +347,10 @@ template class Executable<FileCreateTransaction, proto::Transaction, proto::Tran
 template class Executable<FileDeleteTransaction, proto::Transaction, proto::TransactionResponse, TransactionResponse>;
 template class Executable<FileInfoQuery, proto::Query, proto::Response, FileInfo>;
 template class Executable<FileUpdateTransaction, proto::Transaction, proto::TransactionResponse, TransactionResponse>;
+template class Executable<TokenAssociateTransaction,
+                          proto::Transaction,
+                          proto::TransactionResponse,
+                          TransactionResponse>;
 template class Executable<TokenCreateTransaction, proto::Transaction, proto::TransactionResponse, TransactionResponse>;
 template class Executable<TransactionReceiptQuery, proto::Query, proto::Response, TransactionReceipt>;
 template class Executable<TransactionRecordQuery, proto::Query, proto::Response, TransactionRecord>;

--- a/sdk/main/src/TokenAssociateTransaction.cc
+++ b/sdk/main/src/TokenAssociateTransaction.cc
@@ -89,7 +89,11 @@ grpc::Status TokenAssociateTransaction::submitRequest(const Client& client,
 proto::TokenAssociateTransactionBody* TokenAssociateTransaction::build() const
 {
   auto body = std::make_unique<proto::TokenAssociateTransactionBody>();
-  body->set_allocated_account(mAccountId.toProtobuf().release());
+
+  if (mAccountId.has_value())
+  {
+    body->set_allocated_account(mAccountId->toProtobuf().release());
+  }
 
   for (const auto& token : mTokenIds)
   {

--- a/sdk/main/src/TokenAssociateTransaction.cc
+++ b/sdk/main/src/TokenAssociateTransaction.cc
@@ -1,0 +1,102 @@
+/*-
+ *
+ * Hedera C++ SDK
+ *
+ * Copyright (C) 2020 - 2022 Hedera Hashgraph, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+#include "TokenAssociateTransaction.h"
+#include "impl/Node.h"
+
+#include <grpcpp/client_context.h>
+#include <proto/token_associate.pb.h>
+#include <proto/transaction.pb.h>
+#include <stdexcept>
+
+namespace Hedera
+{
+//-----
+TokenAssociateTransaction::TokenAssociateTransaction(const proto::TransactionBody& transactionBody)
+  : Transaction<TokenAssociateTransaction>(transactionBody)
+{
+  if (!transactionBody.has_tokenassociate())
+  {
+    throw std::invalid_argument("Transaction body doesn't contain TokenAssociate data");
+  }
+
+  const proto::TokenAssociateTransactionBody& body = transactionBody.tokenassociate();
+
+  if (body.has_account())
+  {
+    mAccountId = AccountId::fromProtobuf(body.account());
+  }
+
+  for (int i = 0; i < body.tokens_size(); ++i)
+  {
+    mTokenIds.push_back(TokenId::fromProtobuf(body.tokens(i)));
+  }
+}
+
+//-----
+TokenAssociateTransaction& TokenAssociateTransaction::setAccountId(const AccountId& accountId)
+{
+  requireNotFrozen();
+  mAccountId = accountId;
+  return *this;
+}
+
+//-----
+TokenAssociateTransaction& TokenAssociateTransaction::setTokenIds(const std::vector<TokenId>& tokenIds)
+{
+  requireNotFrozen();
+  mTokenIds = tokenIds;
+  return *this;
+}
+
+//-----
+proto::Transaction TokenAssociateTransaction::makeRequest(const Client& client,
+                                                          const std::shared_ptr<internal::Node>&) const
+{
+  proto::TransactionBody transactionBody = generateTransactionBody(client);
+  transactionBody.set_allocated_tokenassociate(build());
+
+  return signTransaction(transactionBody, client);
+}
+
+//-----
+grpc::Status TokenAssociateTransaction::submitRequest(const Client& client,
+                                                      const std::chrono::system_clock::time_point& deadline,
+                                                      const std::shared_ptr<internal::Node>& node,
+                                                      proto::TransactionResponse* response) const
+{
+  return node->submitTransaction(
+    proto::TransactionBody::DataCase::kTokenAssociate, makeRequest(client, node), deadline, response);
+}
+
+//-----
+proto::TokenAssociateTransactionBody* TokenAssociateTransaction::build() const
+{
+  auto body = std::make_unique<proto::TokenAssociateTransactionBody>();
+  body->set_allocated_account(mAccountId.toProtobuf().release());
+
+  for (const auto& token : mTokenIds)
+  {
+    *body->add_tokens() = *token.toProtobuf();
+  }
+
+  return body.release();
+}
+
+} // namespace Hedera

--- a/sdk/main/src/Transaction.cc
+++ b/sdk/main/src/Transaction.cc
@@ -36,6 +36,7 @@
 #include "FileUpdateTransaction.h"
 #include "PrivateKey.h"
 #include "Status.h"
+#include "TokenAssociateTransaction.h"
 #include "TokenCreateTransaction.h"
 #include "TransactionId.h"
 #include "TransactionResponse.h"
@@ -72,7 +73,8 @@ std::pair<int,
                        ContractUpdateTransaction,
                        EthereumTransaction,
                        FileUpdateTransaction,
-                       FileAppendTransaction>>
+                       FileAppendTransaction,
+                       TokenAssociateTransaction>>
 Transaction<SdkRequestType>::fromBytes(const std::vector<std::byte>& bytes)
 {
   proto::TransactionBody txBody;
@@ -144,6 +146,8 @@ Transaction<SdkRequestType>::fromBytes(const std::vector<std::byte>& bytes)
       return { 13, FileUpdateTransaction(txBody) };
     case proto::TransactionBody::kFileAppend:
       return { 14, FileAppendTransaction(txBody) };
+    case proto::TransactionBody::kTokenAssociate:
+      return { 15, TokenAssociateTransaction(txBody) };
     default:
       throw std::invalid_argument("Type of transaction cannot be determined from input bytes");
   }
@@ -459,6 +463,7 @@ template class Transaction<FileAppendTransaction>;
 template class Transaction<FileCreateTransaction>;
 template class Transaction<FileDeleteTransaction>;
 template class Transaction<FileUpdateTransaction>;
+template class Transaction<TokenAssociateTransaction>;
 template class Transaction<TokenCreateTransaction>;
 template class Transaction<TransferTransaction>;
 

--- a/sdk/main/src/impl/Node.cc
+++ b/sdk/main/src/impl/Node.cc
@@ -190,6 +190,8 @@ grpc::Status Node::submitTransaction(proto::TransactionBody::DataCase funcEnum,
       return mFileStub->deleteFile(&context, transaction, response);
     case proto::TransactionBody::DataCase::kFileUpdate:
       return mFileStub->updateFile(&context, transaction, response);
+    case proto::TransactionBody::DataCase::kTokenAssociate:
+      return mTokenStub->associateTokens(&context, transaction, response);
     case proto::TransactionBody::DataCase::kTokenCreation:
       return mTokenStub->createToken(&context, transaction, response);
     default:

--- a/sdk/tests/integration/CMakeLists.txt
+++ b/sdk/tests/integration/CMakeLists.txt
@@ -24,6 +24,7 @@ add_executable(${TEST_PROJECT_NAME}
         FileInfoQueryIntegrationTests.cc
         FileUpdateTransactionIntegrationTests.cc
         JSONIntegrationTest.cc
+        TokenAssociateTransactionIntegrationTests.cc
         TokenCreateTransactionIntegrationTests.cc
         TransactionIntegrationTest.cc
         TransactionReceiptIntegrationTest.cc

--- a/sdk/tests/integration/TokenAssociateTransactionIntegrationTests.cc
+++ b/sdk/tests/integration/TokenAssociateTransactionIntegrationTests.cc
@@ -26,6 +26,7 @@
 #include "PrivateKey.h"
 #include "TokenAssociateTransaction.h"
 #include "TokenCreateTransaction.h"
+#include "TokenDeleteTransaction.h"
 #include "TransactionReceipt.h"
 #include "TransactionRecord.h"
 #include "TransactionResponse.h"
@@ -102,7 +103,8 @@ TEST_F(TokenAssociateTransactionIntegrationTest, ExecuteTokenAssociateTransactio
                                                          .sign(accountKey.get())
                                                          .execute(getTestClient())
                                                          .getReceipt(getTestClient()));
-  // TODO: TokenDeleteTransaction
+  ASSERT_NO_THROW(const TransactionReceipt txReceipt =
+                    TokenDeleteTransaction().setTokenId(tokenId).execute(getTestClient()).getReceipt(getTestClient()));
 }
 
 //-----
@@ -212,5 +214,6 @@ TEST_F(TokenAssociateTransactionIntegrationTest, CannotAssociateTokensWhenAccoun
                                                          .sign(accountKey.get())
                                                          .execute(getTestClient())
                                                          .getReceipt(getTestClient()));
-  // TODO: TokenDeleteTransaction
+  ASSERT_NO_THROW(const TransactionReceipt txReceipt =
+                    TokenDeleteTransaction().setTokenId(tokenId).execute(getTestClient()).getReceipt(getTestClient()));
 }

--- a/sdk/tests/integration/TokenAssociateTransactionIntegrationTests.cc
+++ b/sdk/tests/integration/TokenAssociateTransactionIntegrationTests.cc
@@ -1,0 +1,216 @@
+/*-
+ *
+ * Hedera C++ SDK
+ *
+ * Copyright (C) 2020 - 2022 Hedera Hashgraph, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+#include "AccountCreateTransaction.h"
+#include "AccountDeleteTransaction.h"
+#include "AccountId.h"
+#include "BaseIntegrationTest.h"
+#include "Client.h"
+#include "ED25519PrivateKey.h"
+#include "PrivateKey.h"
+#include "TokenAssociateTransaction.h"
+#include "TokenCreateTransaction.h"
+#include "TransactionReceipt.h"
+#include "TransactionRecord.h"
+#include "TransactionResponse.h"
+#include "exceptions/PrecheckStatusException.h"
+#include "exceptions/ReceiptStatusException.h"
+
+#include <gtest/gtest.h>
+
+using namespace Hedera;
+
+class TokenAssociateTransactionIntegrationTest : public BaseIntegrationTest
+{
+};
+
+//-----
+TEST_F(TokenAssociateTransactionIntegrationTest, ExecuteTokenAssociateTransaction)
+{
+  // Given
+  std::shared_ptr<PrivateKey> operatorKey;
+  ASSERT_NO_THROW(
+    operatorKey = std::shared_ptr<PrivateKey>(
+      ED25519PrivateKey::fromString(
+        "302e020100300506032b65700422042091132178e72057a1d7528025956fe39b0b847f200ab59b2fdd367017f3087137")
+        .release()));
+
+  std::shared_ptr<PrivateKey> accountKey;
+  ASSERT_NO_THROW(accountKey = ED25519PrivateKey::generatePrivateKey());
+
+  AccountId accountId;
+  ASSERT_NO_THROW(accountId = AccountCreateTransaction()
+                                .setKey(accountKey.get())
+                                .setInitialBalance(Hbar(1LL))
+                                .execute(getTestClient())
+                                .getReceipt(getTestClient())
+                                .getAccountId()
+                                .value());
+
+  TokenId tokenId;
+  ASSERT_NO_THROW(tokenId = TokenCreateTransaction()
+                              .setTokenName("ffff")
+                              .setTokenSymbol("F")
+                              .setDecimals(3)
+                              .setInitialSupply(100000)
+                              .setTreasuryAccountId(AccountId(2ULL))
+                              .setAdminKey(operatorKey)
+                              .setFreezeKey(operatorKey)
+                              .setWipeKey(operatorKey)
+                              .setKycKey(operatorKey)
+                              .setSupplyKey(operatorKey)
+                              .setFeeScheduleKey(operatorKey)
+                              .execute(getTestClient())
+                              .getReceipt(getTestClient())
+                              .getTokenId()
+                              .value());
+
+  // When
+  TransactionResponse txResponse;
+  EXPECT_NO_THROW(txResponse = TokenAssociateTransaction()
+                                 .setAccountId(accountId)
+                                 .setTokenIds({ tokenId })
+                                 .freezeWith(getTestClient())
+                                 .sign(accountKey.get())
+                                 .execute(getTestClient()));
+
+  // Then
+  const TransactionRecord txRecord = txResponse.getRecord(getTestClient());
+  // TODO: TokenAssociation
+
+  // Clean up
+  ASSERT_NO_THROW(const TransactionReceipt txReceipt = AccountDeleteTransaction()
+                                                         .setDeleteAccountId(accountId)
+                                                         .setTransferAccountId(AccountId(2ULL))
+                                                         .freezeWith(getTestClient())
+                                                         .sign(accountKey.get())
+                                                         .execute(getTestClient())
+                                                         .getReceipt(getTestClient()));
+  // TODO: TokenDeleteTransaction
+}
+
+//-----
+TEST_F(TokenAssociateTransactionIntegrationTest, CanAssociateAccountWithNoTokens)
+{
+  // Given
+  std::shared_ptr<PrivateKey> operatorKey;
+  ASSERT_NO_THROW(
+    operatorKey = std::shared_ptr<PrivateKey>(
+      ED25519PrivateKey::fromString(
+        "302e020100300506032b65700422042091132178e72057a1d7528025956fe39b0b847f200ab59b2fdd367017f3087137")
+        .release()));
+
+  std::shared_ptr<PrivateKey> accountKey;
+  ASSERT_NO_THROW(accountKey = ED25519PrivateKey::generatePrivateKey());
+
+  AccountId accountId;
+  ASSERT_NO_THROW(accountId = AccountCreateTransaction()
+                                .setKey(accountKey.get())
+                                .setInitialBalance(Hbar(1LL))
+                                .execute(getTestClient())
+                                .getReceipt(getTestClient())
+                                .getAccountId()
+                                .value());
+
+  // When / Then
+  EXPECT_NO_THROW(const TransactionReceipt txReceipt = TokenAssociateTransaction()
+                                                         .setAccountId(accountId)
+                                                         .freezeWith(getTestClient())
+                                                         .sign(accountKey.get())
+                                                         .execute(getTestClient())
+                                                         .getReceipt(getTestClient()));
+
+  // Clean up
+  ASSERT_NO_THROW(const TransactionReceipt txReceipt = AccountDeleteTransaction()
+                                                         .setDeleteAccountId(accountId)
+                                                         .setTransferAccountId(AccountId(2ULL))
+                                                         .freezeWith(getTestClient())
+                                                         .sign(accountKey.get())
+                                                         .execute(getTestClient())
+                                                         .getReceipt(getTestClient()));
+}
+
+//-----
+TEST_F(TokenAssociateTransactionIntegrationTest, CannotAssociateTokensWithNoAccountId)
+{
+  // Given / When / Then
+  EXPECT_THROW(const TransactionReceipt txReceipt =
+                 TokenAssociateTransaction().execute(getTestClient()).getReceipt(getTestClient()),
+               PrecheckStatusException); // INVALID_ACCOUNT_ID
+}
+
+//-----
+TEST_F(TokenAssociateTransactionIntegrationTest, CannotAssociateTokensWhenAccountDoesNotSign)
+{
+  // Given
+  std::shared_ptr<PrivateKey> operatorKey;
+  ASSERT_NO_THROW(
+    operatorKey = std::shared_ptr<PrivateKey>(
+      ED25519PrivateKey::fromString(
+        "302e020100300506032b65700422042091132178e72057a1d7528025956fe39b0b847f200ab59b2fdd367017f3087137")
+        .release()));
+
+  std::shared_ptr<PrivateKey> accountKey;
+  ASSERT_NO_THROW(accountKey = ED25519PrivateKey::generatePrivateKey());
+
+  AccountId accountId;
+  ASSERT_NO_THROW(accountId = AccountCreateTransaction()
+                                .setKey(accountKey.get())
+                                .setInitialBalance(Hbar(1LL))
+                                .execute(getTestClient())
+                                .getReceipt(getTestClient())
+                                .getAccountId()
+                                .value());
+
+  TokenId tokenId;
+  ASSERT_NO_THROW(tokenId = TokenCreateTransaction()
+                              .setTokenName("ffff")
+                              .setTokenSymbol("F")
+                              .setDecimals(3)
+                              .setInitialSupply(100000)
+                              .setTreasuryAccountId(AccountId(2ULL))
+                              .setAdminKey(operatorKey)
+                              .setFreezeKey(operatorKey)
+                              .setWipeKey(operatorKey)
+                              .setKycKey(operatorKey)
+                              .setSupplyKey(operatorKey)
+                              .setFeeScheduleKey(operatorKey)
+                              .execute(getTestClient())
+                              .getReceipt(getTestClient())
+                              .getTokenId()
+                              .value());
+
+  // When / Then
+  EXPECT_THROW(const TransactionReceipt txReceipt = TokenAssociateTransaction()
+                                                      .setAccountId(accountId)
+                                                      .setTokenIds({ tokenId })
+                                                      .execute(getTestClient())
+                                                      .getReceipt(getTestClient()),
+               ReceiptStatusException); // INVALID_SIGNATURE
+
+  // Clean up
+  ASSERT_NO_THROW(const TransactionReceipt txReceipt = AccountDeleteTransaction()
+                                                         .setDeleteAccountId(accountId)
+                                                         .setTransferAccountId(AccountId(2ULL))
+                                                         .freezeWith(getTestClient())
+                                                         .sign(accountKey.get())
+                                                         .execute(getTestClient())
+                                                         .getReceipt(getTestClient()));
+  // TODO: TokenDeleteTransaction
+}

--- a/sdk/tests/integration/TransactionReceiptIntegrationTest.cc
+++ b/sdk/tests/integration/TransactionReceiptIntegrationTest.cc
@@ -26,6 +26,7 @@
 #include "FileCreateTransaction.h"
 #include "FileDeleteTransaction.h"
 #include "TokenCreateTransaction.h"
+#include "TokenDeleteTransaction.h"
 #include "TransactionId.h"
 #include "TransactionReceipt.h"
 #include "TransactionReceiptQuery.h"
@@ -151,7 +152,7 @@ TEST_F(TransactionReceiptIntegrationTest, ExecuteContractCreateTransactionAndChe
 TEST_F(TransactionReceiptIntegrationTest, ExecuteTokenCreateTransactionAndCheckTransactionReceipt)
 {
   // Given
-  std::unique_ptr<PrivateKey> operatorKey;
+  std::shared_ptr<PrivateKey> operatorKey;
   ASSERT_NO_THROW(
     operatorKey = ED25519PrivateKey::fromString(
       "302e020100300506032b65700422042091132178e72057a1d7528025956fe39b0b847f200ab59b2fdd367017f3087137"));
@@ -161,6 +162,7 @@ TEST_F(TransactionReceiptIntegrationTest, ExecuteTokenCreateTransactionAndCheckT
                                  .setTokenName("test token name")
                                  .setTokenSymbol("test token symbol")
                                  .setTreasuryAccountId(AccountId(2ULL))
+                                 .setAdminKey(operatorKey)
                                  .execute(getTestClient()));
 
   // When
@@ -178,5 +180,8 @@ TEST_F(TransactionReceiptIntegrationTest, ExecuteTokenCreateTransactionAndCheckT
   EXPECT_TRUE(txReceipt.getTokenId().has_value());
 
   // Clean up
-  // TODO: TokenDeleteTransaction
+  ASSERT_NO_THROW(txReceipt = TokenDeleteTransaction()
+                                .setTokenId(txReceipt.getTokenId().value())
+                                .execute(getTestClient())
+                                .getReceipt(getTestClient()));
 }

--- a/sdk/tests/unit/CMakeLists.txt
+++ b/sdk/tests/unit/CMakeLists.txt
@@ -60,6 +60,7 @@ add_executable(${TEST_PROJECT_NAME}
         NodeAddressTest.cc
         StakingInfoTest.cc
         TokenAllowanceTest.cc
+        TokenAssociateTransactionUnitTests.cc
         TokenCreateTransactionTest.cc
         TokenIdTest.cc
         TokenNftAllowanceTest.cc

--- a/sdk/tests/unit/TokenAssociateTransactionUnitTests.cc
+++ b/sdk/tests/unit/TokenAssociateTransactionUnitTests.cc
@@ -1,0 +1,117 @@
+/*-
+ *
+ * Hedera C++ SDK
+ *
+ * Copyright (C) 2020 - 2022 Hedera Hashgraph, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+#include "AccountId.h"
+#include "Client.h"
+#include "ECDSAsecp256k1PrivateKey.h"
+#include "TokenAssociateTransaction.h"
+#include "exceptions/IllegalStateException.h"
+
+#include <gtest/gtest.h>
+#include <proto/transaction_body.pb.h>
+
+using namespace Hedera;
+
+class TokenAssociateTransactionTest : public ::testing::Test
+{
+protected:
+  void SetUp() override { mClient.setOperator(AccountId(), ECDSAsecp256k1PrivateKey::generatePrivateKey().get()); }
+
+  [[nodiscard]] inline const Client& getTestClient() const { return mClient; }
+  [[nodiscard]] inline const AccountId& getTestAccountId() const { return mTestAccountId; }
+  [[nodiscard]] inline const std::vector<TokenId>& getTestTokenIds() const { return mTestTokenIds; }
+
+private:
+  Client mClient;
+  const AccountId mTestAccountId = AccountId(1ULL, 2ULL, 3ULL);
+  const std::vector<TokenId> mTestTokenIds = { TokenId(4ULL, 5ULL, 6ULL),
+                                               TokenId(7ULL, 8ULL, 9ULL),
+                                               TokenId(10ULL, 11ULL, 12ULL) };
+};
+
+//-----
+TEST_F(TokenAssociateTransactionTest, ConstructTokenAssociateTransactionFromTransactionBodyProtobuf)
+{
+  // Given
+  auto body = std::make_unique<proto::TokenAssociateTransactionBody>();
+  body->set_allocated_account(getTestAccountId().toProtobuf().release());
+
+  for (const auto& token : getTestTokenIds())
+  {
+    *body->add_tokens() = *token.toProtobuf();
+  }
+
+  proto::TransactionBody txBody;
+  txBody.set_allocated_tokenassociate(body.release());
+
+  // When
+  const TokenAssociateTransaction tokenAssociateTransaction(txBody);
+
+  // Then
+  EXPECT_EQ(tokenAssociateTransaction.getAccountId(), getTestAccountId());
+  EXPECT_EQ(tokenAssociateTransaction.getTokenIds().size(), getTestTokenIds().size());
+}
+
+//-----
+TEST_F(TokenAssociateTransactionTest, GetSetAccountId)
+{
+  // Given
+  TokenAssociateTransaction transaction;
+
+  // When
+  EXPECT_NO_THROW(transaction.setAccountId(getTestAccountId()));
+
+  // Then
+  EXPECT_EQ(transaction.getAccountId(), getTestAccountId());
+}
+
+//-----
+TEST_F(TokenAssociateTransactionTest, GetSetAccountIdFrozen)
+{
+  // Given
+  TokenAssociateTransaction transaction;
+  ASSERT_NO_THROW(transaction.freezeWith(getTestClient()));
+
+  // When / Then
+  EXPECT_THROW(transaction.setAccountId(getTestAccountId()), IllegalStateException);
+}
+
+//-----
+TEST_F(TokenAssociateTransactionTest, GetSetTokenIds)
+{
+  // Given
+  TokenAssociateTransaction transaction;
+
+  // When
+  EXPECT_NO_THROW(transaction.setTokenIds(getTestTokenIds()));
+
+  // Then
+  EXPECT_EQ(transaction.getTokenIds(), getTestTokenIds());
+}
+
+//-----
+TEST_F(TokenAssociateTransactionTest, GetSetTokenIdFrozen)
+{
+  // Given
+  TokenAssociateTransaction transaction;
+  ASSERT_NO_THROW(transaction.freezeWith(getTestClient()));
+
+  // When / Then
+  EXPECT_THROW(transaction.setTokenIds(getTestTokenIds()), IllegalStateException);
+}

--- a/sdk/tests/unit/TransactionTest.cc
+++ b/sdk/tests/unit/TransactionTest.cc
@@ -32,6 +32,7 @@
 #include "FileCreateTransaction.h"
 #include "FileDeleteTransaction.h"
 #include "FileUpdateTransaction.h"
+#include "TokenAssociateTransaction.h"
 #include "TransferTransaction.h"
 #include "impl/Utilities.h"
 
@@ -928,4 +929,62 @@ TEST_F(TransactionTest, FileAppendTransactionFromTransactionBytes)
   // Then
   ASSERT_EQ(index, 14);
   EXPECT_NO_THROW(const FileAppendTransaction fileAppendTransaction = std::get<14>(txVariant));
+}
+
+TEST_F(TransactionTest, TokenAssociateTransactionFromTransactionBodyBytes)
+{
+  // Given
+  proto::TransactionBody txBody;
+  txBody.set_allocated_tokenassociate(new proto::TokenAssociateTransactionBody);
+
+  // When
+  const auto [index, txVariant] = Transaction<TokenAssociateTransaction>::fromBytes(
+    internal::Utilities::stringToByteVector(txBody.SerializeAsString()));
+
+  // Then
+  ASSERT_EQ(index, 15);
+  EXPECT_NO_THROW(const TokenAssociateTransaction tokenAssociateTransaction = std::get<15>(txVariant));
+}
+
+//-----
+TEST_F(TransactionTest, TokenAssociateTransactionFromSignedTransactionBytes)
+{
+  // Given
+  proto::TransactionBody txBody;
+  txBody.set_allocated_tokenassociate(new proto::TokenAssociateTransactionBody);
+
+  proto::SignedTransaction signedTx;
+  signedTx.set_bodybytes(txBody.SerializeAsString());
+  // SignatureMap not required
+
+  // When
+  const auto [index, txVariant] = Transaction<TokenAssociateTransaction>::fromBytes(
+    internal::Utilities::stringToByteVector(txBody.SerializeAsString()));
+
+  // Then
+  ASSERT_EQ(index, 15);
+  EXPECT_NO_THROW(const TokenAssociateTransaction tokenAssociateTransaction = std::get<15>(txVariant));
+}
+
+//-----
+TEST_F(TransactionTest, TokenAssociateTransactionFromTransactionBytes)
+{
+  // Given
+  proto::TransactionBody txBody;
+  txBody.set_allocated_tokenassociate(new proto::TokenAssociateTransactionBody);
+
+  proto::SignedTransaction signedTx;
+  signedTx.set_bodybytes(txBody.SerializeAsString());
+  // SignatureMap not required
+
+  proto::Transaction tx;
+  tx.set_signedtransactionbytes(signedTx.SerializeAsString());
+
+  // When
+  const auto [index, txVariant] = Transaction<TokenAssociateTransaction>::fromBytes(
+    internal::Utilities::stringToByteVector(txBody.SerializeAsString()));
+
+  // Then
+  ASSERT_EQ(index, 15);
+  EXPECT_NO_THROW(const TokenAssociateTransaction tokenAssociateTransaction = std::get<15>(txVariant));
 }


### PR DESCRIPTION
**Description**:
This PR implements `TokenAssociateTransaction`, which allows users to associate tokens to accounts. It also adds its unit and integration tests.

**Related issue(s)**:

Fixes #377 

**Checklist**

- [x] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
