### PR TITLE
Implement `TokenBurnTransaction`

### DIFF
--- a/sdk/main/CMakeLists.txt
+++ b/sdk/main/CMakeLists.txt
@@ -72,6 +72,7 @@ add_library(${PROJECT_NAME} STATIC
         src/TokenAllowance.cc
         src/TokenAssociateTransaction.cc
         src/TokenAssociation.cc
+        src/TokenBurnTransaction.cc
         src/TokenCreateTransaction.cc
         src/TokenDeleteTransaction.cc
         src/TokenId.cc

--- a/sdk/main/include/TokenBurnTransaction.h
+++ b/sdk/main/include/TokenBurnTransaction.h
@@ -17,8 +17,8 @@
  * limitations under the License.
  *
  */
-#ifndef HEDERA_SDK_CPP_TOKEN_WIPE_TRANSACTION_H_
-#define HEDERA_SDK_CPP_TOKEN_WIPE_TRANSACTION_H_
+#ifndef HEDERA_SDK_CPP_TOKEN_BURN_TRANSACTION_H_
+#define HEDERA_SDK_CPP_TOKEN_BURN_TRANSACTION_H_
 
 #include "TokenId.h"
 #include "Transaction.h"
@@ -162,4 +162,4 @@ private:
 
 } // namespace Hedera
 
-#endif // HEDERA_SDK_CPP_TOKEN_WIPE_TRANSACTION_H_
+#endif // HEDERA_SDK_CPP_TOKEN_BURN_TRANSACTION_H_

--- a/sdk/main/include/TokenBurnTransaction.h
+++ b/sdk/main/include/TokenBurnTransaction.h
@@ -1,0 +1,165 @@
+/*-
+ *
+ * Hedera C++ SDK
+ *
+ * Copyright (C) 2020 - 2022 Hedera Hashgraph, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+#ifndef HEDERA_SDK_CPP_TOKEN_WIPE_TRANSACTION_H_
+#define HEDERA_SDK_CPP_TOKEN_WIPE_TRANSACTION_H_
+
+#include "TokenId.h"
+#include "Transaction.h"
+
+#include <cstdint>
+#include <vector>
+
+namespace proto
+{
+class TokenBurnTransactionBody;
+class TransactionBody;
+}
+
+namespace Hedera
+{
+/**
+ * Burns fungible and non-fungible tokens owned by the treasury account. If no supply key is defined, this transaction
+ * will resolve to TOKEN_HAS_NO_SUPPLY_KEY. The operation decreases the total supply of the token. Total supply cannot
+ * go below zero. The amount provided must be in the lowest denomination possible. Example: Token A has 2 decimals. In
+ * order to burn 100 tokens, one must provide an amount of 10000. In order to burn 100.55 tokens, one must provide an
+ * amount of 10055. This transaction accepts zero unit token burn operations for fungible tokens (HIP-564).
+ *
+ * Transaction Signing Requirements:
+ *  - Supply key.
+ *  - Transaction fee payer account key.
+ */
+class TokenBurnTransaction : public Transaction<TokenBurnTransaction>
+{
+public:
+  TokenBurnTransaction() = default;
+
+  /**
+   * Construct from a TransactionBody protobuf object.
+   *
+   * @param transactionBody The TransactionBody protobuf object from which to construct.
+   * @throws std::invalid_argument If the input TransactionBody does not represent a TokenBurn transaction.
+   */
+  explicit TokenBurnTransaction(const proto::TransactionBody& transactionBody);
+
+  /**
+   * Set the ID of the token to burn.
+   *
+   * @param tokenId The ID of the token to burn.
+   * @return A reference to this TokenBurnTransaction object with the newly-set token ID.
+   * @throws IllegalStateException If this TokenBurnTransaction is frozen.
+   */
+  TokenBurnTransaction& setTokenId(const TokenId& tokenId);
+
+  /**
+   * Set the amount of FUNGIBLE_COMMON tokens to burn. This should be in the lowest denomination possible.
+   *
+   * @param amount The amount of FUNGIBLE_COMMON tokens to burn.
+   * @return A reference to this TokenBurnTransaction object with the newly-set amount.
+   * @throws IllegalStateException If this TokenBurnTransaction is frozen.
+   */
+  TokenBurnTransaction& setAmount(uint64_t amount);
+
+  /**
+   * Set the serial numbers of NON_FUNGIBLE_UNIQUE tokens to burn.
+   *
+   * @param serialNumbers The serial numbers of NON_FUNGIBLE_UNIQUE tokens to burn.
+   * @return A reference to this TokenBurnTransaction object with the newly-set serial numbers.
+   * @throws IllegalStateException If this TokenBurnTransaction is frozen.
+   */
+  TokenBurnTransaction& setSerialNumbers(const std::vector<uint64_t>& serialNumbers);
+
+  /**
+   * Get the ID of the token to burn.
+   *
+   * @return The ID of the token to burn.
+   */
+  [[nodiscard]] inline TokenId getTokenId() const { return mTokenId; }
+
+  /**
+   * Get the amount of FUNGIBLE_COMMON tokens to burn.
+   *
+   * @return The amount of FUNGIBLE_COMMON tokens to burn.
+   */
+  [[nodiscard]] inline uint64_t getAmount() const { return mAmount; }
+
+  /**
+   * Get the serial numbers of the NON_FUNGIBLE_UNIQUE tokens to burn.
+   *
+   * @return The serial numbers of the NON_FUNGIBLE_UNIQUE tokens to burn.
+   */
+  [[nodiscard]] inline std::vector<uint64_t> getSerialNumbers() const { return mSerialNumbers; }
+
+private:
+  /**
+   * Derived from Executable. Construct a Transaction protobuf object from this TokenBurnTransaction object.
+   *
+   * @param client The Client trying to construct this TokenBurnTransaction.
+   * @param node   The Node to which this TokenBurnTransaction will be sent. This is unused.
+   * @return A Transaction protobuf object filled with this TokenBurnTransaction object's data.
+   * @throws UninitializedException If the input client has no operator with which to sign this
+   *                                TokenBurnTransaction.
+   */
+  [[nodiscard]] proto::Transaction makeRequest(const Client& client,
+                                               const std::shared_ptr<internal::Node>& /*node*/) const override;
+
+  /**
+   * Derived from Executable. Submit this TokenBurnTransaction to a Node.
+   *
+   * @param client   The Client submitting this TokenBurnTransaction.
+   * @param deadline The deadline for submitting this TokenBurnTransaction.
+   * @param node     Pointer to the Node to which this TokenBurnTransaction should be submitted.
+   * @param response Pointer to the TransactionResponse protobuf object that gRPC should populate with the response
+   *                 information from the gRPC server.
+   * @return The gRPC status of the submission.
+   */
+  [[nodiscard]] grpc::Status submitRequest(const Client& client,
+                                           const std::chrono::system_clock::time_point& deadline,
+                                           const std::shared_ptr<internal::Node>& node,
+                                           proto::TransactionResponse* response) const override;
+
+  /**
+   * Build a TokenBurnTransactionBody protobuf object from this TokenBurnTransaction object.
+   *
+   * @return A pointer to a TokenBurnTransactionBody protobuf object filled with this TokenBurnTransaction object's
+   *         data.
+   */
+  [[nodiscard]] proto::TokenBurnTransactionBody* build() const;
+
+  /**
+   * The ID of the token to burn.
+   */
+  TokenId mTokenId;
+
+  /**
+   * Applicable to tokens of type FUNGIBLE_COMMON. The amount of tokens to burn from the treasury account. Amount must
+   * be a positive non-zero number in the lowest denomination possible and not bigger than the token balance of the
+   * treasury account.
+   */
+  uint64_t mAmount = 0ULL;
+
+  /**
+   * Applicable to tokens of type NON_FUNGIBLE_UNIQUE. The list of serial numbers to be burned.
+   */
+  std::vector<uint64_t> mSerialNumbers;
+};
+
+} // namespace Hedera
+
+#endif // HEDERA_SDK_CPP_TOKEN_WIPE_TRANSACTION_H_

