### PR TITLE
Implement `TokenInfoQuery`

### DIFF
--- a/sdk/main/CMakeLists.txt
+++ b/sdk/main/CMakeLists.txt
@@ -74,6 +74,8 @@ add_library(${PROJECT_NAME} STATIC
         src/TokenCreateTransaction.cc
         src/TokenDeleteTransaction.cc
         src/TokenId.cc
+        src/TokenInfo.cc
+        src/TokenInfoQuery.cc
         src/TokenNftAllowance.cc
         src/TokenNftRemoveAllowance.cc
         src/TokenNftTransfer.cc

--- a/sdk/main/include/AccountInfo.h
+++ b/sdk/main/include/AccountInfo.h
@@ -52,6 +52,7 @@ public:
    * @return The constructed AccountInfo object.
    */
   [[nodiscard]] static AccountInfo fromProtobuf(const proto::CryptoGetInfoResponse_AccountInfo& proto);
+
   /**
    * The ID of the queried account.
    */

--- a/sdk/main/include/TokenInfo.h
+++ b/sdk/main/include/TokenInfo.h
@@ -66,6 +66,20 @@ public:
   [[nodiscard]] static TokenInfo fromBytes(const std::vector<std::byte>& bytes);
 
   /**
+   * Construct a TokenInfo protobuf object from this TokenInfo object.
+   *
+   * @return A pointer to the created TokenInfo protobuf object.
+   */
+  [[nodiscard]] std::unique_ptr<proto::TokenInfo> toProtobuf() const;
+
+  /**
+   * Construct a representative byte array from this TokenInfo object.
+   *
+   * @return The byte array representing this TokenInfo object.
+   */
+  [[nodiscard]] std::vector<std::byte> toBytes() const;
+
+  /**
    * The ID of the token.
    */
   TokenId mTokenId;

--- a/sdk/main/include/TokenInfo.h
+++ b/sdk/main/include/TokenInfo.h
@@ -1,0 +1,210 @@
+/*-
+ *
+ * Hedera C++ SDK
+ *
+ * Copyright (C) 2020 - 2022 Hedera Hashgraph, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+#ifndef HEDERA_SDK_CPP_TOKEN_INFO_H_
+#define HEDERA_SDK_CPP_TOKEN_INFO_H_
+
+#include "AccountId.h"
+#include "CustomFee.h"
+#include "Defaults.h"
+#include "Key.h"
+#include "LedgerId.h"
+#include "TokenId.h"
+#include "TokenSupplyType.h"
+#include "TokenType.h"
+
+#include <cstddef>
+#include <cstdint>
+#include <memory>
+#include <optional>
+#include <string>
+#include <vector>
+
+namespace proto
+{
+class TokenInfo;
+}
+
+namespace Hedera
+{
+/**
+ * Response from a Hedera network when the client sends an TokenInfoQuery.
+ */
+class TokenInfo
+{
+public:
+  /**
+   * Construct a TokenInfo object from a TokenInfo protobuf object.
+   *
+   * @param proto The TokenInfo protobuf object from which to construct a TokenInfo object.
+   * @return The constructed TokenInfo object.
+   */
+  [[nodiscard]] static TokenInfo fromProtobuf(const proto::TokenInfo& proto);
+
+  /**
+   * Construct a TokenInfo object from a byte array.
+   *
+   * @param bytes The byte array representing a TokenInfo object.
+   * @return The constructed TokenInfo object.
+   */
+  [[nodiscard]] static TokenInfo fromBytes(const std::vector<std::byte>& bytes);
+
+  /**
+   * The ID of the token.
+   */
+  TokenId mTokenId;
+
+  /**
+   * The name of the token. It is a string of ASCII only characters.
+   */
+  std::string mTokenName;
+
+  /**
+   * The symbol of the token. It is a UTF-8 capitalized alphabetical string.
+   */
+  std::string mTokenSymbol;
+
+  /**
+   * The number of decimal places by which a token is divisible. Always 0 for NON_FUNGIBLE_UNIQUE tokens.
+   */
+  uint32_t mDecimals = 0U;
+
+  /**
+   * For FUNGIBLE_COMMON tokens - the total supply of tokens that are currently in circulation. For NON_FUNGIBLE_UNIQUE
+   * tokens - the number of NFTs created of this token instance.
+   */
+  uint64_t mTotalSupply = 0ULL;
+
+  /**
+   * The ID of the treasury account for the token.
+   */
+  AccountId mTreasuryAccountId;
+
+  /**
+   * The key which can perform update/delete operations on the token. If nullptr, the token can be perceived as
+   * immutable (not being able to be updated/deleted).
+   */
+  std::shared_ptr<Key> mAdminKey = nullptr;
+
+  /**
+   * The key which can grant or revoke KYC of an account for the token's transactions. If nullptr, KYC is not required,
+   * and KYC grant or revoke operations are not possible.
+   */
+  std::shared_ptr<Key> mKycKey = nullptr;
+
+  /**
+   * The key which can  freeze or unfreeze an account for token transactions. If nullptr, freezing is not possible.
+   */
+  std::shared_ptr<Key> mFreezeKey = nullptr;
+
+  /**
+   * The key which can wipe the token balance of an account. If nullptr, wipe is not possible.
+   */
+  std::shared_ptr<Key> mWipeKey = nullptr;
+
+  /**
+   * The key which can change the supply of a token. The key is used to sign token mint and burn operations.
+   */
+  std::shared_ptr<Key> mSupplyKey = nullptr;
+
+  /**
+   * The default freeze status (FreezeNotApplicable, Frozen, or Unfrozen) of Hedera accounts relative to this token.
+   * Uninitialized if mFreezeKey is empty, \c TRUE if mFreezeKey is set and mDefaultFreeze is set to true, or \c FALSE
+   * if mFreezeKey is set and mDefaultFreeze is set to false.
+   */
+  std::optional<bool> mDefaultFreezeStatus;
+
+  /**
+   * The default KYC status (KycNotApplicable or Revoked) of Hedera accounts relative to this token. KycNotApplicable if
+   * mKycKey is not set, otherwise \c FALSE (no way to have the default KYC status be Granted (or \c TRUE)).
+   */
+  std::optional<bool> mDefaultKycStatus;
+
+  /**
+   * Specifies whether the token was deleted or not.
+   */
+  bool mIsDeleted = false;
+
+  /**
+   * The ID of the account which will be automatically charged to renew the token's expiration, at the interval
+   * specified in mAutoRenewPeriod.
+   */
+  AccountId mAutoRenewAccountId;
+
+  /**
+   * The interval at which the auto-renew account will be charged to extend the token's expiry.
+   */
+  std::chrono::duration<double> mAutoRenewPeriod = DEFAULT_AUTO_RENEW_PERIOD;
+
+  /**
+   * The epoch second at which the token should expire.
+   */
+  std::chrono::system_clock::time_point mExpirationTime = std::chrono::system_clock::now() + DEFAULT_AUTO_RENEW_PERIOD;
+
+  /**
+   * The memo associated with the token (UTF-8 encoding max 100 bytes).
+   */
+  std::string mTokenMemo;
+
+  /**
+   * The token type.
+   */
+  TokenType mTokenType = TokenType::FUNGIBLE_COMMON;
+
+  /**
+   * The token supply type.
+   */
+  TokenSupplyType mSupplyType = TokenSupplyType::INFINITE;
+
+  /**
+   * For FUNGIBLE_COMMON tokens - the maximum number of fungible tokens that can be in circulation. For
+   * NON_FUNGIBLE_UNIQUE tokens - the maximum number of NFTs (serial numbers) that can be in circulation.
+   */
+  uint64_t mMaxSupply = 0ULL;
+
+  /**
+   * The key which can change the token's custom fee schedule. If nullptr, the fee schedule is immutable.
+   */
+  std::shared_ptr<Key> mFeeScheduleKey = nullptr;
+
+  /**
+   * The custom fees to be assessed during a TransferTransaction that transfers units of the token.
+   */
+  std::vector<std::shared_ptr<CustomFee>> mCustomFees;
+
+  /**
+   * The key which can pause and unpause the new token. If nullptr, the token cannot be paused.
+   */
+  std::shared_ptr<Key> mPauseKey = nullptr;
+
+  /**
+   * Specifies whether the token is paused or not. Uninitialized if mPauseKey is not set, \c TRUE if mPauseKey is set
+   * and the token is paused, or \c FALSE if mPauseKey is set and the token is not paused.
+   */
+  std::optional<bool> mPauseStatus;
+
+  /**
+   * The ID of the ledger from which this response was returned.
+   */
+  LedgerId mLedgerId;
+};
+
+} // namespace Hedera
+
+#endif // HEDERA_SDK_CPP_TOKEN_INFO_H_

