### PR TITLE
Implement `TokenWipeTransaction`

### DIFF
--- a/sdk/main/CMakeLists.txt
+++ b/sdk/main/CMakeLists.txt
@@ -80,6 +80,7 @@ add_library(${PROJECT_NAME} STATIC
         src/TokenSupplyType.cc
         src/TokenTransfer.cc
         src/TokenType.cc
+        src/TokenWipeTransaction.cc
         src/Transaction.cc
         src/TransactionId.cc
         src/TransactionReceipt.cc

--- a/sdk/main/include/TokenWipeTransaction.h
+++ b/sdk/main/include/TokenWipeTransaction.h
@@ -1,0 +1,203 @@
+/*-
+ *
+ * Hedera C++ SDK
+ *
+ * Copyright (C) 2020 - 2022 Hedera Hashgraph, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+#ifndef HEDERA_SDK_CPP_TOKEN_WIPE_TRANSACTION_H_
+#define HEDERA_SDK_CPP_TOKEN_WIPE_TRANSACTION_H_
+
+#include "AccountId.h"
+#include "TokenId.h"
+#include "Transaction.h"
+
+#include <cstdint>
+#include <vector>
+
+namespace proto
+{
+class TokenWipeAccountTransactionBody;
+class TransactionBody;
+}
+
+namespace Hedera
+{
+/**
+ * Wipes the provided amount of fungible or non-fungible tokens from the specified Hedera account. This transaction does
+ * not delete tokens from the treasury account. This transaction must be signed by the token's Wipe Key. Wiping an
+ * account's tokens burns the tokens and decreases the total supply.
+ *
+ *  - If the provided account is not found, the transaction will resolve to INVALID_ACCOUNT_ID.
+ *  - If the provided account has been deleted, the transaction will resolve to ACCOUNT_DELETED.
+ *  - If the provided token is not found, the transaction will resolve to INVALID_TOKEN_ID.
+ *  - If the provided token has been deleted, the transaction will resolve to TOKEN_WAS_DELETED.
+ *  - If an Association between the provided token and the account is not found, the transaction will resolve to
+ *    TOKEN_NOT_ASSOCIATED_TO_ACCOUNT.
+ *  - If Wipe Key is not present in the Token, the transaction results in TOKEN_HAS_NO_WIPE_KEY.
+ *  - If the provided account is the token's Treasury Account, the transaction results in
+ *    CANNOT_WIPE_TOKEN_TREASURY_ACCOUNT.
+ *
+ * On success, tokens are removed from the account and the total supply of the token is decreased by the wiped amount.
+ * The amount provided is in the lowest denomination possible.
+ *  - Example: Token A has 2 decimals. In order to wipe 100 tokens from an account, one must provide an amount of 10000.
+ *             In order to wipe 100.55 tokens, one must provide an amount of 10055.
+ *
+ * This transaction accepts zero-unit token wipe operations for fungible tokens (HIP-564).
+ *
+ * Transaction Signing Requirements:
+ *  - Wipe key.
+ *  - Transaction fee payer account key.
+ */
+class TokenWipeTransaction : public Transaction<TokenWipeTransaction>
+{
+public:
+  TokenWipeTransaction() = default;
+
+  /**
+   * Construct from a TransactionBody protobuf object.
+   *
+   * @param transactionBody The TransactionBody protobuf object from which to construct.
+   * @throws std::invalid_argument If the input TransactionBody does not represent a TokenWipe transaction.
+   */
+  explicit TokenWipeTransaction(const proto::TransactionBody& transactionBody);
+
+  /**
+   * Set the ID of the token to wipe.
+   *
+   * @param tokenId The ID of the token to wipe.
+   * @return A reference to this TokenWipeTransaction object with the newly-set token ID.
+   * @throws IllegalStateException If this TokenWipeTransaction is frozen.
+   */
+  TokenWipeTransaction& setTokenId(const TokenId& tokenId);
+
+  /**
+   * Set the ID of the account from which to wipe the token(s).
+   *
+   * @param accountId The ID of the account from which to wipe the token(s).
+   * @return A reference to this TokenWipeTransaction object with the newly-set account ID.
+   * @throws IllegalStateException If this TokenWipeTransaction is frozen.
+   */
+  TokenWipeTransaction& setAccountId(const AccountId& accountId);
+
+  /**
+   * Set the amount of FUNGIBLE_COMMON tokens to wipe from the account. This should be in the lowest denomination
+   * possible.
+   *
+   * @param amount The amount of FUNGIBLE_COMMON tokens to wipe from the account.
+   * @return A reference to this TokenWipeTransaction object with the newly-set amount.
+   * @throws IllegalStateException If this TokenWipeTransaction is frozen.
+   */
+  TokenWipeTransaction& setAmount(uint64_t amount);
+
+  /**
+   * Set the serial numbers of NON_FUNGIBLE_UNIQUE tokens to wipe from the account.
+   *
+   * @param serialNumbers The serial numbers of NON_FUNGIBLE_UNIQUE tokens to wipe from the account.
+   * @return A reference to this TokenWipeTransaction object with the newly-set serial numbers.
+   * @throws IllegalStateException If this TokenWipeTransaction is frozen.
+   */
+  TokenWipeTransaction& setSerialNumbers(const std::vector<uint64_t>& serialNumbers);
+
+  /**
+   * Get the ID of the token to wipe.
+   *
+   * @return The ID of the token to wipe.
+   */
+  [[nodiscard]] inline TokenId getTokenId() const { return mTokenId; }
+
+  /**
+   * Get the ID of the account from which to wipe the token(s).
+   *
+   * @return The ID of the account from which to wipe the token(s).
+   */
+  [[nodiscard]] inline AccountId getAccountId() const { return mAccountId; }
+
+  /**
+   * Get the amount of FUNGIBLE_COMMON tokens to wipe from the account.
+   *
+   * @return The amount of FUNGIBLE_COMMON tokens to wipe from the account.
+   */
+  [[nodiscard]] inline uint64_t getAmount() const { return mAmount; }
+
+  /**
+   * Get the serial numbers of the NON_FUNGIBLE_UNIQUE tokens to wipe from the account.
+   *
+   * @return The serial numbers of the NON_FUNGIBLE_UNIQUE tokens to wipe from the account.
+   */
+  [[nodiscard]] inline std::vector<uint64_t> getSerialNumbers() const { return mSerialNumbers; }
+
+private:
+  /**
+   * Derived from Executable. Construct a Transaction protobuf object from this TokenWipeTransaction object.
+   *
+   * @param client The Client trying to construct this TokenWipeTransaction.
+   * @param node   The Node to which this TokenWipeTransaction will be sent. This is unused.
+   * @return A Transaction protobuf object filled with this TokenWipeTransaction object's data.
+   * @throws UninitializedException If the input client has no operator with which to sign this
+   *                                TokenWipeTransaction.
+   */
+  [[nodiscard]] proto::Transaction makeRequest(const Client& client,
+                                               const std::shared_ptr<internal::Node>& /*node*/) const override;
+
+  /**
+   * Derived from Executable. Submit this TokenWipeTransaction to a Node.
+   *
+   * @param client   The Client submitting this TokenWipeTransaction.
+   * @param deadline The deadline for submitting this TokenWipeTransaction.
+   * @param node     Pointer to the Node to which this TokenWipeTransaction should be submitted.
+   * @param response Pointer to the TransactionResponse protobuf object that gRPC should populate with the response
+   *                 information from the gRPC server.
+   * @return The gRPC status of the submission.
+   */
+  [[nodiscard]] grpc::Status submitRequest(const Client& client,
+                                           const std::chrono::system_clock::time_point& deadline,
+                                           const std::shared_ptr<internal::Node>& node,
+                                           proto::TransactionResponse* response) const override;
+
+  /**
+   * Build a TokenWipeAccountTransactionBody protobuf object from this TokenWipeTransaction object.
+   *
+   * @return A pointer to a TokenWipeAccountTransactionBody protobuf object filled with this TokenWipeTransaction
+   *         object's data.
+   */
+  [[nodiscard]] proto::TokenWipeAccountTransactionBody* build() const;
+
+  /**
+   * The ID of the token to wipe from the account.
+   */
+  TokenId mTokenId;
+
+  /**
+   * The ID of the account from which to wipe the tokens.
+   */
+  AccountId mAccountId;
+
+  /**
+   * Applicable to tokens of type FUNGIBLE_COMMON. The amount of tokens to wipe from the specified account. Amount must
+   * be a positive non-zero number in the lowest denomination possible and not bigger than the token balance of the
+   * account.
+   */
+  uint64_t mAmount = 0ULL;
+
+  /**
+   * Applicable to tokens of type NON_FUNGIBLE_UNIQUE. THe list of serial numbers to be wiped from the account.
+   */
+  std::vector<uint64_t> mSerialNumbers;
+};
+
+} // namespace Hedera
+
+#endif // HEDERA_SDK_CPP_TOKEN_WIPE_TRANSACTION_H_