--- a/sdk/main/include/Transaction.h
+++ b/sdk/main/include/Transaction.h
@@ -51,6 +51,7 @@ class FileDeleteTransaction;
 class FileUpdateTransaction;
 class PrivateKey;
 class TokenAssociateTransaction;
+class TokenBurnTransaction;
 class TokenCreateTransaction;
 class TokenDeleteTransaction;
 class TokenMintTransaction;
@@ -130,7 +131,8 @@ public:
                                               TokenDeleteTransaction,
                                               TokenAssociateTransaction,
                                               TokenMintTransaction,
-                                              TokenUpdateTransaction>>
+                                              TokenUpdateTransaction,
+                                              TokenBurnTransaction>>
   fromBytes(const std::vector<std::byte>& bytes);
 
   /**

--- a/sdk/main/include/TransactionReceipt.h
+++ b/sdk/main/include/TransactionReceipt.h
@@ -100,7 +100,7 @@ public:
    * In the receipt of a TokenMint, for tokens of type NON_FUNGIBLE_COMMON, these are the serial numbers of the
    * newly-created NFTs.
    */
-  std::vector<int64_t> mSerialNumbers;
+  std::vector<uint64_t> mSerialNumbers;
 };
 
 } // namespace Hedera

--- a/sdk/main/src/Executable.cc
+++ b/sdk/main/src/Executable.cc
@@ -48,6 +48,7 @@
 #include "FileInfoQuery.h"
 #include "FileUpdateTransaction.h"
 #include "TokenAssociateTransaction.h"
+#include "TokenBurnTransaction.h"
 #include "TokenCreateTransaction.h"
 #include "TokenDeleteTransaction.h"
 #include "TokenMintTransaction.h"
@@ -354,6 +355,7 @@ template class Executable<TokenAssociateTransaction,
                           proto::Transaction,
                           proto::TransactionResponse,
                           TransactionResponse>;
+template class Executable<TokenBurnTransaction, proto::Transaction, proto::TransactionResponse, TransactionResponse>;
 template class Executable<TokenCreateTransaction, proto::Transaction, proto::TransactionResponse, TransactionResponse>;
 template class Executable<TokenDeleteTransaction, proto::Transaction, proto::TransactionResponse, TransactionResponse>;
 template class Executable<TokenMintTransaction, proto::Transaction, proto::TransactionResponse, TransactionResponse>;