--- a/sdk/main/include/TokenInfo.h
+++ b/sdk/main/include/TokenInfo.h
@@ -28,6 +28,7 @@
 #include "TokenSupplyType.h"
 #include "TokenType.h"
 
+#include <chrono>
 #include <cstddef>
 #include <cstdint>
 #include <memory>

--- a/sdk/main/include/TokenInfo.h
+++ b/sdk/main/include/TokenInfo.h
@@ -22,7 +22,6 @@
 
 #include "AccountId.h"
 #include "CustomFee.h"
-#include "Defaults.h"
 #include "Key.h"
 #include "LedgerId.h"
 #include "TokenId.h"
@@ -164,12 +163,12 @@ public:
   /**
    * The interval at which the auto-renew account will be charged to extend the token's expiry.
    */
-  std::chrono::duration<double> mAutoRenewPeriod = DEFAULT_AUTO_RENEW_PERIOD;
+  std::chrono::duration<double> mAutoRenewPeriod;
 
   /**
    * The epoch second at which the token should expire.
    */
-  std::chrono::system_clock::time_point mExpirationTime = std::chrono::system_clock::now() + DEFAULT_AUTO_RENEW_PERIOD;
+  std::chrono::system_clock::time_point mExpirationTime;
 
   /**
    * The memo associated with the token (UTF-8 encoding max 100 bytes).

--- a/sdk/main/include/TokenInfoQuery.h
+++ b/sdk/main/include/TokenInfoQuery.h
@@ -1,0 +1,106 @@
+/*-
+ *
+ * Hedera C++ SDK
+ *
+ * Copyright (C) 2020 - 2022 Hedera Hashgraph, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+#ifndef HEDERA_SDK_CPP_TOKEN_INFO_QUERY_H_
+#define HEDERA_SDK_CPP_TOKEN_INFO_QUERY_H_
+
+#include "Query.h"
+#include "TokenId.h"
+
+namespace Hedera
+{
+class TokenInfo;
+class TransactionRecord;
+}
+
+namespace Hedera
+{
+/**
+ * A query that gets information about a fungible or non-fungible token instance.
+ */
+class TokenInfoQuery : public Query<TokenInfoQuery, TokenInfo>
+{
+public:
+  /**
+   * Set the ID of the token of which to request the info.
+   *
+   * @param token The ID of the token of which to request the info.
+   * @return A reference to this TokenInfoQuery object with the newly-set token ID.
+   */
+  TokenInfoQuery& setTokenId(const TokenId& tokenId);
+
+  /**
+   * Get the ID of the token of which this query is currently configured to get the info.
+   *
+   * @return The ID of the token for which this query is meant.
+   */
+  [[nodiscard]] inline TokenId getTokenId() const { return mTokenId; }
+
+private:
+  /**
+   * Derived from Executable. Construct a Query protobuf object from this TokenInfoQuery object.
+   *
+   * @param client The Client trying to construct this TokenInfoQuery.
+   * @param node   The Node to which this TokenInfoQuery will be sent.
+   * @return A Query protobuf object filled with this TokenInfoQuery object's data.
+   */
+  [[nodiscard]] proto::Query makeRequest(const Client& client,
+                                         const std::shared_ptr<internal::Node>& node) const override;
+
+  /**
+   * Derived from Executable. Construct a TokenInfo object from a Response protobuf object.
+   *
+   * @param response The Response protobuf object from which to construct a TokenInfo object.
+   * @return A TokenInfo object filled with the Response protobuf object's data.
+   */
+  [[nodiscard]] TokenInfo mapResponse(const proto::Response& response) const override;
+
+  /**
+   * Derived from Executable. Get the status response code for a submitted TokenInfoQuery from a Response protobuf
+   * object.
+   *
+   * @param response The Response protobuf object from which to grab the TokenInfoQuery status response code.
+   * @return The TokenInfoQuery status response code of the input Response protobuf object.
+   */
+  [[nodiscard]] Status mapResponseStatus(const proto::Response& response) const override;
+
+  /**
+   * Derived from Executable. Submit this TokenInfoQuery to a Node.
+   *
+   * @param client   The Client submitting this TokenInfoQuery.
+   * @param deadline The deadline for submitting this TokenInfoQuery.
+   * @param node     Pointer to the Node to which this TokenInfoQuery should be submitted.
+   * @param response Pointer to the Response protobuf object that gRPC should populate with the response information
+   *                 from the gRPC server.
+   * @return The gRPC status of the submission.
+   */
+  [[nodiscard]] grpc::Status submitRequest(const Client& client,
+                                           const std::chrono::system_clock::time_point& deadline,
+                                           const std::shared_ptr<internal::Node>& node,
+                                           proto::Response* response) const override;
+
+  /**
+   * The ID of the token of which this query should get the info.
+   */
+  TokenId mTokenId;
+};
+
+} // namespace Hedera
+
+#endif // HEDERA_SDK_CPP_TOKEN_INFO_QUERY_H_

--- a/sdk/main/include/TransferTransaction.h
+++ b/sdk/main/include/TransferTransaction.h
@@ -203,6 +203,7 @@ private:
   friend class ContractInfoQuery;
   friend class FileContentsQuery;
   friend class FileInfoQuery;