--- a/sdk/main/include/Transaction.h
+++ b/sdk/main/include/Transaction.h
@@ -53,6 +53,7 @@ class PrivateKey;
 class TokenAssociateTransaction;
 class TokenCreateTransaction;
 class TokenDeleteTransaction;
+class TokenWipeTransaction;
 class TransactionResponse;
 class TransferTransaction;
 }
@@ -126,7 +127,8 @@ public:
                                               FileAppendTransaction,
                                               TokenCreateTransaction,
                                               TokenDeleteTransaction,
-                                              TokenAssociateTransaction>>
+                                              TokenAssociateTransaction,
+                                              TokenWipeTransaction>>
   fromBytes(const std::vector<std::byte>& bytes);
 
   /**

--- a/sdk/main/src/Executable.cc
+++ b/sdk/main/src/Executable.cc
@@ -50,6 +50,7 @@
 #include "TokenAssociateTransaction.h"
 #include "TokenCreateTransaction.h"
 #include "TokenDeleteTransaction.h"
+#include "TokenWipeTransaction.h"
 #include "TransactionReceipt.h"
 #include "TransactionReceiptQuery.h"
 #include "TransactionRecord.h"
@@ -354,6 +355,7 @@ template class Executable<TokenAssociateTransaction,
                           TransactionResponse>;
 template class Executable<TokenCreateTransaction, proto::Transaction, proto::TransactionResponse, TransactionResponse>;
 template class Executable<TokenDeleteTransaction, proto::Transaction, proto::TransactionResponse, TransactionResponse>;
+template class Executable<TokenWipeTransaction, proto::Transaction, proto::TransactionResponse, TransactionResponse>;
 template class Executable<TransactionReceiptQuery, proto::Query, proto::Response, TransactionReceipt>;
 template class Executable<TransactionRecordQuery, proto::Query, proto::Response, TransactionRecord>;
 template class Executable<TransferTransaction, proto::Transaction, proto::TransactionResponse, TransactionResponse>;

--- a/sdk/main/src/TokenWipeTransaction.cc
+++ b/sdk/main/src/TokenWipeTransaction.cc
@@ -1,0 +1,126 @@
+/*-
+ *
+ * Hedera C++ SDK
+ *
+ * Copyright (C) 2020 - 2022 Hedera Hashgraph, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+#include "TokenWipeTransaction.h"
+#include "impl/Node.h"
+
+#include <grpcpp/client_context.h>
+#include <proto/token_wipe_account.pb.h>
+#include <proto/transaction.pb.h>
+#include <stdexcept>
+
+namespace Hedera
+{
+//-----
+TokenWipeTransaction::TokenWipeTransaction(const proto::TransactionBody& transactionBody)
+  : Transaction<TokenWipeTransaction>(transactionBody)
+{
+  if (!transactionBody.has_tokenwipe())
+  {
+    throw std::invalid_argument("Transaction body doesn't contain TokenWipe data");
+  }
+
+  const proto::TokenWipeAccountTransactionBody& body = transactionBody.tokenwipe();
+
+  if (body.has_token())
+  {
+    mTokenId = TokenId::fromProtobuf(body.token());
+  }
+
+  if (body.has_account())
+  {
+    mAccountId = AccountId::fromProtobuf(body.account());
+  }
+
+  mAmount = body.amount();
+
+  for (int i = 0; i < body.serialnumbers_size(); ++i)
+  {
+    mSerialNumbers.push_back(static_cast<uint64_t>(body.serialnumbers(i)));
+  }
+}
+
+//-----
+TokenWipeTransaction& TokenWipeTransaction::setTokenId(const TokenId& tokenId)
+{
+  requireNotFrozen();
+  mTokenId = tokenId;
+  return *this;
+}
+
+//-----
+TokenWipeTransaction& TokenWipeTransaction::setAccountId(const AccountId& accountId)
+{
+  requireNotFrozen();
+  mAccountId = accountId;
+  return *this;
+}
+
+//-----
+TokenWipeTransaction& TokenWipeTransaction::setAmount(uint64_t amount)
+{
+  requireNotFrozen();
+  mAmount = amount;
+  return *this;
+}
+
+//-----
+TokenWipeTransaction& TokenWipeTransaction::setSerialNumbers(const std::vector<uint64_t>& serialNumbers)
+{
+  requireNotFrozen();
+  mSerialNumbers = serialNumbers;
+  return *this;
+}
+
+//-----
+proto::Transaction TokenWipeTransaction::makeRequest(const Client& client, const std::shared_ptr<internal::Node>&) const
+{
+  proto::TransactionBody transactionBody = generateTransactionBody(client);
+  transactionBody.set_allocated_tokenwipe(build());
+
+  return signTransaction(transactionBody, client);
+}
+
+//-----
+grpc::Status TokenWipeTransaction::submitRequest(const Client& client,
+                                                 const std::chrono::system_clock::time_point& deadline,
+                                                 const std::shared_ptr<internal::Node>& node,
+                                                 proto::TransactionResponse* response) const
+{
+  return node->submitTransaction(
+    proto::TransactionBody::DataCase::kTokenWipe, makeRequest(client, node), deadline, response);
+}
+
+//-----
+proto::TokenWipeAccountTransactionBody* TokenWipeTransaction::build() const
+{
+  auto body = std::make_unique<proto::TokenWipeAccountTransactionBody>();
+  body->set_allocated_token(mTokenId.toProtobuf().release());
+  body->set_allocated_account(mAccountId.toProtobuf().release());
+  body->set_amount(mAmount);
+
+  for (const auto& num : mSerialNumbers)
+  {
+    body->add_serialnumbers(static_cast<int64_t>(num));
+  }
+
+  return body.release();
+}
+
+} // namespace Hedera

--- a/sdk/main/src/Transaction.cc
+++ b/sdk/main/src/Transaction.cc
@@ -39,6 +39,7 @@
 #include "TokenAssociateTransaction.h"
 #include "TokenCreateTransaction.h"
 #include "TokenDeleteTransaction.h"
+#include "TokenWipeTransaction.h"
 #include "TransactionId.h"
 #include "TransactionResponse.h"
 #include "TransferTransaction.h"
@@ -77,7 +78,8 @@ std::pair<int,
                        FileAppendTransaction,
                        TokenCreateTransaction,
                        TokenDeleteTransaction,
-                       TokenAssociateTransaction>>
+                       TokenAssociateTransaction,
+                       TokenWipeTransaction>>
 Transaction<SdkRequestType>::fromBytes(const std::vector<std::byte>& bytes)
 {
   proto::TransactionBody txBody;
@@ -155,6 +157,8 @@ Transaction<SdkRequestType>::fromBytes(const std::vector<std::byte>& bytes)
       return { 16, TokenDeleteTransaction(txBody) };
     case proto::TransactionBody::kTokenAssociate:
       return { 17, TokenAssociateTransaction(txBody) };
+    case proto::TransactionBody::kTokenWipe:
+      return { 18, TokenWipeTransaction(txBody) };
     default:
       throw std::invalid_argument("Type of transaction cannot be determined from input bytes");
   }
@@ -473,6 +477,7 @@ template class Transaction<FileUpdateTransaction>;
 template class Transaction<TokenAssociateTransaction>;
 template class Transaction<TokenCreateTransaction>;
 template class Transaction<TokenDeleteTransaction>;
+template class Transaction<TokenWipeTransaction>;
 template class Transaction<TransferTransaction>;
 
 } // namespace Hedera

--- a/sdk/tests/unit/CMakeLists.txt
+++ b/sdk/tests/unit/CMakeLists.txt
@@ -71,6 +71,7 @@ add_executable(${TEST_PROJECT_NAME}
         TokenSupplyTypeTest.cc
         TokenTransferTest.cc
         TokenTypeTest.cc
+        TokenWipeTransactionUnitTests.cc
         TransactionIdTest.cc
         TransactionReceiptQueryTest.cc
         TransactionReceiptTest.cc

--- a/sdk/tests/unit/TokenWipeTransactionUnitTests.cc
+++ b/sdk/tests/unit/TokenWipeTransactionUnitTests.cc
@@ -1,0 +1,170 @@
+/*-
+ *
+ * Hedera C++ SDK
+ *
+ * Copyright (C) 2020 - 2022 Hedera Hashgraph, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+#include "Client.h"
+#include "ECDSAsecp256k1PrivateKey.h"
+#include "TokenWipeTransaction.h"
+#include "exceptions/IllegalStateException.h"
+
+#include <gtest/gtest.h>
+#include <proto/transaction_body.pb.h>
+
+using namespace Hedera;
+
+class TokenWipeTransactionTest : public ::testing::Test
+{
+protected:
+  void SetUp() override { mClient.setOperator(AccountId(), ECDSAsecp256k1PrivateKey::generatePrivateKey().get()); }
+
+  [[nodiscard]] inline const Client& getTestClient() const { return mClient; }
+  [[nodiscard]] inline const TokenId& getTestTokenId() const { return mTestTokenId; }
+  [[nodiscard]] inline const AccountId& getTestAccountId() const { return mTestAccountId; }
+  [[nodiscard]] inline const uint64_t& getTestAmount() const { return mTestAmount; }
+  [[nodiscard]] inline const std::vector<uint64_t>& getTestSerialNumbers() const { return mTestSerialNumbers; }
+
+private:
+  Client mClient;
+  const TokenId mTestTokenId = TokenId(1ULL, 2ULL, 3ULL);
+  const AccountId mTestAccountId = AccountId(4ULL, 5ULL, 6ULL);
+  const uint64_t mTestAmount = 7ULL;
+  const std::vector<uint64_t> mTestSerialNumbers = { 8ULL, 9ULL, 10ULL };
+};
+
+//-----
+TEST_F(TokenWipeTransactionTest, ConstructTokenWipeTransactionFromTransactionBodyProtobuf)
+{
+  // Given
+  auto body = std::make_unique<proto::TokenWipeAccountTransactionBody>();
+  body->set_allocated_token(getTestTokenId().toProtobuf().release());
+  body->set_allocated_account(getTestAccountId().toProtobuf().release());
+  body->set_amount(getTestAmount());
+
+  for (const auto& num : getTestSerialNumbers())
+  {
+    body->add_serialnumbers(static_cast<int64_t>(num));
+  }
+
+  proto::TransactionBody txBody;
+  txBody.set_allocated_tokenwipe(body.release());
+
+  // When
+  const TokenWipeTransaction tokenWipeTransaction(txBody);
+
+  // Then
+  EXPECT_EQ(tokenWipeTransaction.getTokenId(), getTestTokenId());
+  EXPECT_EQ(tokenWipeTransaction.getAccountId(), getTestAccountId());
+  EXPECT_EQ(tokenWipeTransaction.getAmount(), getTestAmount());
+  EXPECT_EQ(tokenWipeTransaction.getSerialNumbers(), getTestSerialNumbers());
+}
+
+//-----
+TEST_F(TokenWipeTransactionTest, GetSetTokenId)
+{
+  // Given
+  TokenWipeTransaction transaction;
+
+  // When
+  EXPECT_NO_THROW(transaction.setTokenId(getTestTokenId()));
+
+  // Then
+  EXPECT_EQ(transaction.getTokenId(), getTestTokenId());
+}
+
+//-----
+TEST_F(TokenWipeTransactionTest, GetSetTokenIdFrozen)
+{
+  // Given
+  TokenWipeTransaction transaction;
+  ASSERT_NO_THROW(transaction.freezeWith(getTestClient()));
+
+  // When / Then
+  EXPECT_THROW(transaction.setTokenId(getTestTokenId()), IllegalStateException);
+}
+
+//-----
+TEST_F(TokenWipeTransactionTest, GetSetAccountId)
+{
+  // Given
+  TokenWipeTransaction transaction;
+
+  // When
+  EXPECT_NO_THROW(transaction.setAccountId(getTestAccountId()));
+
+  // Then
+  EXPECT_EQ(transaction.getAccountId(), getTestAccountId());
+}
+
+//-----
+TEST_F(TokenWipeTransactionTest, GetSetAccountIdFrozen)
+{
+  // Given
+  TokenWipeTransaction transaction;
+  ASSERT_NO_THROW(transaction.freezeWith(getTestClient()));
+
+  // When / Then
+  EXPECT_THROW(transaction.setAccountId(getTestAccountId()), IllegalStateException);
+}
+
+//-----
+TEST_F(TokenWipeTransactionTest, GetSetAmount)
+{
+  // Given
+  TokenWipeTransaction transaction;
+
+  // When
+  EXPECT_NO_THROW(transaction.setAmount(getTestAmount()));
+
+  // Then
+  EXPECT_EQ(transaction.getAmount(), getTestAmount());
+}
+
+//-----
+TEST_F(TokenWipeTransactionTest, GetSetAmountFrozen)
+{
+  // Given
+  TokenWipeTransaction transaction;
+  ASSERT_NO_THROW(transaction.freezeWith(getTestClient()));
+
+  // When / Then
+  EXPECT_THROW(transaction.setAmount(getTestAmount()), IllegalStateException);
+}
+
+//-----
+TEST_F(TokenWipeTransactionTest, GetSetSerialNumbers)
+{
+  // Given
+  TokenWipeTransaction transaction;
+
+  // When
+  EXPECT_NO_THROW(transaction.setSerialNumbers(getTestSerialNumbers()));
+
+  // Then
+  EXPECT_EQ(transaction.getSerialNumbers(), getTestSerialNumbers());
+}
+
+//-----
+TEST_F(TokenWipeTransactionTest, GetSetSerialNumbersFrozen)
+{
+  // Given
+  TokenWipeTransaction transaction;
+  ASSERT_NO_THROW(transaction.freezeWith(getTestClient()));
+
+  // When / Then
+  EXPECT_THROW(transaction.setSerialNumbers(getTestSerialNumbers()), IllegalStateException);
+}

--- a/sdk/tests/unit/TransactionTest.cc
+++ b/sdk/tests/unit/TransactionTest.cc
@@ -35,6 +35,7 @@
 #include "TokenAssociateTransaction.h"
 #include "TokenCreateTransaction.h"
 #include "TokenDeleteTransaction.h"
+#include "TokenWipeTransaction.h"
 #include "TransferTransaction.h"
 #include "impl/Utilities.h"
 
@@ -1107,4 +1108,63 @@ TEST_F(TransactionTest, TokenAssociateTransactionFromTransactionBytes)
   // Then
   ASSERT_EQ(index, 17);
   EXPECT_NO_THROW(const TokenAssociateTransaction tokenAssociateTransaction = std::get<17>(txVariant));
+}
+
+//-----
+TEST_F(TransactionTest, TokenWipeTransactionFromTransactionBodyBytes)
+{
+  // Given
+  proto::TransactionBody txBody;
+  txBody.set_allocated_tokenwipe(new proto::TokenWipeAccountTransactionBody);
+
+  // When
+  const auto [index, txVariant] =
+    Transaction<TokenWipeTransaction>::fromBytes(internal::Utilities::stringToByteVector(txBody.SerializeAsString()));
+
+  // Then
+  ASSERT_EQ(index, 18);
+  EXPECT_NO_THROW(const TokenWipeTransaction tokenWipeTransaction = std::get<18>(txVariant));
+}
+
+//-----
+TEST_F(TransactionTest, TokenWipeTransactionFromSignedTransactionBytes)
+{
+  // Given
+  proto::TransactionBody txBody;
+  txBody.set_allocated_tokenwipe(new proto::TokenWipeAccountTransactionBody);
+
+  proto::SignedTransaction signedTx;
+  signedTx.set_bodybytes(txBody.SerializeAsString());
+  // SignatureMap not required
+
+  // When
+  const auto [index, txVariant] =
+    Transaction<TokenWipeTransaction>::fromBytes(internal::Utilities::stringToByteVector(txBody.SerializeAsString()));
+
+  // Then
+  ASSERT_EQ(index, 18);
+  EXPECT_NO_THROW(const TokenWipeTransaction tokenWipeTransaction = std::get<18>(txVariant));
+}
+
+//-----
+TEST_F(TransactionTest, TokenWipeTransactionFromTransactionBytes)
+{
+  // Given
+  proto::TransactionBody txBody;
+  txBody.set_allocated_tokenwipe(new proto::TokenWipeAccountTransactionBody);
+
+  proto::SignedTransaction signedTx;
+  signedTx.set_bodybytes(txBody.SerializeAsString());
+  // SignatureMap not required
+
+  proto::Transaction tx;
+  tx.set_signedtransactionbytes(signedTx.SerializeAsString());
+
+  // When
+  const auto [index, txVariant] =
+    Transaction<TokenWipeTransaction>::fromBytes(internal::Utilities::stringToByteVector(txBody.SerializeAsString()));
+
+  // Then
+  ASSERT_EQ(index, 18);
+  EXPECT_NO_THROW(const TokenWipeTransaction tokenWipeTransaction = std::get<18>(txVariant));
 }


### PR DESCRIPTION
**Description**:
This PR implements the APIs associated with `TokenWipeTransaction`, which allows a user to wipe the tokens held by an account.

**Related issue(s)**:

Fixes #383 

**Notes for reviewer**:
Integration tests requires #386 to be completed, so that will be completed with that effort. 

**Checklist**

- [x] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