--- a/sdk/main/src/TokenBurnTransaction.cc
+++ b/sdk/main/src/TokenBurnTransaction.cc
@@ -1,0 +1,112 @@
+/*-
+ *
+ * Hedera C++ SDK
+ *
+ * Copyright (C) 2020 - 2022 Hedera Hashgraph, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+#include "TokenBurnTransaction.h"
+#include "impl/Node.h"
+
+#include <grpcpp/client_context.h>
+#include <proto/token_burn.pb.h>
+#include <proto/transaction.pb.h>
+#include <stdexcept>
+
+namespace Hedera
+{
+//-----
+TokenBurnTransaction::TokenBurnTransaction(const proto::TransactionBody& transactionBody)
+  : Transaction<TokenBurnTransaction>(transactionBody)
+{
+  if (!transactionBody.has_tokenburn())
+  {
+    throw std::invalid_argument("Transaction body doesn't contain TokenBurn data");
+  }
+
+  const proto::TokenBurnTransactionBody& body = transactionBody.tokenburn();
+
+  if (body.has_token())
+  {
+    mTokenId = TokenId::fromProtobuf(body.token());
+  }
+
+  mAmount = body.amount();
+
+  for (int i = 0; i < body.serialnumbers_size(); ++i)
+  {
+    mSerialNumbers.push_back(static_cast<uint64_t>(body.serialnumbers(i)));
+  }
+}
+
+//-----
+TokenBurnTransaction& TokenBurnTransaction::setTokenId(const TokenId& tokenId)
+{
+  requireNotFrozen();
+  mTokenId = tokenId;
+  return *this;
+}
+
+//-----
+TokenBurnTransaction& TokenBurnTransaction::setAmount(uint64_t amount)
+{
+  requireNotFrozen();
+  mAmount = amount;
+  return *this;
+}
+
+//-----
+TokenBurnTransaction& TokenBurnTransaction::setSerialNumbers(const std::vector<uint64_t>& serialNumbers)
+{
+  requireNotFrozen();
+  mSerialNumbers = serialNumbers;
+  return *this;
+}
+
+//-----
+proto::Transaction TokenBurnTransaction::makeRequest(const Client& client, const std::shared_ptr<internal::Node>&) const
+{
+  proto::TransactionBody transactionBody = generateTransactionBody(client);
+  transactionBody.set_allocated_tokenburn(build());
+
+  return signTransaction(transactionBody, client);
+}
+
+//-----
+grpc::Status TokenBurnTransaction::submitRequest(const Client& client,
+                                                 const std::chrono::system_clock::time_point& deadline,
+                                                 const std::shared_ptr<internal::Node>& node,
+                                                 proto::TransactionResponse* response) const
+{
+  return node->submitTransaction(
+    proto::TransactionBody::DataCase::kTokenBurn, makeRequest(client, node), deadline, response);
+}
+
+//-----
+proto::TokenBurnTransactionBody* TokenBurnTransaction::build() const
+{
+  auto body = std::make_unique<proto::TokenBurnTransactionBody>();
+  body->set_allocated_token(mTokenId.toProtobuf().release());
+  body->set_amount(mAmount);
+
+  for (const auto& num : mSerialNumbers)
+  {
+    body->add_serialnumbers(static_cast<int64_t>(num));
+  }
+
+  return body.release();
+}
+
+} // namespace Hedera

--- a/sdk/main/src/TokenBurnTransaction.cc
+++ b/sdk/main/src/TokenBurnTransaction.cc
@@ -103,7 +103,7 @@ proto::TokenBurnTransactionBody* TokenBurnTransaction::build() const
   {
     body->set_allocated_token(mTokenId.toProtobuf().release());
   }
-  
+
   body->set_amount(mAmount);
 
   for (const auto& num : mSerialNumbers)

--- a/sdk/main/src/TokenBurnTransaction.cc
+++ b/sdk/main/src/TokenBurnTransaction.cc
@@ -98,7 +98,12 @@ grpc::Status TokenBurnTransaction::submitRequest(const Client& client,
 proto::TokenBurnTransactionBody* TokenBurnTransaction::build() const
 {
   auto body = std::make_unique<proto::TokenBurnTransactionBody>();
-  body->set_allocated_token(mTokenId.toProtobuf().release());
+
+  if (!(mTokenId == TokenId()))
+  {
+    body->set_allocated_token(mTokenId.toProtobuf().release());
+  }
+  
   body->set_amount(mAmount);
 
   for (const auto& num : mSerialNumbers)

--- a/sdk/main/src/Transaction.cc
+++ b/sdk/main/src/Transaction.cc
@@ -37,6 +37,7 @@
 #include "PrivateKey.h"
 #include "Status.h"
 #include "TokenAssociateTransaction.h"
+#include "TokenBurnTransaction.h"
 #include "TokenCreateTransaction.h"
 #include "TokenDeleteTransaction.h"
 #include "TokenMintTransaction.h"
@@ -81,7 +82,8 @@ std::pair<int,
                        TokenDeleteTransaction,
                        TokenAssociateTransaction,
                        TokenMintTransaction,
-                       TokenUpdateTransaction>>
+                       TokenUpdateTransaction,
+                       TokenBurnTransaction>>
 Transaction<SdkRequestType>::fromBytes(const std::vector<std::byte>& bytes)
 {
   proto::TransactionBody txBody;
@@ -163,6 +165,8 @@ Transaction<SdkRequestType>::fromBytes(const std::vector<std::byte>& bytes)
       return { 18, TokenMintTransaction(txBody) };
     case proto::TransactionBody::kTokenUpdate:
       return { 19, TokenUpdateTransaction(txBody) };
+    case proto::TransactionBody::kTokenBurn:
+      return { 20, TokenBurnTransaction(txBody) };
     default:
       throw std::invalid_argument("Type of transaction cannot be determined from input bytes");
   }
@@ -479,6 +483,7 @@ template class Transaction<FileCreateTransaction>;
 template class Transaction<FileDeleteTransaction>;
 template class Transaction<FileUpdateTransaction>;
 template class Transaction<TokenAssociateTransaction>;
+template class Transaction<TokenBurnTransaction>;
 template class Transaction<TokenCreateTransaction>;
 template class Transaction<TokenDeleteTransaction>;
 template class Transaction<TokenMintTransaction>;

--- a/sdk/main/src/impl/Node.cc
+++ b/sdk/main/src/impl/Node.cc
@@ -192,6 +192,8 @@ grpc::Status Node::submitTransaction(proto::TransactionBody::DataCase funcEnum,
       return mFileStub->updateFile(&context, transaction, response);
     case proto::TransactionBody::DataCase::kTokenAssociate:
       return mTokenStub->associateTokens(&context, transaction, response);
+    case proto::TransactionBody::DataCase::kTokenBurn:
+      return mTokenStub->burnToken(&context, transaction, response);
     case proto::TransactionBody::DataCase::kTokenCreation:
       return mTokenStub->createToken(&context, transaction, response);
     case proto::TransactionBody::DataCase::kTokenDeletion:

--- a/sdk/tests/integration/CMakeLists.txt
+++ b/sdk/tests/integration/CMakeLists.txt
@@ -25,6 +25,7 @@ add_executable(${TEST_PROJECT_NAME}
         FileUpdateTransactionIntegrationTests.cc
         JSONIntegrationTest.cc
         TokenAssociateTransactionIntegrationTests.cc
+        TokenBurnTransactionIntegrationTests.cc
         TokenCreateTransactionIntegrationTests.cc
         TokenDeleteTransactionIntegrationTests.cc
         TokenMintTransactionIntegrationTests.cc

--- a/sdk/tests/integration/TokenBurnTransactionIntegrationTests.cc
+++ b/sdk/tests/integration/TokenBurnTransactionIntegrationTests.cc
@@ -97,6 +97,7 @@ TEST_F(TokenBurnTransactionIntegrationTest, CanBurnTokensWhenAmountIsNotSet)
 {
   // Given
   const uint64_t initialSupply = 100000ULL;
+
   std::shared_ptr<PrivateKey> operatorKey;
   ASSERT_NO_THROW(
     operatorKey = ED25519PrivateKey::fromString(
@@ -166,10 +167,6 @@ TEST_F(TokenBurnTransactionIntegrationTest, CannotBurnTokensIfSupplyKeyDoesNotSi
 TEST_F(TokenBurnTransactionIntegrationTest, CanBurnNfts)
 {
   // Given
-  const std::vector<std::vector<std::byte>> nftMetadata = {
-    { std::byte(0x01) }, { std::byte(0x02) }, { std::byte(0x03) }, { std::byte(0x04) }, { std::byte(0x05) }
-  };
-
   std::shared_ptr<PrivateKey> operatorKey;
   ASSERT_NO_THROW(
     operatorKey = ED25519PrivateKey::fromString(
@@ -188,11 +185,14 @@ TEST_F(TokenBurnTransactionIntegrationTest, CanBurnNfts)
                               .mTokenId.value());
 
   TransactionReceipt txReceipt;
-  ASSERT_NO_THROW(txReceipt = TokenMintTransaction()
-                                .setTokenId(tokenId)
-                                .setMetadata(nftMetadata)
-                                .execute(getTestClient())
-                                .getReceipt(getTestClient()));
+  ASSERT_NO_THROW(
+    txReceipt =
+      TokenMintTransaction()
+        .setTokenId(tokenId)
+        .setMetadata(
+          { { std::byte(0x01) }, { std::byte(0x02) }, { std::byte(0x03) }, { std::byte(0x04) }, { std::byte(0x05) } })
+        .execute(getTestClient())
+        .getReceipt(getTestClient()));
 
   // When
   EXPECT_NO_THROW(txReceipt = TokenBurnTransaction()

--- a/sdk/tests/integration/TokenBurnTransactionIntegrationTests.cc
+++ b/sdk/tests/integration/TokenBurnTransactionIntegrationTests.cc
@@ -1,0 +1,292 @@
+/*-
+ *
+ * Hedera C++ SDK
+ *
+ * Copyright (C) 2020 - 2022 Hedera Hashgraph, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+#include "AccountCreateTransaction.h"
+#include "AccountDeleteTransaction.h"
+#include "BaseIntegrationTest.h"
+#include "Client.h"
+#include "ED25519PrivateKey.h"
+#include "PrivateKey.h"
+#include "TokenAssociateTransaction.h"
+#include "TokenBurnTransaction.h"
+#include "TokenCreateTransaction.h"
+#include "TokenDeleteTransaction.h"
+#include "TokenMintTransaction.h"
+#include "TransactionReceipt.h"
+#include "TransactionResponse.h"
+#include "TransferTransaction.h"
+#include "exceptions/PrecheckStatusException.h"
+#include "exceptions/ReceiptStatusException.h"
+#include "impl/Utilities.h"
+
+#include <gtest/gtest.h>
+
+using namespace Hedera;
+
+class TokenBurnTransactionIntegrationTest : public BaseIntegrationTest
+{
+};
+
+//-----
+TEST_F(TokenBurnTransactionIntegrationTest, ExecuteTokenBurnTransaction)
+{
+  // Given
+  const uint64_t initialSupply = 100000ULL;
+  const uint64_t burnAmount = 10ULL;
+
+  std::shared_ptr<PrivateKey> operatorKey;
+  ASSERT_NO_THROW(
+    operatorKey = ED25519PrivateKey::fromString(
+      "302e020100300506032b65700422042091132178e72057a1d7528025956fe39b0b847f200ab59b2fdd367017f3087137"));
+
+  TokenId tokenId;
+  ASSERT_NO_THROW(tokenId = TokenCreateTransaction()
+                              .setTokenName("ffff")
+                              .setTokenSymbol("F")
+                              .setInitialSupply(initialSupply)
+                              .setTreasuryAccountId(AccountId(2ULL))
+                              .setAdminKey(operatorKey)
+                              .setSupplyKey(operatorKey)
+                              .execute(getTestClient())
+                              .getReceipt(getTestClient())
+                              .mTokenId.value());
+
+  // When
+  TransactionReceipt txReceipt;
+  EXPECT_NO_THROW(txReceipt = TokenBurnTransaction()
+                                .setTokenId(tokenId)
+                                .setAmount(burnAmount)
+                                .execute(getTestClient())
+                                .getReceipt(getTestClient()));
+
+  // Then
+  EXPECT_EQ(txReceipt.mNewTotalSupply, initialSupply - burnAmount);
+
+  // Clean up
+  ASSERT_NO_THROW(txReceipt =
+                    TokenDeleteTransaction().setTokenId(tokenId).execute(getTestClient()).getReceipt(getTestClient()));
+}
+
+//-----
+TEST_F(TokenBurnTransactionIntegrationTest, CannotBurnTokensWhenTokenIdIsNotSet)
+{
+  // Given / When / Then
+  EXPECT_THROW(const TransactionReceipt txReceipt =
+                 TokenBurnTransaction().setAmount(10ULL).execute(getTestClient()).getReceipt(getTestClient()),
+               PrecheckStatusException); // INVALID_TOKEN_ID
+}
+
+//-----
+TEST_F(TokenBurnTransactionIntegrationTest, CanBurnTokensWhenAmountIsNotSet)
+{
+  // Given
+  const uint64_t initialSupply = 100000ULL;
+  std::shared_ptr<PrivateKey> operatorKey;
+  ASSERT_NO_THROW(
+    operatorKey = ED25519PrivateKey::fromString(
+      "302e020100300506032b65700422042091132178e72057a1d7528025956fe39b0b847f200ab59b2fdd367017f3087137"));
+
+  TokenId tokenId;
+  ASSERT_NO_THROW(tokenId = TokenCreateTransaction()
+                              .setTokenName("ffff")
+                              .setTokenSymbol("F")
+                              .setInitialSupply(initialSupply)
+                              .setTreasuryAccountId(AccountId(2ULL))
+                              .setAdminKey(operatorKey)
+                              .setSupplyKey(operatorKey)
+                              .execute(getTestClient())
+                              .getReceipt(getTestClient())
+                              .mTokenId.value());
+
+  // When
+  TransactionReceipt txReceipt;
+  EXPECT_NO_THROW(txReceipt =
+                    TokenBurnTransaction().setTokenId(tokenId).execute(getTestClient()).getReceipt(getTestClient()));
+
+  // Then
+  EXPECT_EQ(txReceipt.mNewTotalSupply, initialSupply);
+
+  // Clean up
+  ASSERT_NO_THROW(txReceipt =
+                    TokenDeleteTransaction().setTokenId(tokenId).execute(getTestClient()).getReceipt(getTestClient()));
+}
+
+//-----
+TEST_F(TokenBurnTransactionIntegrationTest, CannotBurnTokensIfSupplyKeyDoesNotSign)
+{
+  // Given
+  std::shared_ptr<PrivateKey> operatorKey;
+  std::shared_ptr<PrivateKey> supplyKey;
+
+  ASSERT_NO_THROW(
+    operatorKey = ED25519PrivateKey::fromString(
+      "302e020100300506032b65700422042091132178e72057a1d7528025956fe39b0b847f200ab59b2fdd367017f3087137"));
+  ASSERT_NO_THROW(supplyKey = ED25519PrivateKey::generatePrivateKey());
+
+  TokenId tokenId;
+  ASSERT_NO_THROW(tokenId = TokenCreateTransaction()
+                              .setTokenName("ffff")
+                              .setTokenSymbol("F")
+                              .setInitialSupply(100000ULL)
+                              .setTreasuryAccountId(AccountId(2ULL))
+                              .setAdminKey(operatorKey)
+                              .setSupplyKey(supplyKey)
+                              .execute(getTestClient())
+                              .getReceipt(getTestClient())
+                              .mTokenId.value());
+
+  // When / Then
+  EXPECT_THROW(
+    const TransactionReceipt txReceipt =
+      TokenBurnTransaction().setTokenId(tokenId).setAmount(10ULL).execute(getTestClient()).getReceipt(getTestClient()),
+    ReceiptStatusException); // INVALID_SIGNATURE
+
+  // Clean up
+  ASSERT_NO_THROW(const TransactionReceipt txReceipt =
+                    TokenDeleteTransaction().setTokenId(tokenId).execute(getTestClient()).getReceipt(getTestClient()));
+}
+
+//-----
+TEST_F(TokenBurnTransactionIntegrationTest, CanBurnNfts)
+{
+  // Given
+  const std::vector<std::vector<std::byte>> nftMetadata = {
+    { std::byte(0x01) }, { std::byte(0x02) }, { std::byte(0x03) }, { std::byte(0x04) }, { std::byte(0x05) }
+  };
+
+  std::shared_ptr<PrivateKey> operatorKey;
+  ASSERT_NO_THROW(
+    operatorKey = ED25519PrivateKey::fromString(
+      "302e020100300506032b65700422042091132178e72057a1d7528025956fe39b0b847f200ab59b2fdd367017f3087137"));
+
+  TokenId tokenId;
+  ASSERT_NO_THROW(tokenId = TokenCreateTransaction()
+                              .setTokenName("ffff")
+                              .setTokenSymbol("F")
+                              .setTokenType(TokenType::NON_FUNGIBLE_UNIQUE)
+                              .setTreasuryAccountId(AccountId(2ULL))
+                              .setAdminKey(operatorKey)
+                              .setSupplyKey(operatorKey)
+                              .execute(getTestClient())
+                              .getReceipt(getTestClient())
+                              .mTokenId.value());
+
+  TransactionReceipt txReceipt;
+  ASSERT_NO_THROW(txReceipt = TokenMintTransaction()
+                                .setTokenId(tokenId)
+                                .setMetadata(nftMetadata)
+                                .execute(getTestClient())
+                                .getReceipt(getTestClient()));
+
+  // When
+  EXPECT_NO_THROW(txReceipt = TokenBurnTransaction()
+                                .setTokenId(tokenId)
+                                .setSerialNumbers(txReceipt.mSerialNumbers)
+                                .execute(getTestClient())
+                                .getReceipt(getTestClient()));
+
+  // Then
+  EXPECT_EQ(txReceipt.mNewTotalSupply, 0);
+
+  // Clean up
+  ASSERT_NO_THROW(txReceipt =
+                    TokenDeleteTransaction().setTokenId(tokenId).execute(getTestClient()).getReceipt(getTestClient()));
+}
+
+//-----
+TEST_F(TokenBurnTransactionIntegrationTest, CannotBurnNftIfNftIsNotOwnedByTreasury)
+{
+  // Given
+  std::shared_ptr<PrivateKey> operatorKey;
+  std::shared_ptr<PrivateKey> accountKey;
+
+  ASSERT_NO_THROW(
+    operatorKey = ED25519PrivateKey::fromString(
+      "302e020100300506032b65700422042091132178e72057a1d7528025956fe39b0b847f200ab59b2fdd367017f3087137"));
+  ASSERT_NO_THROW(accountKey = ED25519PrivateKey::generatePrivateKey());
+
+  TokenId tokenId;
+  ASSERT_NO_THROW(tokenId = TokenCreateTransaction()
+                              .setTokenName("ffff")
+                              .setTokenSymbol("F")
+                              .setTokenType(TokenType::NON_FUNGIBLE_UNIQUE)
+                              .setTreasuryAccountId(AccountId(2ULL))
+                              .setAdminKey(operatorKey)
+                              .setSupplyKey(operatorKey)
+                              .execute(getTestClient())
+                              .getReceipt(getTestClient())
+                              .mTokenId.value());
+
+  std::vector<uint64_t> serialNumbers;
+  ASSERT_NO_THROW(serialNumbers = TokenMintTransaction()
+                                    .setTokenId(tokenId)
+                                    .setMetadata({ { std::byte(0x01) } })
+                                    .execute(getTestClient())
+                                    .getReceipt(getTestClient())
+                                    .mSerialNumbers);
+  ASSERT_FALSE(serialNumbers.empty());
+
+  AccountId accountId;
+  ASSERT_NO_THROW(accountId = AccountCreateTransaction()
+                                .setKey(accountKey.get())
+                                .setInitialBalance(Hbar(1LL))
+                                .execute(getTestClient())
+                                .getReceipt(getTestClient())
+                                .mAccountId.value());
+
+  TransactionReceipt txReceipt;
+  ASSERT_NO_THROW(txReceipt = TokenAssociateTransaction()
+                                .setTokenIds({ tokenId })
+                                .setAccountId(accountId)
+                                .freezeWith(getTestClient())
+                                .sign(accountKey.get())
+                                .execute(getTestClient())
+                                .getReceipt(getTestClient()));
+
+  const NftId nftId(tokenId, serialNumbers.at(0));
+  ASSERT_NO_THROW(txReceipt = TransferTransaction()
+                                .addNftTransfer(nftId, AccountId(2ULL), accountId)
+                                .execute(getTestClient())
+                                .getReceipt(getTestClient()));
+
+  // When / Then
+  EXPECT_THROW(txReceipt = TokenBurnTransaction()
+                             .setTokenId(tokenId)
+                             .setSerialNumbers(serialNumbers)
+                             .execute(getTestClient())
+                             .getReceipt(getTestClient()),
+               ReceiptStatusException); // TREASURY_MUST_OWN_BURNED_NFT
+
+  // Clean up
+  ASSERT_NO_THROW(txReceipt = TransferTransaction()
+                                .addNftTransfer(nftId, accountId, AccountId(2ULL))
+                                .freezeWith(getTestClient())
+                                .sign(accountKey.get())
+                                .execute(getTestClient())
+                                .getReceipt(getTestClient()));
+  ASSERT_NO_THROW(txReceipt = AccountDeleteTransaction()
+                                .setTransferAccountId(AccountId(2ULL))
+                                .setDeleteAccountId(accountId)
+                                .freezeWith(getTestClient())
+                                .sign(accountKey.get())
+                                .execute(getTestClient())
+                                .getReceipt(getTestClient()));
+  ASSERT_NO_THROW(txReceipt =
+                    TokenDeleteTransaction().setTokenId(tokenId).execute(getTestClient()).getReceipt(getTestClient()));
+}

--- a/sdk/tests/unit/CMakeLists.txt
+++ b/sdk/tests/unit/CMakeLists.txt
@@ -63,6 +63,7 @@ add_executable(${TEST_PROJECT_NAME}
         TokenAllowanceTest.cc
         TokenAssociateTransactionUnitTests.cc
         TokenAssociationUnitTests.cc
+        TokenBurnTransactionUnitTests.cc
         TokenCreateTransactionTest.cc
         TokenDeleteTransactionTest.cc
         TokenIdTest.cc

--- a/sdk/tests/unit/TokenBurnTransactionUnitTests.cc
+++ b/sdk/tests/unit/TokenBurnTransactionUnitTests.cc
@@ -1,0 +1,142 @@
+/*-
+ *
+ * Hedera C++ SDK
+ *
+ * Copyright (C) 2020 - 2022 Hedera Hashgraph, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+#include "Client.h"
+#include "ECDSAsecp256k1PrivateKey.h"
+#include "TokenBurnTransaction.h"
+#include "exceptions/IllegalStateException.h"
+
+#include <gtest/gtest.h>
+#include <proto/transaction_body.pb.h>
+
+using namespace Hedera;
+
+class TokenBurnTransactionTest : public ::testing::Test
+{
+protected:
+  void SetUp() override { mClient.setOperator(AccountId(), ECDSAsecp256k1PrivateKey::generatePrivateKey().get()); }
+
+  [[nodiscard]] inline const Client& getTestClient() const { return mClient; }
+  [[nodiscard]] inline const TokenId& getTestTokenId() const { return mTestTokenId; }
+  [[nodiscard]] inline const uint64_t& getTestAmount() const { return mTestAmount; }
+  [[nodiscard]] inline const std::vector<uint64_t>& getTestSerialNumbers() const { return mTestSerialNumbers; }
+
+private:
+  Client mClient;
+  const TokenId mTestTokenId = TokenId(1ULL, 2ULL, 3ULL);
+  const uint64_t mTestAmount = 4ULL;
+  const std::vector<uint64_t> mTestSerialNumbers = { 5ULL, 6ULL, 7ULL };
+};
+
+//-----
+TEST_F(TokenBurnTransactionTest, ConstructTokenBurnTransactionFromTransactionBodyProtobuf)
+{
+  // Given
+  auto body = std::make_unique<proto::TokenBurnTransactionBody>();
+  body->set_allocated_token(getTestTokenId().toProtobuf().release());
+  body->set_amount(getTestAmount());
+
+  for (const auto& num : getTestSerialNumbers())
+  {
+    body->add_serialnumbers(static_cast<int64_t>(num));
+  }
+
+  proto::TransactionBody txBody;
+  txBody.set_allocated_tokenburn(body.release());
+
+  // When
+  const TokenBurnTransaction tokenBurnTransaction(txBody);
+
+  // Then
+  EXPECT_EQ(tokenBurnTransaction.getTokenId(), getTestTokenId());
+  EXPECT_EQ(tokenBurnTransaction.getAmount(), getTestAmount());
+  EXPECT_EQ(tokenBurnTransaction.getSerialNumbers(), getTestSerialNumbers());
+}
+
+//-----
+TEST_F(TokenBurnTransactionTest, GetSetTokenId)
+{
+  // Given
+  TokenBurnTransaction transaction;
+
+  // When
+  EXPECT_NO_THROW(transaction.setTokenId(getTestTokenId()));
+
+  // Then
+  EXPECT_EQ(transaction.getTokenId(), getTestTokenId());
+}
+
+//-----
+TEST_F(TokenBurnTransactionTest, GetSetTokenIdFrozen)
+{
+  // Given
+  TokenBurnTransaction transaction;
+  ASSERT_NO_THROW(transaction.freezeWith(getTestClient()));
+
+  // When / Then
+  EXPECT_THROW(transaction.setTokenId(getTestTokenId()), IllegalStateException);
+}
+
+//-----
+TEST_F(TokenBurnTransactionTest, GetSetAmount)
+{
+  // Given
+  TokenBurnTransaction transaction;
+
+  // When
+  EXPECT_NO_THROW(transaction.setAmount(getTestAmount()));
+
+  // Then
+  EXPECT_EQ(transaction.getAmount(), getTestAmount());
+}
+
+//-----
+TEST_F(TokenBurnTransactionTest, GetSetAmountFrozen)
+{
+  // Given
+  TokenBurnTransaction transaction;
+  ASSERT_NO_THROW(transaction.freezeWith(getTestClient()));
+
+  // When / Then
+  EXPECT_THROW(transaction.setAmount(getTestAmount()), IllegalStateException);
+}
+
+//-----
+TEST_F(TokenBurnTransactionTest, GetSetSerialNumbers)
+{
+  // Given
+  TokenBurnTransaction transaction;
+
+  // When
+  EXPECT_NO_THROW(transaction.setSerialNumbers(getTestSerialNumbers()));
+
+  // Then
+  EXPECT_EQ(transaction.getSerialNumbers(), getTestSerialNumbers());
+}
+
+//-----
+TEST_F(TokenBurnTransactionTest, GetSetSerialNumbersFrozen)
+{
+  // Given
+  TokenBurnTransaction transaction;
+  ASSERT_NO_THROW(transaction.freezeWith(getTestClient()));
+
+  // When / Then
+  EXPECT_THROW(transaction.setSerialNumbers(getTestSerialNumbers()), IllegalStateException);
+}

--- a/sdk/tests/unit/TransactionReceiptTest.cc
+++ b/sdk/tests/unit/TransactionReceiptTest.cc
@@ -34,7 +34,7 @@ protected:
   [[nodiscard]] inline const ContractId& getTestContractId() const { return mTestContractId; }
   [[nodiscard]] inline const TokenId& getTestTokenId() const { return mTestTokenId; }
   [[nodiscard]] inline const uint64_t& getTestNewTotalSupply() const { return mTestNewTotalSupply; }
-  [[nodiscard]] inline const std::vector<int64_t>& getTestSerialNumbers() const { return mTestSerialNumbers; }
+  [[nodiscard]] inline const std::vector<uint64_t>& getTestSerialNumbers() const { return mTestSerialNumbers; }
 
 private:
   const AccountId mTestAccountId = AccountId(1ULL);
@@ -42,7 +42,7 @@ private:
   const ContractId mTestContractId = ContractId(3ULL);
   const TokenId mTestTokenId = TokenId(4ULL);
   const uint64_t mTestNewTotalSupply = 5ULL;
-  const std::vector<int64_t> mTestSerialNumbers = { 6LL, 7LL, 8LL };
+  const std::vector<uint64_t> mTestSerialNumbers = { 6ULL, 7ULL, 8ULL };
 };
 
 //-----
@@ -86,7 +86,7 @@ TEST_F(TransactionReceiptTest, ProtobufTransactionReceipt)
 
   for (const auto& serialNum : getTestSerialNumbers())
   {
-    protoTxReceipt.add_serialnumbers(serialNum);
+    protoTxReceipt.add_serialnumbers(static_cast<int64_t>(serialNum));
   }
 
   // When

--- a/sdk/tests/unit/TransactionTest.cc
+++ b/sdk/tests/unit/TransactionTest.cc
@@ -33,6 +33,7 @@
 #include "FileDeleteTransaction.h"
 #include "FileUpdateTransaction.h"
 #include "TokenAssociateTransaction.h"
+#include "TokenBurnTransaction.h"
 #include "TokenCreateTransaction.h"
 #include "TokenDeleteTransaction.h"
 #include "TokenMintTransaction.h"
@@ -1228,4 +1229,63 @@ TEST_F(TransactionTest, TokenUpdateTransactionFromTransactionBytes)
   // Then
   ASSERT_EQ(index, 19);
   EXPECT_NO_THROW(const TokenUpdateTransaction tokenUpdateTransaction = std::get<19>(txVariant));
+}
+
+//-----
+TEST_F(TransactionTest, TokenBurnTransactionFromTransactionBodyBytes)
+{
+  // Given
+  proto::TransactionBody txBody;
+  txBody.set_allocated_tokenburn(new proto::TokenBurnTransactionBody);
+
+  // When
+  const auto [index, txVariant] =
+    Transaction<TokenBurnTransaction>::fromBytes(internal::Utilities::stringToByteVector(txBody.SerializeAsString()));
+
+  // Then
+  ASSERT_EQ(index, 20);
+  EXPECT_NO_THROW(const TokenBurnTransaction tokenBurnTransaction = std::get<20>(txVariant));
+}
+
+//-----
+TEST_F(TransactionTest, TokenBurnTransactionFromSignedTransactionBytes)
+{
+  // Given
+  proto::TransactionBody txBody;
+  txBody.set_allocated_tokenburn(new proto::TokenBurnTransactionBody);
+
+  proto::SignedTransaction signedTx;
+  signedTx.set_bodybytes(txBody.SerializeAsString());
+  // SignatureMap not required
+
+  // When
+  const auto [index, txVariant] =
+    Transaction<TokenBurnTransaction>::fromBytes(internal::Utilities::stringToByteVector(txBody.SerializeAsString()));
+
+  // Then
+  ASSERT_EQ(index, 20);
+  EXPECT_NO_THROW(const TokenBurnTransaction tokenBurnTransaction = std::get<20>(txVariant));
+}
+
+//-----
+TEST_F(TransactionTest, TokenBurnTransactionFromTransactionBytes)
+{
+  // Given
+  proto::TransactionBody txBody;
+  txBody.set_allocated_tokenburn(new proto::TokenBurnTransactionBody);
+
+  proto::SignedTransaction signedTx;
+  signedTx.set_bodybytes(txBody.SerializeAsString());
+  // SignatureMap not required
+
+  proto::Transaction tx;
+  tx.set_signedtransactionbytes(signedTx.SerializeAsString());
+
+  // When
+  const auto [index, txVariant] =
+    Transaction<TokenBurnTransaction>::fromBytes(internal::Utilities::stringToByteVector(txBody.SerializeAsString()));
+
+  // Then
+  ASSERT_EQ(index, 20);
+  EXPECT_NO_THROW(const TokenBurnTransaction tokenBurnTransaction = std::get<20>(txVariant));
 }


### PR DESCRIPTION
**Description**:
This PR implements the APIs associated with `TokenBurnTransaction`, which allows a user to burn tokens owned by the treasury account.

**Related issue(s)**:

Fixes #390 

**Checklist**

- [x] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