+  friend class TokenInfoQuery;
   friend class TransactionRecordQuery;
 
   /**

--- a/sdk/main/src/Executable.cc
+++ b/sdk/main/src/Executable.cc
@@ -50,6 +50,8 @@
 #include "TokenAssociateTransaction.h"
 #include "TokenCreateTransaction.h"
 #include "TokenDeleteTransaction.h"
+#include "TokenInfo.h"
+#include "TokenInfoQuery.h"
 #include "TransactionReceipt.h"
 #include "TransactionReceiptQuery.h"
 #include "TransactionRecord.h"
@@ -354,6 +356,7 @@ template class Executable<TokenAssociateTransaction,
                           TransactionResponse>;
 template class Executable<TokenCreateTransaction, proto::Transaction, proto::TransactionResponse, TransactionResponse>;
 template class Executable<TokenDeleteTransaction, proto::Transaction, proto::TransactionResponse, TransactionResponse>;
+template class Executable<TokenInfoQuery, proto::Query, proto::Response, TokenInfo>;
 template class Executable<TransactionReceiptQuery, proto::Query, proto::Response, TransactionReceipt>;
 template class Executable<TransactionRecordQuery, proto::Query, proto::Response, TransactionRecord>;
 template class Executable<TransferTransaction, proto::Transaction, proto::TransactionResponse, TransactionResponse>;

--- a/sdk/main/src/Query.cc
+++ b/sdk/main/src/Query.cc
@@ -29,6 +29,8 @@
 #include "FileContentsQuery.h"
 #include "FileInfo.h"
 #include "FileInfoQuery.h"
+#include "TokenInfo.h"
+#include "TokenInfoQuery.h"
 #include "TransactionReceipt.h"
 #include "TransactionReceiptQuery.h"
 #include "TransactionRecord.h"
@@ -45,6 +47,7 @@ template class Query<ContractCallQuery, ContractFunctionResult>;
 template class Query<ContractInfoQuery, ContractInfo>;
 template class Query<FileContentsQuery, FileContents>;
 template class Query<FileInfoQuery, FileInfo>;
+template class Query<TokenInfoQuery, TokenInfo>;
 template class Query<TransactionReceiptQuery, TransactionReceipt>;
 template class Query<TransactionRecordQuery, TransactionRecord>;
 

--- a/sdk/main/src/TokenInfo.cc
+++ b/sdk/main/src/TokenInfo.cc
@@ -1,0 +1,132 @@
+/*-
+ *
+ * Hedera C++ SDK
+ *
+ * Copyright (C) 2020 - 2022 Hedera Hashgraph, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+#include "TokenInfo.h"
+#include "impl/DurationConverter.h"
+#include "impl/TimestampConverter.h"
+#include "impl/Utilities.h"
+
+#include <proto/basic_types.pb.h>
+#include <proto/token_get_info.pb.h>
+
+namespace Hedera
+{
+//-----
+TokenInfo TokenInfo::fromProtobuf(const proto::TokenInfo& proto)
+{
+  TokenInfo tokenInfo;
+
+  if (proto.has_tokenid())
+  {
+    tokenInfo.mTokenId = TokenId::fromProtobuf(proto.tokenid());
+  }
+
+  tokenInfo.mTokenName = proto.name();
+  tokenInfo.mTokenSymbol = proto.symbol();
+  tokenInfo.mDecimals = proto.decimals();
+  tokenInfo.mTotalSupply = proto.totalsupply();
+
+  if (proto.has_treasury())
+  {
+    tokenInfo.mTreasuryAccountId = AccountId::fromProtobuf(proto.treasury());
+  }
+
+  if (proto.has_adminkey())
+  {
+    tokenInfo.mAdminKey = Key::fromProtobuf(proto.adminkey());
+  }
+
+  if (proto.has_kyckey())
+  {
+    tokenInfo.mKycKey = Key::fromProtobuf(proto.kyckey());
+  }
+
+  if (proto.has_freezekey())
+  {
+    tokenInfo.mFreezeKey = Key::fromProtobuf(proto.freezekey());
+  }
+
+  if (proto.has_wipekey())
+  {
+    tokenInfo.mWipeKey = Key::fromProtobuf(proto.wipekey());
+  }
+
+  if (proto.has_supplykey())
+  {
+    tokenInfo.mSupplyKey = Key::fromProtobuf(proto.supplykey());
+  }
+
+  if (proto.defaultfreezestatus() != proto::TokenFreezeStatus::FreezeNotApplicable)
+  {
+    tokenInfo.mDefaultFreezeStatus = proto.defaultfreezestatus() == proto::TokenFreezeStatus::Frozen;
+  }
+
+  if (proto.defaultkycstatus() != proto::TokenKycStatus::KycNotApplicable)
+  {
+    tokenInfo.mDefaultKycStatus = proto.defaultkycstatus() == proto::TokenKycStatus::Granted;
+  }
+
+  tokenInfo.mIsDeleted = proto.deleted();
+
+  if (proto.has_autorenewaccount())
+  {
+    tokenInfo.mAutoRenewAccountId = AccountId::fromProtobuf(proto.autorenewaccount());
+  }
+
+  if (proto.has_autorenewperiod())
+  {
+    tokenInfo.mAutoRenewPeriod = internal::DurationConverter::fromProtobuf(proto.autorenewperiod());
+  }
+
+  if (proto.has_expiry())
+  {
+    tokenInfo.mExpirationTime = internal::TimestampConverter::fromProtobuf(proto.expiry());
+  }
+
+  tokenInfo.mTokenMemo = proto.memo();
+  tokenInfo.mTokenType = gProtobufTokenTypeToTokenType.at(proto.tokentype());
+  tokenInfo.mSupplyType = gProtobufTokenSupplyTypeToTokenSupplyType.at(proto.supplytype());
+  tokenInfo.mMaxSupply = static_cast<uint64_t>(proto.maxsupply());
+
+  if (proto.has_fee_schedule_key())
+  {
+    tokenInfo.mFeeScheduleKey = Key::fromProtobuf(proto.fee_schedule_key());
+  }
+
+  for (int i = 0; i < proto.custom_fees_size(); ++i)
+  {
+    tokenInfo.mCustomFees.push_back(CustomFee::fromProtobuf(proto.custom_fees(i)));
+  }
+
+  if (proto.has_pause_key())
+  {
+    tokenInfo.mPauseKey = Key::fromProtobuf(proto.pause_key());
+  }
+
+  if (proto.pause_status() != proto::TokenPauseStatus::PauseNotApplicable)
+  {
+    tokenInfo.mPauseStatus = proto.pause_status() == proto::TokenPauseStatus::Paused;
+  }
+
+  tokenInfo.mLedgerId = LedgerId(internal::Utilities::stringToByteVector(proto.ledger_id()));
+
+  return tokenInfo;
+}
+
+} // namespace Hedera

--- a/sdk/main/src/TokenInfoQuery.cc
+++ b/sdk/main/src/TokenInfoQuery.cc
@@ -1,0 +1,85 @@
+/*-
+ *
+ * Hedera C++ SDK
+ *
+ * Copyright (C) 2020 - 2022 Hedera Hashgraph, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+#include "TokenInfoQuery.h"
+#include "Client.h"
+#include "TokenInfo.h"
+#include "TransactionRecord.h"
+#include "TransferTransaction.h"
+#include "impl/Node.h"
+
+#include <proto/query.pb.h>
+#include <proto/query_header.pb.h>
+#include <proto/response.pb.h>
+#include <proto/token_get_info.pb.h>
+
+namespace Hedera
+{
+//-----
+TokenInfoQuery& TokenInfoQuery::setTokenId(const TokenId& tokenId)
+{
+  mTokenId = tokenId;
+  return *this;
+}
+
+//-----
+proto::Query TokenInfoQuery::makeRequest(const Client& client, const std::shared_ptr<internal::Node>& node) const
+{
+  proto::Query query;
+  proto::TokenGetInfoQuery* getTokenInfoQuery = query.mutable_tokengetinfo();
+
+  proto::QueryHeader* header = getTokenInfoQuery->mutable_header();
+  header->set_responsetype(proto::ANSWER_ONLY);
+
+  TransferTransaction tx = TransferTransaction()
+                             .setTransactionId(TransactionId::generate(*client.getOperatorAccountId()))
+                             .setNodeAccountIds({ node->getAccountId() })
+                             .setMaxTransactionFee(Hbar(1LL))
+                             .addHbarTransfer(*client.getOperatorAccountId(), Hbar(-1LL))
+                             .addHbarTransfer(node->getAccountId(), Hbar(1LL));
+  tx.onSelectNode(node);
+  header->set_allocated_payment(new proto::Transaction(tx.makeRequest(client, node)));
+
+  getTokenInfoQuery->set_allocated_token(mTokenId.toProtobuf().release());
+
+  return query;
+}
+
+//-----
+TokenInfo TokenInfoQuery::mapResponse(const proto::Response& response) const
+{
+  return TokenInfo::fromProtobuf(response.tokengetinfo().tokeninfo());
+}
+
+//-----
+Status TokenInfoQuery::mapResponseStatus(const proto::Response& response) const
+{
+  return gProtobufResponseCodeToStatus.at(response.tokengetinfo().header().nodetransactionprecheckcode());
+}
+
+//-----
+grpc::Status TokenInfoQuery::submitRequest(const Client& client,
+                                           const std::chrono::system_clock::time_point& deadline,
+                                           const std::shared_ptr<internal::Node>& node,
+                                           proto::Response* response) const
+{
+  return node->submitQuery(proto::Query::QueryCase::kTokenGetInfo, makeRequest(client, node), deadline, response);
+}
+
+} // namespace Hedera

--- a/sdk/main/src/impl/Node.cc
+++ b/sdk/main/src/impl/Node.cc
@@ -130,6 +130,8 @@ grpc::Status Node::submitQuery(proto::Query::QueryCase funcEnum,
       return mFileStub->getFileContent(&context, query, response);
     case proto::Query::QueryCase::kFileGetInfo:
       return mFileStub->getFileInfo(&context, query, response);
+    case proto::Query::QueryCase::kTokenGetInfo:
+      return mTokenStub->getTokenInfo(&context, query, response);
     case proto::Query::QueryCase::kTransactionGetReceipt:
       return mCryptoStub->getTransactionReceipts(&context, query, response);
     case proto::Query::QueryCase::kTransactionGetRecord:

--- a/sdk/tests/integration/CMakeLists.txt
+++ b/sdk/tests/integration/CMakeLists.txt
@@ -27,6 +27,7 @@ add_executable(${TEST_PROJECT_NAME}
         TokenAssociateTransactionIntegrationTests.cc
         TokenCreateTransactionIntegrationTests.cc
         TokenDeleteTransactionIntegrationTests.cc
+        TokenInfoQueryIntegrationTests.cc
         TokenMintTransactionIntegrationTests.cc
         TransactionIntegrationTest.cc
         TransactionReceiptIntegrationTest.cc

--- a/sdk/tests/integration/TokenInfoQueryIntegrationTests.cc
+++ b/sdk/tests/integration/TokenInfoQueryIntegrationTests.cc
@@ -1,0 +1,248 @@
+/*-
+ *
+ * Hedera C++ SDK
+ *
+ * Copyright (C) 2020 - 2022 Hedera Hashgraph, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+#include "BaseIntegrationTest.h"
+#include "Client.h"
+#include "CustomFixedFee.h"
+#include "ED25519PrivateKey.h"
+#include "PrivateKey.h"
+#include "TokenCreateTransaction.h"
+#include "TokenDeleteTransaction.h"
+#include "TokenInfo.h"
+#include "TokenInfoQuery.h"
+#include "TokenMintTransaction.h"
+#include "TransactionReceipt.h"
+#include "TransactionResponse.h"
+#include "impl/Utilities.h"
+
+#include <gtest/gtest.h>
+
+using namespace Hedera;
+
+class TokenInfoQueryIntegrationTest : public BaseIntegrationTest
+{
+};
+
+//-----
+TEST_F(TokenInfoQueryIntegrationTest, ExecuteTokenInfoQuery)
+{
+  // Given
+  std::shared_ptr<PrivateKey> operatorKey;
+  std::shared_ptr<PrivateKey> adminKey;
+  std::shared_ptr<PrivateKey> freezeKey;
+  std::shared_ptr<PrivateKey> wipeKey;
+  std::shared_ptr<PrivateKey> kycKey;
+  std::shared_ptr<PrivateKey> supplyKey;
+  std::shared_ptr<PrivateKey> feeScheduleKey;
+  std::shared_ptr<PrivateKey> pauseKey;
+
+  ASSERT_NO_THROW(
+    operatorKey = ED25519PrivateKey::fromString(
+      "302e020100300506032b65700422042091132178e72057a1d7528025956fe39b0b847f200ab59b2fdd367017f3087137"));
+  ASSERT_NO_THROW(adminKey = ED25519PrivateKey::generatePrivateKey());
+  ASSERT_NO_THROW(freezeKey = ED25519PrivateKey::generatePrivateKey());
+  ASSERT_NO_THROW(wipeKey = ED25519PrivateKey::generatePrivateKey());
+  ASSERT_NO_THROW(kycKey = ED25519PrivateKey::generatePrivateKey());
+  ASSERT_NO_THROW(supplyKey = ED25519PrivateKey::generatePrivateKey());
+  ASSERT_NO_THROW(feeScheduleKey = ED25519PrivateKey::generatePrivateKey());
+  ASSERT_NO_THROW(pauseKey = ED25519PrivateKey::generatePrivateKey());
+
+  const std::string tokenName = "ffff";
+  const std::string tokenSymbol = "F";
+  const uint32_t decimals = 3U;
+  const uint64_t supply = 100000ULL;
+  const std::string memo = "test memo";
+  const std::vector<std::shared_ptr<CustomFee>> customFees = { std::make_shared<CustomFixedFee>(
+    CustomFixedFee().setAmount(10LL).setFeeCollectorAccountId(AccountId(2ULL))) };
+
+  TokenId tokenId;
+  ASSERT_NO_THROW(tokenId = TokenCreateTransaction()
+                              .setTokenName(tokenName)
+                              .setTokenSymbol(tokenSymbol)
+                              .setDecimals(decimals)
+                              .setInitialSupply(supply)
+                              .setTreasuryAccountId(AccountId(2ULL))
+                              .setAdminKey(adminKey)
+                              .setFreezeKey(freezeKey)
+                              .setWipeKey(wipeKey)
+                              .setKycKey(kycKey)
+                              .setSupplyKey(supplyKey)
+                              .setTokenMemo(memo)
+                              .setFeeScheduleKey(feeScheduleKey)
+                              .setCustomFees(customFees)
+                              .setPauseKey(pauseKey)
+                              .freezeWith(getTestClient())
+                              .sign(adminKey.get())
+                              .execute(getTestClient())
+                              .getReceipt(getTestClient())
+                              .mTokenId.value());
+
+  // When
+  TokenInfo tokenInfo;
+  EXPECT_NO_THROW(tokenInfo = TokenInfoQuery().setTokenId(tokenId).execute(getTestClient()));
+
+  // Then
+  EXPECT_EQ(tokenInfo.mTokenId, tokenId);
+  EXPECT_EQ(tokenInfo.mTokenName, tokenName);
+  EXPECT_EQ(tokenInfo.mTokenSymbol, tokenSymbol);
+  EXPECT_EQ(tokenInfo.mDecimals, decimals);
+  EXPECT_EQ(tokenInfo.mTotalSupply, supply);
+  EXPECT_EQ(tokenInfo.mTreasuryAccountId, AccountId(2ULL));
+  ASSERT_NE(tokenInfo.mAdminKey, nullptr);
+  EXPECT_EQ(tokenInfo.mAdminKey->toBytes(), adminKey->getPublicKey()->toBytes());
+  ASSERT_NE(tokenInfo.mKycKey, nullptr);
+  EXPECT_EQ(tokenInfo.mKycKey->toBytes(), kycKey->getPublicKey()->toBytes());
+  ASSERT_NE(tokenInfo.mFreezeKey, nullptr);
+  EXPECT_EQ(tokenInfo.mFreezeKey->toBytes(), freezeKey->getPublicKey()->toBytes());
+  ASSERT_NE(tokenInfo.mWipeKey, nullptr);
+  EXPECT_EQ(tokenInfo.mWipeKey->toBytes(), wipeKey->getPublicKey()->toBytes());
+  ASSERT_NE(tokenInfo.mSupplyKey, nullptr);
+  EXPECT_EQ(tokenInfo.mSupplyKey->toBytes(), supplyKey->getPublicKey()->toBytes());
+  EXPECT_FALSE(tokenInfo.mDefaultFreezeStatus.value());
+  EXPECT_FALSE(tokenInfo.mDefaultKycStatus.value());
+  EXPECT_FALSE(tokenInfo.mIsDeleted);
+  EXPECT_EQ(tokenInfo.mTokenMemo, memo);
+  EXPECT_EQ(tokenInfo.mTokenType, TokenType::FUNGIBLE_COMMON);
+  EXPECT_EQ(tokenInfo.mSupplyType, TokenSupplyType::INFINITE);
+  ASSERT_NE(tokenInfo.mFeeScheduleKey, nullptr);
+  EXPECT_EQ(tokenInfo.mFeeScheduleKey->toBytes(), feeScheduleKey->getPublicKey()->toBytes());
+  EXPECT_EQ(tokenInfo.mCustomFees.size(), customFees.size());
+  ASSERT_NE(tokenInfo.mPauseKey, nullptr);
+  EXPECT_EQ(tokenInfo.mPauseKey->toBytes(), pauseKey->getPublicKey()->toBytes());
+  EXPECT_FALSE(tokenInfo.mPauseStatus.value());
+
+  // Clean up
+  ASSERT_NO_THROW(const TransactionReceipt txReceipt = TokenDeleteTransaction()
+                                                         .setTokenId(tokenId)
+                                                         .freezeWith(getTestClient())
+                                                         .sign(adminKey.get())
+                                                         .execute(getTestClient())
+                                                         .getReceipt(getTestClient()));
+}
+
+//-----
+TEST_F(TokenInfoQueryIntegrationTest, CanQueryTokenWithMinimalProperties)
+{
+  // Given
+  std::shared_ptr<PrivateKey> operatorKey;
+  ASSERT_NO_THROW(
+    operatorKey = ED25519PrivateKey::fromString(
+      "302e020100300506032b65700422042091132178e72057a1d7528025956fe39b0b847f200ab59b2fdd367017f3087137"));
+
+  const std::string tokenName = "ffff";
+  const std::string tokenSymbol = "F";
+
+  TokenId tokenId;
+  ASSERT_NO_THROW(tokenId = TokenCreateTransaction()
+                              .setTokenName(tokenName)
+                              .setTokenSymbol(tokenSymbol)
+                              .setTreasuryAccountId(AccountId(2ULL))
+                              .execute(getTestClient())
+                              .getReceipt(getTestClient())
+                              .mTokenId.value());
+
+  // When
+  TokenInfo tokenInfo;
+  EXPECT_NO_THROW(tokenInfo = TokenInfoQuery().setTokenId(tokenId).execute(getTestClient()));
+
+  // Then
+  EXPECT_EQ(tokenInfo.mTokenId, tokenId);
+  EXPECT_EQ(tokenInfo.mTokenName, tokenName);
+  EXPECT_EQ(tokenInfo.mTokenSymbol, tokenSymbol);
+  EXPECT_EQ(tokenInfo.mDecimals, 0U);
+  EXPECT_EQ(tokenInfo.mTotalSupply, 0U);
+  EXPECT_EQ(tokenInfo.mTreasuryAccountId, AccountId(2ULL));
+  EXPECT_EQ(tokenInfo.mAdminKey, nullptr);
+  EXPECT_EQ(tokenInfo.mKycKey, nullptr);
+  EXPECT_EQ(tokenInfo.mFreezeKey, nullptr);
+  EXPECT_EQ(tokenInfo.mWipeKey, nullptr);
+  EXPECT_EQ(tokenInfo.mSupplyKey, nullptr);
+  EXPECT_FALSE(tokenInfo.mDefaultFreezeStatus.has_value());
+  EXPECT_FALSE(tokenInfo.mDefaultKycStatus.has_value());
+  EXPECT_FALSE(tokenInfo.mIsDeleted);
+  EXPECT_EQ(tokenInfo.mTokenType, TokenType::FUNGIBLE_COMMON);
+  EXPECT_EQ(tokenInfo.mSupplyType, TokenSupplyType::INFINITE);
+  EXPECT_EQ(tokenInfo.mFeeScheduleKey, nullptr);
+  EXPECT_TRUE(tokenInfo.mCustomFees.empty());
+  EXPECT_EQ(tokenInfo.mPauseKey, nullptr);
+  EXPECT_FALSE(tokenInfo.mPauseStatus.has_value());
+}
+
+//-----
+TEST_F(TokenInfoQueryIntegrationTest, CanQueryNft)
+{
+  // Given
+  std::shared_ptr<PrivateKey> operatorKey;
+  ASSERT_NO_THROW(
+    operatorKey = ED25519PrivateKey::fromString(
+      "302e020100300506032b65700422042091132178e72057a1d7528025956fe39b0b847f200ab59b2fdd367017f3087137"));
+
+  const std::string tokenName = "ffff";
+  const std::string tokenSymbol = "F";
+  const uint64_t maxSupply = 5000ULL;
+  const uint64_t supply = 10ULL;
+
+  TokenId tokenId;
+  ASSERT_NO_THROW(tokenId = TokenCreateTransaction()
+                              .setTokenName(tokenName)
+                              .setTokenSymbol(tokenSymbol)
+                              .setTreasuryAccountId(AccountId(2ULL))
+                              .setAdminKey(operatorKey)
+                              .setSupplyKey(operatorKey)
+                              .setTokenType(TokenType::NON_FUNGIBLE_UNIQUE)
+                              .setSupplyType(TokenSupplyType::FINITE)
+                              .setMaxSupply(maxSupply)
+                              .execute(getTestClient())
+                              .getReceipt(getTestClient())
+                              .mTokenId.value());
+
+  TransactionReceipt txReceipt;
+  ASSERT_NO_THROW(txReceipt = TokenMintTransaction()
+                                .setTokenId(tokenId)
+                                .setMetadata(std::vector<std::vector<std::byte>>(supply, { std::byte(0x01) }))
+                                .execute(getTestClient())
+                                .getReceipt(getTestClient()));
+
+  // When
+  TokenInfo tokenInfo;
+  EXPECT_NO_THROW(tokenInfo = TokenInfoQuery().setTokenId(tokenId).execute(getTestClient()));
+
+  // Then
+  EXPECT_EQ(tokenInfo.mTokenId, tokenId);
+  EXPECT_EQ(tokenInfo.mTokenName, tokenName);
+  EXPECT_EQ(tokenInfo.mTokenSymbol, tokenSymbol);
+  EXPECT_EQ(tokenInfo.mDecimals, 0U);
+  EXPECT_EQ(tokenInfo.mTotalSupply, supply);
+  EXPECT_EQ(tokenInfo.mTreasuryAccountId, AccountId(2ULL));
+  EXPECT_NE(tokenInfo.mAdminKey, nullptr);
+  EXPECT_EQ(tokenInfo.mKycKey, nullptr);
+  EXPECT_EQ(tokenInfo.mFreezeKey, nullptr);
+  EXPECT_EQ(tokenInfo.mWipeKey, nullptr);
+  EXPECT_NE(tokenInfo.mSupplyKey, nullptr);
+  EXPECT_FALSE(tokenInfo.mDefaultFreezeStatus.has_value());
+  EXPECT_FALSE(tokenInfo.mDefaultKycStatus.has_value());
+  EXPECT_FALSE(tokenInfo.mIsDeleted);
+  EXPECT_EQ(tokenInfo.mTokenType, TokenType::NON_FUNGIBLE_UNIQUE);
+  EXPECT_EQ(tokenInfo.mSupplyType, TokenSupplyType::FINITE);
+  EXPECT_EQ(tokenInfo.mMaxSupply, maxSupply);
+  EXPECT_EQ(tokenInfo.mFeeScheduleKey, nullptr);
+  EXPECT_TRUE(tokenInfo.mCustomFees.empty());
+  EXPECT_EQ(tokenInfo.mPauseKey, nullptr);
+  EXPECT_FALSE(tokenInfo.mPauseStatus.has_value());
+}

--- a/sdk/tests/unit/CMakeLists.txt
+++ b/sdk/tests/unit/CMakeLists.txt
@@ -65,6 +65,8 @@ add_executable(${TEST_PROJECT_NAME}
         TokenCreateTransactionTest.cc
         TokenDeleteTransactionTest.cc
         TokenIdTest.cc
+        TokenInfoQueryUnitTests.cc
+        TokenInfoUnitTests.cc
         TokenNftAllowanceTest.cc
         TokenNftRemoveAllowanceTest.cc
         TokenNftTransferTest.cc

--- a/sdk/tests/unit/TokenInfoQueryUnitTests.cc
+++ b/sdk/tests/unit/TokenInfoQueryUnitTests.cc
@@ -1,0 +1,46 @@
+/*-
+ *
+ * Hedera C++ SDK
+ *
+ * Copyright (C) 2020 - 2022 Hedera Hashgraph, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+#include "TokenInfoQuery.h"
+
+#include <gtest/gtest.h>
+
+using namespace Hedera;
+
+class TokenInfoQueryTest : public ::testing::Test
+{
+protected:
+  [[nodiscard]] inline const TokenId& getTestTokenId() const { return mTestTokenId; }
+
+private:
+  const TokenId mTestTokenId = TokenId(1ULL);
+};
+
+//-----
+TEST_F(TokenInfoQueryTest, GetSetTokenId)
+{
+  // Given
+  TokenInfoQuery query;
+
+  // When
+  query.setTokenId(getTestTokenId());
+
+  // Then
+  EXPECT_EQ(query.getTokenId(), getTestTokenId());
+}

--- a/sdk/tests/unit/TokenInfoUnitTests.cc
+++ b/sdk/tests/unit/TokenInfoUnitTests.cc
@@ -1,0 +1,431 @@
+/*-
+ *
+ * Hedera C++ SDK
+ *
+ * Copyright (C) 2020 - 2022 Hedera Hashgraph, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+#include "CustomFixedFee.h"
+#include "CustomFractionalFee.h"
+#include "CustomRoyaltyFee.h"
+#include "ECDSAsecp256k1PrivateKey.h"
+#include "TokenInfo.h"
+#include "impl/DurationConverter.h"
+#include "impl/TimestampConverter.h"
+#include "impl/Utilities.h"
+
+#include <gtest/gtest.h>
+#include <proto/token_get_info.pb.h>
+
+using namespace Hedera;
+
+class TokenInfoTest : public ::testing::Test
+{
+protected:
+  [[nodiscard]] inline const TokenId& getTestTokenId() const { return mTestTokenId; }
+  [[nodiscard]] inline const std::string& getTestTokenName() const { return mTestTokenName; }
+  [[nodiscard]] inline const std::string& getTestTokenSymbol() const { return mTestTokenSymbol; }
+  [[nodiscard]] inline uint32_t getTestDecimals() const { return mTestDecimals; }
+  [[nodiscard]] inline const uint64_t& getTestTotalSupply() const { return mTestTotalSupply; }
+  [[nodiscard]] inline const AccountId& getTestTreasuryAccountId() const { return mTestTreasuryAccountId; }
+  [[nodiscard]] inline const std::shared_ptr<PublicKey>& getTestAdminKey() const { return mTestAdminKey; }
+  [[nodiscard]] inline const std::shared_ptr<PublicKey>& getTestKycKey() const { return mTestKycKey; }
+  [[nodiscard]] inline const std::shared_ptr<PublicKey>& getTestFreezeKey() const { return mTestFreezeKey; }
+  [[nodiscard]] inline const std::shared_ptr<PublicKey>& getTestWipeKey() const { return mTestWipeKey; }
+  [[nodiscard]] inline const std::shared_ptr<PublicKey>& getTestSupplyKey() const { return mTestSupplyKey; }
+  [[nodiscard]] inline const std::optional<bool>& getTestDefaultFreezeStatus() const
+  {
+    return mTestDefaultFreezeStatus;
+  }
+  [[nodiscard]] inline const std::optional<bool>& getTestDefaultKycStatus() const { return mTestDefaultKycStatus; }
+  [[nodiscard]] inline bool getTestIsDeleted() const { return mTestIsDeleted; }
+  [[nodiscard]] inline const std::chrono::system_clock::time_point& getTestExpirationTime() const
+  {
+    return mTestExpirationTime;
+  }
+  [[nodiscard]] inline const AccountId& getTestAutoRenewAccountId() const { return mTestAutoRenewAccountId; }
+  [[nodiscard]] inline const std::chrono::duration<double>& getTestAutoRenewPeriod() const
+  {
+    return mTestAutoRenewPeriod;
+  }
+  [[nodiscard]] inline const std::string& getTestTokenMemo() const { return mTestTokenMemo; }
+  [[nodiscard]] inline TokenType getTestTokenType() const { return mTestTokenType; }
+  [[nodiscard]] inline TokenSupplyType getTestTokenSupplyType() const { return mTestTokenSupplyType; }
+  [[nodiscard]] inline const uint64_t& getTestMaxSupply() const { return mTestMaxSupply; }
+  [[nodiscard]] inline const std::shared_ptr<PublicKey>& getTestFeeScheduleKey() const { return mTestFeeScheduleKey; }
+  [[nodiscard]] inline const std::vector<std::shared_ptr<CustomFee>>& getTestCustomFees() const
+  {
+    return mTestCustomFees;
+  }
+  [[nodiscard]] inline const std::shared_ptr<PublicKey>& getTestPauseKey() const { return mTestPauseKey; }
+  [[nodiscard]] inline const std::optional<bool>& getTestPauseStatus() const { return mTestPauseStatus; }
+  [[nodiscard]] inline const LedgerId& getTestLedgerId() const { return mTestLedgerId; }
+
+private:
+  const TokenId mTestTokenId = TokenId(1ULL, 2ULL, 3ULL);
+  const std::string mTestTokenName = "test name";
+  const std::string mTestTokenSymbol = "test symbol";
+  const uint32_t mTestDecimals = 4U;
+  const uint64_t mTestTotalSupply = 5ULL;
+  const AccountId mTestTreasuryAccountId = AccountId(6ULL, 7ULL, 8ULL);
+  const std::shared_ptr<PublicKey> mTestAdminKey = ECDSAsecp256k1PrivateKey::generatePrivateKey()->getPublicKey();
+  const std::shared_ptr<PublicKey> mTestKycKey = ECDSAsecp256k1PrivateKey::generatePrivateKey()->getPublicKey();
+  const std::shared_ptr<PublicKey> mTestFreezeKey = ECDSAsecp256k1PrivateKey::generatePrivateKey()->getPublicKey();
+  const std::shared_ptr<PublicKey> mTestWipeKey = ECDSAsecp256k1PrivateKey::generatePrivateKey()->getPublicKey();
+  const std::shared_ptr<PublicKey> mTestSupplyKey = ECDSAsecp256k1PrivateKey::generatePrivateKey()->getPublicKey();
+  const std::optional<bool> mTestDefaultFreezeStatus = true;
+  const std::optional<bool> mTestDefaultKycStatus = true;
+  const bool mTestIsDeleted = true;
+  const std::chrono::system_clock::time_point mTestExpirationTime = std::chrono::system_clock::now();
+  const AccountId mTestAutoRenewAccountId = AccountId(9ULL, 10ULL, 11ULL);
+  const std::chrono::duration<double> mTestAutoRenewPeriod = std::chrono::hours(12);
+  const std::string mTestTokenMemo = "test memo";
+  const TokenType mTestTokenType = TokenType::NON_FUNGIBLE_UNIQUE;
+  const TokenSupplyType mTestTokenSupplyType = TokenSupplyType::FINITE;
+  const uint64_t mTestMaxSupply = 13ULL;
+  const std::shared_ptr<PublicKey> mTestFeeScheduleKey = ECDSAsecp256k1PrivateKey::generatePrivateKey()->getPublicKey();
+  const std::vector<std::shared_ptr<CustomFee>> mTestCustomFees = { std::make_shared<CustomFixedFee>(),
+                                                                    std::make_shared<CustomFractionalFee>(),
+                                                                    std::make_shared<CustomRoyaltyFee>() };
+  const std::shared_ptr<PublicKey> mTestPauseKey = ECDSAsecp256k1PrivateKey::generatePrivateKey()->getPublicKey();
+  const std::optional<bool> mTestPauseStatus = true;
+  const LedgerId mTestLedgerId = LedgerId({ std::byte(0x0E), std::byte(0x0F) });
+};
+
+//-----
+TEST_F(TokenInfoTest, FromProtobuf)
+{
+  // Given
+  proto::TokenInfo protoTokenInfo;
+  protoTokenInfo.set_allocated_tokenid(getTestTokenId().toProtobuf().release());
+  protoTokenInfo.set_name(getTestTokenName());
+  protoTokenInfo.set_symbol(getTestTokenSymbol());
+  protoTokenInfo.set_decimals(getTestDecimals());
+  protoTokenInfo.set_totalsupply(getTestTotalSupply());
+  protoTokenInfo.set_allocated_treasury(getTestTreasuryAccountId().toProtobuf().release());
+  protoTokenInfo.set_allocated_adminkey(getTestAdminKey()->toProtobufKey().release());
+  protoTokenInfo.set_allocated_kyckey(getTestKycKey()->toProtobufKey().release());
+  protoTokenInfo.set_allocated_freezekey(getTestFreezeKey()->toProtobufKey().release());
+  protoTokenInfo.set_allocated_wipekey(getTestWipeKey()->toProtobufKey().release());
+  protoTokenInfo.set_allocated_supplykey(getTestSupplyKey()->toProtobufKey().release());
+
+  if (getTestDefaultFreezeStatus().has_value())
+  {
+    protoTokenInfo.set_defaultfreezestatus(getTestDefaultFreezeStatus().value() ? proto::TokenFreezeStatus::Frozen
+                                                                                : proto::TokenFreezeStatus::Unfrozen);
+  }
+  else
+  {
+    protoTokenInfo.set_defaultfreezestatus(proto::TokenFreezeStatus::FreezeNotApplicable);
+  }
+
+  if (getTestDefaultKycStatus().has_value())
+  {
+    protoTokenInfo.set_defaultkycstatus(getTestDefaultKycStatus().value() ? proto::TokenKycStatus::Granted
+                                                                          : proto::TokenKycStatus::Revoked);
+  }
+  else
+  {
+    protoTokenInfo.set_defaultkycstatus(proto::TokenKycStatus::KycNotApplicable);
+  }
+
+  protoTokenInfo.set_deleted(getTestIsDeleted());
+  protoTokenInfo.set_allocated_autorenewaccount(getTestAutoRenewAccountId().toProtobuf().release());
+  protoTokenInfo.set_allocated_autorenewperiod(internal::DurationConverter::toProtobuf(getTestAutoRenewPeriod()));
+  protoTokenInfo.set_allocated_expiry(internal::TimestampConverter::toProtobuf(getTestExpirationTime()));
+  protoTokenInfo.set_memo(getTestTokenMemo());
+  protoTokenInfo.set_tokentype(gTokenTypeToProtobufTokenType.at(getTestTokenType()));
+  protoTokenInfo.set_supplytype(gTokenSupplyTypeToProtobufTokenSupplyType.at(getTestTokenSupplyType()));
+  protoTokenInfo.set_maxsupply(static_cast<int64_t>(getTestMaxSupply()));
+  protoTokenInfo.set_allocated_fee_schedule_key(getTestFeeScheduleKey()->toProtobufKey().release());
+
+  for (const auto& fee : getTestCustomFees())
+  {
+    *protoTokenInfo.add_custom_fees() = *fee->toProtobuf();
+  }
+
+  protoTokenInfo.set_allocated_pause_key(getTestPauseKey()->toProtobufKey().release());
+
+  if (getTestPauseStatus().has_value())
+  {
+    protoTokenInfo.set_pause_status(getTestPauseStatus().value() ? proto::TokenPauseStatus::Paused
+                                                                 : proto::TokenPauseStatus::Unpaused);
+  }
+  else
+  {
+    protoTokenInfo.set_pause_status(proto::TokenPauseStatus::PauseNotApplicable);
+  }
+
+  protoTokenInfo.set_ledger_id(internal::Utilities::byteVectorToString(getTestLedgerId().toBytes()));
+
+  // When
+  const TokenInfo tokenInfo = TokenInfo::fromProtobuf(protoTokenInfo);
+
+  // Then
+  EXPECT_EQ(tokenInfo.mTokenId, getTestTokenId());
+  EXPECT_EQ(tokenInfo.mTokenName, getTestTokenName());
+  EXPECT_EQ(tokenInfo.mTokenSymbol, getTestTokenSymbol());
+  EXPECT_EQ(tokenInfo.mDecimals, getTestDecimals());
+  EXPECT_EQ(tokenInfo.mTotalSupply, getTestTotalSupply());
+  EXPECT_EQ(tokenInfo.mTreasuryAccountId, getTestTreasuryAccountId());
+  EXPECT_EQ(tokenInfo.mAdminKey->toBytes(), getTestAdminKey()->toBytes());
+  EXPECT_EQ(tokenInfo.mKycKey->toBytes(), getTestKycKey()->toBytes());
+  EXPECT_EQ(tokenInfo.mFreezeKey->toBytes(), getTestFreezeKey()->toBytes());
+  EXPECT_EQ(tokenInfo.mWipeKey->toBytes(), getTestWipeKey()->toBytes());
+  EXPECT_EQ(tokenInfo.mSupplyKey->toBytes(), getTestSupplyKey()->toBytes());
+  EXPECT_EQ(tokenInfo.mDefaultFreezeStatus, getTestDefaultFreezeStatus());
+  EXPECT_EQ(tokenInfo.mDefaultKycStatus, getTestDefaultKycStatus());
+  EXPECT_EQ(tokenInfo.mIsDeleted, getTestIsDeleted());
+  EXPECT_EQ(tokenInfo.mAutoRenewAccountId, getTestAutoRenewAccountId());
+  EXPECT_EQ(tokenInfo.mAutoRenewPeriod, getTestAutoRenewPeriod());
+  EXPECT_EQ(tokenInfo.mExpirationTime, getTestExpirationTime());
+  EXPECT_EQ(tokenInfo.mTokenMemo, getTestTokenMemo());
+  EXPECT_EQ(tokenInfo.mTokenType, getTestTokenType());
+  EXPECT_EQ(tokenInfo.mSupplyType, getTestTokenSupplyType());
+  EXPECT_EQ(tokenInfo.mMaxSupply, getTestMaxSupply());
+  EXPECT_EQ(tokenInfo.mFeeScheduleKey->toBytes(), getTestFeeScheduleKey()->toBytes());
+  EXPECT_EQ(tokenInfo.mCustomFees.size(), 3);
+  EXPECT_EQ(tokenInfo.mPauseKey->toBytes(), getTestPauseKey()->toBytes());
+  EXPECT_EQ(tokenInfo.mPauseStatus, getTestPauseStatus());
+  EXPECT_EQ(tokenInfo.mLedgerId.toBytes(), getTestLedgerId().toBytes());
+}
+
+//-----
+TEST_F(TokenInfoTest, FromBytes)
+{
+  // Given
+  proto::TokenInfo protoTokenInfo;
+  protoTokenInfo.set_allocated_tokenid(getTestTokenId().toProtobuf().release());
+  protoTokenInfo.set_name(getTestTokenName());
+  protoTokenInfo.set_symbol(getTestTokenSymbol());
+  protoTokenInfo.set_decimals(getTestDecimals());
+  protoTokenInfo.set_totalsupply(getTestTotalSupply());
+  protoTokenInfo.set_allocated_treasury(getTestTreasuryAccountId().toProtobuf().release());
+  protoTokenInfo.set_allocated_adminkey(getTestAdminKey()->toProtobufKey().release());
+  protoTokenInfo.set_allocated_kyckey(getTestKycKey()->toProtobufKey().release());
+  protoTokenInfo.set_allocated_freezekey(getTestFreezeKey()->toProtobufKey().release());
+  protoTokenInfo.set_allocated_wipekey(getTestWipeKey()->toProtobufKey().release());
+  protoTokenInfo.set_allocated_supplykey(getTestSupplyKey()->toProtobufKey().release());
+
+  if (getTestDefaultFreezeStatus().has_value())
+  {
+    protoTokenInfo.set_defaultfreezestatus(getTestDefaultFreezeStatus().value() ? proto::TokenFreezeStatus::Frozen
+                                                                                : proto::TokenFreezeStatus::Unfrozen);
+  }
+  else
+  {
+    protoTokenInfo.set_defaultfreezestatus(proto::TokenFreezeStatus::FreezeNotApplicable);
+  }
+
+  if (getTestDefaultKycStatus().has_value())
+  {
+    protoTokenInfo.set_defaultkycstatus(getTestDefaultKycStatus().value() ? proto::TokenKycStatus::Granted
+                                                                          : proto::TokenKycStatus::Revoked);
+  }
+  else
+  {
+    protoTokenInfo.set_defaultkycstatus(proto::TokenKycStatus::KycNotApplicable);
+  }
+
+  protoTokenInfo.set_deleted(getTestIsDeleted());
+  protoTokenInfo.set_allocated_autorenewaccount(getTestAutoRenewAccountId().toProtobuf().release());
+  protoTokenInfo.set_allocated_autorenewperiod(internal::DurationConverter::toProtobuf(getTestAutoRenewPeriod()));
+  protoTokenInfo.set_allocated_expiry(internal::TimestampConverter::toProtobuf(getTestExpirationTime()));
+  protoTokenInfo.set_memo(getTestTokenMemo());
+  protoTokenInfo.set_tokentype(gTokenTypeToProtobufTokenType.at(getTestTokenType()));
+  protoTokenInfo.set_supplytype(gTokenSupplyTypeToProtobufTokenSupplyType.at(getTestTokenSupplyType()));
+  protoTokenInfo.set_maxsupply(static_cast<int64_t>(getTestMaxSupply()));
+  protoTokenInfo.set_allocated_fee_schedule_key(getTestFeeScheduleKey()->toProtobufKey().release());
+
+  for (const auto& fee : getTestCustomFees())
+  {
+    *protoTokenInfo.add_custom_fees() = *fee->toProtobuf();
+  }
+
+  protoTokenInfo.set_allocated_pause_key(getTestPauseKey()->toProtobufKey().release());
+
+  if (getTestPauseStatus().has_value())
+  {
+    protoTokenInfo.set_pause_status(getTestPauseStatus().value() ? proto::TokenPauseStatus::Paused
+                                                                 : proto::TokenPauseStatus::Unpaused);
+  }
+  else
+  {
+    protoTokenInfo.set_pause_status(proto::TokenPauseStatus::PauseNotApplicable);
+  }
+
+  protoTokenInfo.set_ledger_id(internal::Utilities::byteVectorToString(getTestLedgerId().toBytes()));
+
+  // When
+  const TokenInfo tokenInfo =
+    TokenInfo::fromBytes(internal::Utilities::stringToByteVector(protoTokenInfo.SerializeAsString()));
+
+  // Then
+  EXPECT_EQ(tokenInfo.mTokenId, getTestTokenId());
+  EXPECT_EQ(tokenInfo.mTokenName, getTestTokenName());
+  EXPECT_EQ(tokenInfo.mTokenSymbol, getTestTokenSymbol());
+  EXPECT_EQ(tokenInfo.mDecimals, getTestDecimals());
+  EXPECT_EQ(tokenInfo.mTotalSupply, getTestTotalSupply());
+  EXPECT_EQ(tokenInfo.mTreasuryAccountId, getTestTreasuryAccountId());
+  EXPECT_EQ(tokenInfo.mAdminKey->toBytes(), getTestAdminKey()->toBytes());
+  EXPECT_EQ(tokenInfo.mKycKey->toBytes(), getTestKycKey()->toBytes());
+  EXPECT_EQ(tokenInfo.mFreezeKey->toBytes(), getTestFreezeKey()->toBytes());
+  EXPECT_EQ(tokenInfo.mWipeKey->toBytes(), getTestWipeKey()->toBytes());
+  EXPECT_EQ(tokenInfo.mSupplyKey->toBytes(), getTestSupplyKey()->toBytes());
+  EXPECT_EQ(tokenInfo.mDefaultFreezeStatus, getTestDefaultFreezeStatus());
+  EXPECT_EQ(tokenInfo.mDefaultKycStatus, getTestDefaultKycStatus());
+  EXPECT_EQ(tokenInfo.mIsDeleted, getTestIsDeleted());
+  EXPECT_EQ(tokenInfo.mAutoRenewAccountId, getTestAutoRenewAccountId());
+  EXPECT_EQ(tokenInfo.mAutoRenewPeriod, getTestAutoRenewPeriod());
+  EXPECT_EQ(tokenInfo.mExpirationTime, getTestExpirationTime());
+  EXPECT_EQ(tokenInfo.mTokenMemo, getTestTokenMemo());
+  EXPECT_EQ(tokenInfo.mTokenType, getTestTokenType());
+  EXPECT_EQ(tokenInfo.mSupplyType, getTestTokenSupplyType());
+  EXPECT_EQ(tokenInfo.mMaxSupply, getTestMaxSupply());
+  EXPECT_EQ(tokenInfo.mFeeScheduleKey->toBytes(), getTestFeeScheduleKey()->toBytes());
+  EXPECT_EQ(tokenInfo.mCustomFees.size(), 3);
+  EXPECT_EQ(tokenInfo.mPauseKey->toBytes(), getTestPauseKey()->toBytes());
+  EXPECT_EQ(tokenInfo.mPauseStatus, getTestPauseStatus());
+  EXPECT_EQ(tokenInfo.mLedgerId.toBytes(), getTestLedgerId().toBytes());
+}
+
+//-----
+TEST_F(TokenInfoTest, ToProtobuf)
+{
+  // Given
+  TokenInfo tokenInfo;
+  tokenInfo.mTokenId = getTestTokenId();
+  tokenInfo.mTokenName = getTestTokenName();
+  tokenInfo.mTokenSymbol = getTestTokenSymbol();
+  tokenInfo.mDecimals = getTestDecimals();
+  tokenInfo.mTotalSupply = getTestTotalSupply();
+  tokenInfo.mTreasuryAccountId = getTestTreasuryAccountId();
+  tokenInfo.mAdminKey = getTestAdminKey();
+  tokenInfo.mKycKey = getTestKycKey();
+  tokenInfo.mFreezeKey = getTestFreezeKey();
+  tokenInfo.mWipeKey = getTestWipeKey();
+  tokenInfo.mSupplyKey = getTestSupplyKey();
+  tokenInfo.mDefaultFreezeStatus = getTestDefaultFreezeStatus();
+  tokenInfo.mDefaultKycStatus = getTestDefaultKycStatus();
+  tokenInfo.mIsDeleted = getTestIsDeleted();
+  tokenInfo.mAutoRenewAccountId = getTestAutoRenewAccountId();
+  tokenInfo.mAutoRenewPeriod = getTestAutoRenewPeriod();
+  tokenInfo.mExpirationTime = getTestExpirationTime();
+  tokenInfo.mTokenMemo = getTestTokenMemo();
+  tokenInfo.mTokenType = getTestTokenType();
+  tokenInfo.mSupplyType = getTestTokenSupplyType();
+  tokenInfo.mMaxSupply = getTestMaxSupply();
+  tokenInfo.mFeeScheduleKey = getTestFeeScheduleKey();
+  tokenInfo.mCustomFees = getTestCustomFees();
+  tokenInfo.mPauseKey = getTestPauseKey();
+  tokenInfo.mPauseStatus = getTestPauseStatus();
+  tokenInfo.mLedgerId = getTestLedgerId();
+
+  // When
+  const std::unique_ptr<proto::TokenInfo> protoTokenInfo = tokenInfo.toProtobuf();
+
+  // Then
+  EXPECT_EQ(protoTokenInfo->tokenid().shardnum(), getTestTokenId().getShardNum());
+  EXPECT_EQ(protoTokenInfo->tokenid().realmnum(), getTestTokenId().getRealmNum());
+  EXPECT_EQ(protoTokenInfo->tokenid().tokennum(), getTestTokenId().getTokenNum());
+  EXPECT_EQ(protoTokenInfo->name(), getTestTokenName());
+  EXPECT_EQ(protoTokenInfo->symbol(), getTestTokenSymbol());
+  EXPECT_EQ(protoTokenInfo->decimals(), getTestDecimals());
+  EXPECT_EQ(protoTokenInfo->totalsupply(), getTestTotalSupply());
+  EXPECT_EQ(protoTokenInfo->treasury().shardnum(), getTestTreasuryAccountId().getShardNum());
+  EXPECT_EQ(protoTokenInfo->treasury().realmnum(), getTestTreasuryAccountId().getRealmNum());
+  EXPECT_EQ(protoTokenInfo->treasury().accountnum(), getTestTreasuryAccountId().getAccountNum());
+  EXPECT_EQ(protoTokenInfo->adminkey().ecdsa_secp256k1(),
+            internal::Utilities::byteVectorToString(getTestAdminKey()->toBytesRaw()));
+  EXPECT_EQ(protoTokenInfo->kyckey().ecdsa_secp256k1(),
+            internal::Utilities::byteVectorToString(getTestKycKey()->toBytesRaw()));
+  EXPECT_EQ(protoTokenInfo->freezekey().ecdsa_secp256k1(),
+            internal::Utilities::byteVectorToString(getTestFreezeKey()->toBytesRaw()));
+  EXPECT_EQ(protoTokenInfo->wipekey().ecdsa_secp256k1(),
+            internal::Utilities::byteVectorToString(getTestWipeKey()->toBytesRaw()));
+  EXPECT_EQ(protoTokenInfo->supplykey().ecdsa_secp256k1(),
+            internal::Utilities::byteVectorToString(getTestSupplyKey()->toBytesRaw()));
+  EXPECT_EQ(protoTokenInfo->defaultfreezestatus(),
+            (!getTestDefaultFreezeStatus().has_value()
+               ? proto::TokenFreezeStatus::FreezeNotApplicable
+               : (getTestDefaultFreezeStatus().value() ? proto::TokenFreezeStatus::Frozen
+                                                       : proto::TokenFreezeStatus::Unfrozen)));
+  EXPECT_EQ(
+    protoTokenInfo->defaultkycstatus(),
+    (!getTestDefaultKycStatus().has_value()
+       ? proto::TokenKycStatus::KycNotApplicable
+       : (getTestDefaultKycStatus().value() ? proto::TokenKycStatus::Granted : proto::TokenKycStatus::Revoked)));
+  EXPECT_EQ(protoTokenInfo->deleted(), getTestIsDeleted());
+  EXPECT_EQ(protoTokenInfo->autorenewaccount().shardnum(), getTestAutoRenewAccountId().getShardNum());
+  EXPECT_EQ(protoTokenInfo->autorenewaccount().realmnum(), getTestAutoRenewAccountId().getRealmNum());
+  EXPECT_EQ(protoTokenInfo->autorenewaccount().accountnum(), getTestAutoRenewAccountId().getAccountNum());
+  EXPECT_EQ(protoTokenInfo->autorenewperiod().seconds(),
+            internal::DurationConverter::toProtobuf(getTestAutoRenewPeriod())->seconds());
+  EXPECT_EQ(protoTokenInfo->expiry().seconds(),
+            internal::TimestampConverter::toProtobuf(getTestExpirationTime())->seconds());
+  EXPECT_EQ(protoTokenInfo->memo(), getTestTokenMemo());
+  EXPECT_EQ(protoTokenInfo->tokentype(), gTokenTypeToProtobufTokenType.at(getTestTokenType()));
+  EXPECT_EQ(protoTokenInfo->supplytype(), gTokenSupplyTypeToProtobufTokenSupplyType.at(getTestTokenSupplyType()));
+  EXPECT_EQ(protoTokenInfo->maxsupply(), getTestMaxSupply());
+  EXPECT_EQ(protoTokenInfo->fee_schedule_key().ecdsa_secp256k1(),
+            internal::Utilities::byteVectorToString(getTestFeeScheduleKey()->toBytesRaw()));
+  EXPECT_EQ(protoTokenInfo->custom_fees_size(), getTestCustomFees().size());
+  EXPECT_EQ(protoTokenInfo->pause_key().ecdsa_secp256k1(),
+            internal::Utilities::byteVectorToString(getTestPauseKey()->toBytesRaw()));
+  EXPECT_EQ(protoTokenInfo->pause_status(),
+            (!getTestPauseStatus().has_value()
+               ? proto::TokenPauseStatus::PauseNotApplicable
+               : (getTestPauseStatus().value() ? proto::TokenPauseStatus::Paused : proto::TokenPauseStatus::Unpaused)));
+  EXPECT_EQ(protoTokenInfo->ledger_id(), internal::Utilities::byteVectorToString(getTestLedgerId().toBytes()));
+}
+
+//-----
+TEST_F(TokenInfoTest, ToBytes)
+{
+  // Given
+  TokenInfo tokenInfo;
+  tokenInfo.mTokenId = getTestTokenId();
+  tokenInfo.mTokenName = getTestTokenName();
+  tokenInfo.mTokenSymbol = getTestTokenSymbol();
+  tokenInfo.mDecimals = getTestDecimals();
+  tokenInfo.mTotalSupply = getTestTotalSupply();
+  tokenInfo.mTreasuryAccountId = getTestTreasuryAccountId();
+  tokenInfo.mAdminKey = getTestAdminKey();
+  tokenInfo.mKycKey = getTestKycKey();
+  tokenInfo.mFreezeKey = getTestFreezeKey();
+  tokenInfo.mWipeKey = getTestWipeKey();
+  tokenInfo.mSupplyKey = getTestSupplyKey();
+  tokenInfo.mDefaultFreezeStatus = getTestDefaultFreezeStatus();
+  tokenInfo.mDefaultKycStatus = getTestDefaultKycStatus();
+  tokenInfo.mIsDeleted = getTestIsDeleted();
+  tokenInfo.mAutoRenewAccountId = getTestAutoRenewAccountId();
+  tokenInfo.mAutoRenewPeriod = getTestAutoRenewPeriod();
+  tokenInfo.mExpirationTime = getTestExpirationTime();
+  tokenInfo.mTokenMemo = getTestTokenMemo();
+  tokenInfo.mTokenType = getTestTokenType();
+  tokenInfo.mSupplyType = getTestTokenSupplyType();
+  tokenInfo.mMaxSupply = getTestMaxSupply();
+  tokenInfo.mFeeScheduleKey = getTestFeeScheduleKey();
+  tokenInfo.mCustomFees = getTestCustomFees();
+  tokenInfo.mPauseKey = getTestPauseKey();
+  tokenInfo.mPauseStatus = getTestPauseStatus();
+  tokenInfo.mLedgerId = getTestLedgerId();
+
+  // When
+  const std::vector<std::byte> bytes = tokenInfo.toBytes();
+
+  // Then
+  EXPECT_EQ(bytes, internal::Utilities::stringToByteVector(tokenInfo.toProtobuf()->SerializeAsString()));
+}


### PR DESCRIPTION
**Description**:
This PR implements the APIs associated with `TokenInfoQuery`, which allows users to get information about tokens.

**Related issue(s)**:

Fixes #401 

**Checklist**

- [x] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
