### PR TITLE
Implement `TokenDissociateTransaction`

### DIFF
--- a/sdk/main/CMakeLists.txt
+++ b/sdk/main/CMakeLists.txt
@@ -74,6 +74,7 @@ add_library(${PROJECT_NAME} STATIC
         src/TokenAssociation.cc
         src/TokenCreateTransaction.cc
         src/TokenDeleteTransaction.cc
+        src/TokenDissociateTransaction.cc
         src/TokenId.cc
         src/TokenMintTransaction.cc
         src/TokenNftAllowance.cc

--- a/sdk/main/include/TokenDissociateTransaction.h
+++ b/sdk/main/include/TokenDissociateTransaction.h
@@ -1,0 +1,154 @@
+/*-
+ *
+ * Hedera C++ SDK
+ *
+ * Copyright (C) 2020 - 2022 Hedera Hashgraph, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+#ifndef HEDERA_SDK_CPP_TOKEN_DISSOCIATE_TRANSACTION_H_
+#define HEDERA_SDK_CPP_TOKEN_DISSOCIATE_TRANSACTION_H_
+
+#include "AccountId.h"
+#include "TokenId.h"
+#include "Transaction.h"
+
+#include <optional>
+#include <vector>
+
+namespace proto
+{
+class TokenDissociateTransactionBody;
+class TransactionBody;
+}
+
+namespace Hedera
+{
+/**
+ * Disassociates the provided Hedera account from the provided Hedera tokens. This transaction must be signed by the
+ * provided account's key. Once the association is removed, no token related operation can be performed to that account.
+ * AccountBalanceQuery and AccountInfoQuery will not return anything related to the token that was disassociated.
+ *
+ *  - If the provided account is not found, the transaction will resolve to INVALID_ACCOUNT_ID.
+ *  - If the provided account has been deleted, the transaction will resolve to ACCOUNT_DELETED.
+ *  - If any of the provided tokens is not found, the transaction will resolve to INVALID_TOKEN_REF.
+ *  - If an association between the provided account and any of the tokens does not exist, the transaction will resolve
+ *    to TOKEN_NOT_ASSOCIATED_TO_ACCOUNT.
+ *  - If the provided account has a nonzero balance with any of the provided tokens, the transaction will resolve to
+ *    TRANSACTION_REQUIRES_ZERO_TOKEN_BALANCES.
+ *
+ * On success, associations between the provided account and tokens are removed. The account is required to have a zero
+ * balance of the token you wish to disassociate. If a token balance is present, you will receive a
+ * TRANSACTION_REQUIRES_ZERO_TOKEN_BALANCES error.
+ *
+ * Transaction Signing Requirements:
+ *  - The key of the account from which the token is being dissociated.
+ *  - Transaction fee payer account key.
+ */
+class TokenDissociateTransaction : public Transaction<TokenDissociateTransaction>
+{
+public:
+  TokenDissociateTransaction() = default;
+
+  /**
+   * Construct from a TransactionBody protobuf object.
+   *
+   * @param transactionBody The TransactionBody protobuf object from which to construct.
+   * @throws std::invalid_argument If the input TransactionBody does not represent a TokenDissociate transaction.
+   */
+  explicit TokenDissociateTransaction(const proto::TransactionBody& transactionBody);
+
+  /**
+   * Set the ID of the account to be dissociated from the provided tokens.
+   *
+   * @param accountId The ID of the account to be dissociated from the provided tokens.
+   * @return A reference to this TokenDissociateTransaction object with the newly-set account ID.
+   * @throws IllegalStateException If this TokenDissociateTransaction is frozen.
+   */
+  TokenDissociateTransaction& setAccountId(const AccountId& accountId);
+
+  /**
+   * Set the IDs of the tokens to be dissociated from the provided account.
+   *
+   * @param tokenIds The IDs of the tokens to be dissociated from the provided account.
+   * @return A reference to this TokenDissociateTransaction object with the newly-set token IDs.
+   * @throws IllegalStateException If this TokenDissociateTransaction is frozen.
+   */
+  TokenDissociateTransaction& setTokenIds(const std::vector<TokenId>& tokenIds);
+
+  /**
+   * Get the ID of the account to be dissociated from the provided tokens.
+   *
+   * @return The ID of the account to be dissociated from the provided tokens. Returns uninitialized if no account ID
+   *         has been set.
+   */
+  [[nodiscard]] inline std::optional<AccountId> getAccountId() const { return mAccountId; }
+
+  /**
+   * Get the IDs of the tokens to be dissociated from the provided account.
+   *
+   * @return The IDs of the tokens to be dissociated from the provided account.
+   */
+  [[nodiscard]] inline std::vector<TokenId> getTokenIds() const { return mTokenIds; }
+
+private:
+  /**
+   * Derived from Executable. Construct a Transaction protobuf object from this TokenDissociateTransaction object.
+   *
+   * @param client The Client trying to construct this TokenDissociateTransaction.
+   * @param node   The Node to which this TokenDissociateTransaction will be sent. This is unused.
+   * @return A Transaction protobuf object filled with this TokenDissociateTransaction object's data.
+   * @throws UninitializedException If the input client has no operator with which to sign this
+   *                                TokenDissociateTransaction.
+   */
+  [[nodiscard]] proto::Transaction makeRequest(const Client& client,
+                                               const std::shared_ptr<internal::Node>& /*node*/) const override;
+
+  /**
+   * Derived from Executable. Submit this TokenDissociateTransaction to a Node.
+   *
+   * @param client   The Client submitting this TokenDissociateTransaction.
+   * @param deadline The deadline for submitting this TokenDissociateTransaction.
+   * @param node     Pointer to the Node to which this TokenDissociateTransaction should be submitted.
+   * @param response Pointer to the TransactionResponse protobuf object that gRPC should populate with the response
+   *                 information from the gRPC server.
+   * @return The gRPC status of the submission.
+   */
+  [[nodiscard]] grpc::Status submitRequest(const Client& client,
+                                           const std::chrono::system_clock::time_point& deadline,
+                                           const std::shared_ptr<internal::Node>& node,
+                                           proto::TransactionResponse* response) const override;
+
+  /**
+   * Build a TokenDissociateTransactionBody protobuf object from this TokenDissociateTransaction object.
+   *
+   * @return A pointer to a TokenDissociateTransactionBody protobuf object filled with this TokenDissociateTransaction
+   *         object's data.
+   */
+  [[nodiscard]] proto::TokenDissociateTransactionBody* build() const;
+
+  /**
+   * The ID of the account to be dissociated from the provided tokens.
+   */
+  std::optional<AccountId> mAccountId;
+
+  /**
+   * The IDs of the tokens to be dissociated from the provided account.
+   */
+  std::vector<TokenId> mTokenIds;
+};
+
+} // namespace Hedera
+
+#endif // HEDERA_SDK_CPP_TOKEN_DISSOCIATE_TRANSACTION_H_

--- a/sdk/main/include/Transaction.h
+++ b/sdk/main/include/Transaction.h
@@ -53,6 +53,7 @@ class PrivateKey;
 class TokenAssociateTransaction;
 class TokenCreateTransaction;
 class TokenDeleteTransaction;
+class TokenDissociateTransaction;
 class TokenMintTransaction;
 class TokenUpdateTransaction;
 class TokenWipeTransaction;
@@ -132,7 +133,8 @@ public:
                                               TokenAssociateTransaction,
                                               TokenMintTransaction,
                                               TokenUpdateTransaction,
-                                              TokenWipeTransaction>>
+                                              TokenWipeTransaction,
+                                              TokenDissociateTransaction>>
   fromBytes(const std::vector<std::byte>& bytes);
 
   /**

--- a/sdk/main/src/Executable.cc
+++ b/sdk/main/src/Executable.cc
@@ -50,6 +50,7 @@
 #include "TokenAssociateTransaction.h"
 #include "TokenCreateTransaction.h"
 #include "TokenDeleteTransaction.h"
+#include "TokenDissociateTransaction.h"
 #include "TokenMintTransaction.h"
 #include "TokenUpdateTransaction.h"
 #include "TokenWipeTransaction.h"
@@ -357,6 +358,10 @@ template class Executable<TokenAssociateTransaction,
                           TransactionResponse>;
 template class Executable<TokenCreateTransaction, proto::Transaction, proto::TransactionResponse, TransactionResponse>;
 template class Executable<TokenDeleteTransaction, proto::Transaction, proto::TransactionResponse, TransactionResponse>;
+template class Executable<TokenDissociateTransaction,
+                          proto::Transaction,
+                          proto::TransactionResponse,
+                          TransactionResponse>;
 template class Executable<TokenMintTransaction, proto::Transaction, proto::TransactionResponse, TransactionResponse>;
 template class Executable<TokenUpdateTransaction, proto::Transaction, proto::TransactionResponse, TransactionResponse>;
 template class Executable<TokenWipeTransaction, proto::Transaction, proto::TransactionResponse, TransactionResponse>;

--- a/sdk/main/src/TokenDissociateTransaction.cc
+++ b/sdk/main/src/TokenDissociateTransaction.cc
@@ -1,0 +1,106 @@
+/*-
+ *
+ * Hedera C++ SDK
+ *
+ * Copyright (C) 2020 - 2022 Hedera Hashgraph, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+#include "TokenDissociateTransaction.h"
+#include "impl/Node.h"
+
+#include <grpcpp/client_context.h>
+#include <proto/token_dissociate.pb.h>
+#include <proto/transaction.pb.h>
+#include <stdexcept>
+
+namespace Hedera
+{
+//-----
+TokenDissociateTransaction::TokenDissociateTransaction(const proto::TransactionBody& transactionBody)
+  : Transaction<TokenDissociateTransaction>(transactionBody)
+{
+  if (!transactionBody.has_tokendissociate())
+  {
+    throw std::invalid_argument("Transaction body doesn't contain TokenDissociate data");
+  }
+
+  const proto::TokenDissociateTransactionBody& body = transactionBody.tokendissociate();
+
+  if (body.has_account())
+  {
+    mAccountId = AccountId::fromProtobuf(body.account());
+  }
+
+  for (int i = 0; i < body.tokens_size(); ++i)
+  {
+    mTokenIds.push_back(TokenId::fromProtobuf(body.tokens(i)));
+  }
+}
+
+//-----
+TokenDissociateTransaction& TokenDissociateTransaction::setAccountId(const AccountId& accountId)
+{
+  requireNotFrozen();
+  mAccountId = accountId;
+  return *this;
+}
+
+//-----
+TokenDissociateTransaction& TokenDissociateTransaction::setTokenIds(const std::vector<TokenId>& tokenIds)
+{
+  requireNotFrozen();
+  mTokenIds = tokenIds;
+  return *this;
+}
+
+//-----
+proto::Transaction TokenDissociateTransaction::makeRequest(const Client& client,
+                                                           const std::shared_ptr<internal::Node>&) const
+{
+  proto::TransactionBody transactionBody = generateTransactionBody(client);
+  transactionBody.set_allocated_tokendissociate(build());
+
+  return signTransaction(transactionBody, client);
+}
+
+//-----
+grpc::Status TokenDissociateTransaction::submitRequest(const Client& client,
+                                                       const std::chrono::system_clock::time_point& deadline,
+                                                       const std::shared_ptr<internal::Node>& node,
+                                                       proto::TransactionResponse* response) const
+{
+  return node->submitTransaction(
+    proto::TransactionBody::DataCase::kTokenDissociate, makeRequest(client, node), deadline, response);
+}
+
+//-----
+proto::TokenDissociateTransactionBody* TokenDissociateTransaction::build() const
+{
+  auto body = std::make_unique<proto::TokenDissociateTransactionBody>();
+
+  if (mAccountId.has_value())
+  {
+    body->set_allocated_account(mAccountId->toProtobuf().release());
+  }
+
+  for (const auto& token : mTokenIds)
+  {
+    *body->add_tokens() = *token.toProtobuf();
+  }
+
+  return body.release();
+}
+
+} // namespace Hedera

--- a/sdk/main/src/Transaction.cc
+++ b/sdk/main/src/Transaction.cc
@@ -39,6 +39,7 @@
 #include "TokenAssociateTransaction.h"
 #include "TokenCreateTransaction.h"
 #include "TokenDeleteTransaction.h"
+#include "TokenDissociateTransaction.h"
 #include "TokenMintTransaction.h"
 #include "TokenUpdateTransaction.h"
 #include "TokenWipeTransaction.h"
@@ -83,7 +84,8 @@ std::pair<int,
                        TokenAssociateTransaction,
                        TokenMintTransaction,
                        TokenUpdateTransaction,
-                       TokenWipeTransaction>>
+                       TokenWipeTransaction,
+                       TokenDissociateTransaction>>
 Transaction<SdkRequestType>::fromBytes(const std::vector<std::byte>& bytes)
 {
   proto::TransactionBody txBody;
@@ -167,6 +169,8 @@ Transaction<SdkRequestType>::fromBytes(const std::vector<std::byte>& bytes)
       return { 19, TokenUpdateTransaction(txBody) };
     case proto::TransactionBody::kTokenWipe:
       return { 20, TokenWipeTransaction(txBody) };
+    case proto::TransactionBody::kTokenDissociate:
+      return { 21, TokenDissociateTransaction(txBody) };
     default:
       throw std::invalid_argument("Type of transaction cannot be determined from input bytes");
   }
@@ -485,6 +489,7 @@ template class Transaction<FileUpdateTransaction>;
 template class Transaction<TokenAssociateTransaction>;
 template class Transaction<TokenCreateTransaction>;
 template class Transaction<TokenDeleteTransaction>;
+template class Transaction<TokenDissociateTransaction>;
 template class Transaction<TokenMintTransaction>;
 template class Transaction<TokenUpdateTransaction>;
 template class Transaction<TokenWipeTransaction>;

--- a/sdk/main/src/impl/Node.cc
+++ b/sdk/main/src/impl/Node.cc
@@ -196,6 +196,8 @@ grpc::Status Node::submitTransaction(proto::TransactionBody::DataCase funcEnum,
       return mTokenStub->createToken(&context, transaction, response);
     case proto::TransactionBody::DataCase::kTokenDeletion:
       return mTokenStub->deleteToken(&context, transaction, response);
+    case proto::TransactionBody::DataCase::kTokenDissociate:
+      return mTokenStub->dissociateTokens(&context, transaction, response);
     case proto::TransactionBody::DataCase::kTokenMint:
       return mTokenStub->mintToken(&context, transaction, response);
     case proto::TransactionBody::DataCase::kTokenUpdate:

--- a/sdk/tests/integration/CMakeLists.txt
+++ b/sdk/tests/integration/CMakeLists.txt
@@ -27,6 +27,7 @@ add_executable(${TEST_PROJECT_NAME}
         TokenAssociateTransactionIntegrationTests.cc
         TokenCreateTransactionIntegrationTests.cc
         TokenDeleteTransactionIntegrationTests.cc
+        TokenDissociateTransactionIntegrationTests.cc
         TokenMintTransactionIntegrationTests.cc
         TokenUpdateTransactionIntegrationTests.cc
         TransactionIntegrationTest.cc

--- a/sdk/tests/integration/TokenDissociateTransactionIntegrationTests.cc
+++ b/sdk/tests/integration/TokenDissociateTransactionIntegrationTests.cc
@@ -1,0 +1,314 @@
+/*-
+ *
+ * Hedera C++ SDK
+ *
+ * Copyright (C) 2020 - 2022 Hedera Hashgraph, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+#include "AccountCreateTransaction.h"
+#include "AccountDeleteTransaction.h"
+#include "AccountId.h"
+#include "BaseIntegrationTest.h"
+#include "Client.h"
+#include "ED25519PrivateKey.h"
+#include "PrivateKey.h"
+#include "TokenAssociateTransaction.h"
+#include "TokenCreateTransaction.h"
+#include "TokenDeleteTransaction.h"
+#include "TokenDissociateTransaction.h"
+#include "TransactionReceipt.h"
+#include "TransactionRecord.h"
+#include "TransactionResponse.h"
+#include "exceptions/PrecheckStatusException.h"
+#include "exceptions/ReceiptStatusException.h"
+
+#include <gtest/gtest.h>
+
+using namespace Hedera;
+
+class TokenDissociateTransactionIntegrationTest : public BaseIntegrationTest
+{
+};
+
+//-----
+TEST_F(TokenDissociateTransactionIntegrationTest, ExecuteTokenDissociateTransaction)
+{
+  // Given
+  std::shared_ptr<PrivateKey> operatorKey;
+  std::shared_ptr<PrivateKey> accountKey;
+
+  ASSERT_NO_THROW(
+    operatorKey = ED25519PrivateKey::fromString(
+      "302e020100300506032b65700422042091132178e72057a1d7528025956fe39b0b847f200ab59b2fdd367017f3087137"));
+  ASSERT_NO_THROW(accountKey = ED25519PrivateKey::generatePrivateKey());
+
+  AccountId accountId;
+  ASSERT_NO_THROW(accountId = AccountCreateTransaction()
+                                .setKey(accountKey.get())
+                                .setInitialBalance(Hbar(1LL))
+                                .execute(getTestClient())
+                                .getReceipt(getTestClient())
+                                .mAccountId.value());
+
+  TokenId tokenId;
+  ASSERT_NO_THROW(tokenId = TokenCreateTransaction()
+                              .setTokenName("ffff")
+                              .setTokenSymbol("F")
+                              .setDecimals(3U)
+                              .setInitialSupply(100000ULL)
+                              .setTreasuryAccountId(AccountId(2ULL))
+                              .setAdminKey(operatorKey)
+                              .setFreezeKey(operatorKey)
+                              .setWipeKey(operatorKey)
+                              .setKycKey(operatorKey)
+                              .setSupplyKey(operatorKey)
+                              .setFeeScheduleKey(operatorKey)
+                              .execute(getTestClient())
+                              .getReceipt(getTestClient())
+                              .mTokenId.value());
+
+  TransactionReceipt txReceipt;
+  ASSERT_NO_THROW(txReceipt = TokenAssociateTransaction()
+                                .setAccountId(accountId)
+                                .setTokenIds({ tokenId })
+                                .freezeWith(getTestClient())
+                                .sign(accountKey.get())
+                                .execute(getTestClient())
+                                .getReceipt(getTestClient()));
+
+  // When / Then
+  EXPECT_NO_THROW(txReceipt = TokenDissociateTransaction()
+                                .setAccountId(accountId)
+                                .setTokenIds({ tokenId })
+                                .freezeWith(getTestClient())
+                                .sign(accountKey.get())
+                                .execute(getTestClient())
+                                .getReceipt(getTestClient()));
+
+  // Clean up
+  ASSERT_NO_THROW(txReceipt = AccountDeleteTransaction()
+                                .setDeleteAccountId(accountId)
+                                .setTransferAccountId(AccountId(2ULL))
+                                .freezeWith(getTestClient())
+                                .sign(accountKey.get())
+                                .execute(getTestClient())
+                                .getReceipt(getTestClient()));
+  ASSERT_NO_THROW(txReceipt =
+                    TokenDeleteTransaction().setTokenId(tokenId).execute(getTestClient()).getReceipt(getTestClient()));
+}
+
+//-----
+TEST_F(TokenDissociateTransactionIntegrationTest, CanDissociateNoTokens)
+{
+  // Given
+  std::shared_ptr<PrivateKey> operatorKey;
+  std::shared_ptr<PrivateKey> accountKey;
+
+  ASSERT_NO_THROW(
+    operatorKey = ED25519PrivateKey::fromString(
+      "302e020100300506032b65700422042091132178e72057a1d7528025956fe39b0b847f200ab59b2fdd367017f3087137"));
+  ASSERT_NO_THROW(accountKey = ED25519PrivateKey::generatePrivateKey());
+
+  AccountId accountId;
+  ASSERT_NO_THROW(accountId = AccountCreateTransaction()
+                                .setKey(accountKey.get())
+                                .setInitialBalance(Hbar(1LL))
+                                .execute(getTestClient())
+                                .getReceipt(getTestClient())
+                                .mAccountId.value());
+
+  // When / Then
+  TransactionReceipt txReceipt;
+  EXPECT_NO_THROW(txReceipt = TokenDissociateTransaction()
+                                .setAccountId(accountId)
+                                .freezeWith(getTestClient())
+                                .sign(accountKey.get())
+                                .execute(getTestClient())
+                                .getReceipt(getTestClient()));
+
+  // Clean up
+  ASSERT_NO_THROW(txReceipt = AccountDeleteTransaction()
+                                .setDeleteAccountId(accountId)
+                                .setTransferAccountId(AccountId(2ULL))
+                                .freezeWith(getTestClient())
+                                .sign(accountKey.get())
+                                .execute(getTestClient())
+                                .getReceipt(getTestClient()));
+}
+
+//-----
+TEST_F(TokenDissociateTransactionIntegrationTest, CannotDissociateWithNoAccountIdSet)
+{
+  // Given
+  std::shared_ptr<PrivateKey> operatorKey;
+  std::shared_ptr<PrivateKey> accountKey;
+
+  ASSERT_NO_THROW(
+    operatorKey = ED25519PrivateKey::fromString(
+      "302e020100300506032b65700422042091132178e72057a1d7528025956fe39b0b847f200ab59b2fdd367017f3087137"));
+  ASSERT_NO_THROW(accountKey = ED25519PrivateKey::generatePrivateKey());
+
+  AccountId accountId;
+  ASSERT_NO_THROW(accountId = AccountCreateTransaction()
+                                .setKey(accountKey.get())
+                                .setInitialBalance(Hbar(1LL))
+                                .execute(getTestClient())
+                                .getReceipt(getTestClient())
+                                .mAccountId.value());
+
+  // When / Then
+  TransactionReceipt txReceipt;
+  EXPECT_THROW(txReceipt = TokenDissociateTransaction()
+                             .freezeWith(getTestClient())
+                             .sign(accountKey.get())
+                             .execute(getTestClient())
+                             .getReceipt(getTestClient()),
+               PrecheckStatusException); // INVALID_ACCOUNT_ID
+
+  // Clean up
+  ASSERT_NO_THROW(txReceipt = AccountDeleteTransaction()
+                                .setDeleteAccountId(accountId)
+                                .setTransferAccountId(AccountId(2ULL))
+                                .freezeWith(getTestClient())
+                                .sign(accountKey.get())
+                                .execute(getTestClient())
+                                .getReceipt(getTestClient()));
+}
+
+//-----
+TEST_F(TokenDissociateTransactionIntegrationTest, CannotDissociateIfDissociatingAccountDoesNotSign)
+{
+  // Given
+  std::shared_ptr<PrivateKey> operatorKey;
+  std::shared_ptr<PrivateKey> accountKey;
+
+  ASSERT_NO_THROW(
+    operatorKey = ED25519PrivateKey::fromString(
+      "302e020100300506032b65700422042091132178e72057a1d7528025956fe39b0b847f200ab59b2fdd367017f3087137"));
+  ASSERT_NO_THROW(accountKey = ED25519PrivateKey::generatePrivateKey());
+
+  AccountId accountId;
+  ASSERT_NO_THROW(accountId = AccountCreateTransaction()
+                                .setKey(accountKey.get())
+                                .setInitialBalance(Hbar(1LL))
+                                .execute(getTestClient())
+                                .getReceipt(getTestClient())
+                                .mAccountId.value());
+
+  TokenId tokenId;
+  ASSERT_NO_THROW(tokenId = TokenCreateTransaction()
+                              .setTokenName("ffff")
+                              .setTokenSymbol("F")
+                              .setDecimals(3U)
+                              .setInitialSupply(100000ULL)
+                              .setTreasuryAccountId(AccountId(2ULL))
+                              .setAdminKey(operatorKey)
+                              .setFreezeKey(operatorKey)
+                              .setWipeKey(operatorKey)
+                              .setKycKey(operatorKey)
+                              .setSupplyKey(operatorKey)
+                              .setFeeScheduleKey(operatorKey)
+                              .execute(getTestClient())
+                              .getReceipt(getTestClient())
+                              .mTokenId.value());
+
+  TransactionReceipt txReceipt;
+  ASSERT_NO_THROW(txReceipt = TokenAssociateTransaction()
+                                .setAccountId(accountId)
+                                .setTokenIds({ tokenId })
+                                .freezeWith(getTestClient())
+                                .sign(accountKey.get())
+                                .execute(getTestClient())
+                                .getReceipt(getTestClient()));
+
+  // When / Then
+  EXPECT_THROW(txReceipt = TokenDissociateTransaction()
+                             .setAccountId(accountId)
+                             .setTokenIds({ tokenId })
+                             .execute(getTestClient())
+                             .getReceipt(getTestClient()),
+               ReceiptStatusException); // INVALID_SIGNATURE
+
+  // Clean up
+  ASSERT_NO_THROW(txReceipt = AccountDeleteTransaction()
+                                .setDeleteAccountId(accountId)
+                                .setTransferAccountId(AccountId(2ULL))
+                                .freezeWith(getTestClient())
+                                .sign(accountKey.get())
+                                .execute(getTestClient())
+                                .getReceipt(getTestClient()));
+  ASSERT_NO_THROW(txReceipt =
+                    TokenDeleteTransaction().setTokenId(tokenId).execute(getTestClient()).getReceipt(getTestClient()));
+}
+
+//-----
+TEST_F(TokenDissociateTransactionIntegrationTest, CannotDissociateIfNotAssociated)
+{
+  // Given
+  std::shared_ptr<PrivateKey> operatorKey;
+  std::shared_ptr<PrivateKey> accountKey;
+
+  ASSERT_NO_THROW(
+    operatorKey = ED25519PrivateKey::fromString(
+      "302e020100300506032b65700422042091132178e72057a1d7528025956fe39b0b847f200ab59b2fdd367017f3087137"));
+  ASSERT_NO_THROW(accountKey = ED25519PrivateKey::generatePrivateKey());
+
+  AccountId accountId;
+  ASSERT_NO_THROW(accountId = AccountCreateTransaction()
+                                .setKey(accountKey.get())
+                                .setInitialBalance(Hbar(1LL))
+                                .execute(getTestClient())
+                                .getReceipt(getTestClient())
+                                .mAccountId.value());
+
+  TokenId tokenId;
+  ASSERT_NO_THROW(tokenId = TokenCreateTransaction()
+                              .setTokenName("ffff")
+                              .setTokenSymbol("F")
+                              .setDecimals(3U)
+                              .setInitialSupply(100000ULL)
+                              .setTreasuryAccountId(AccountId(2ULL))
+                              .setAdminKey(operatorKey)
+                              .setFreezeKey(operatorKey)
+                              .setWipeKey(operatorKey)
+                              .setKycKey(operatorKey)
+                              .setSupplyKey(operatorKey)
+                              .setFeeScheduleKey(operatorKey)
+                              .execute(getTestClient())
+                              .getReceipt(getTestClient())
+                              .mTokenId.value());
+
+  // When / Then
+  TransactionReceipt txReceipt;
+  EXPECT_THROW(txReceipt = TokenDissociateTransaction()
+                             .setAccountId(accountId)
+                             .setTokenIds({ tokenId })
+                             .freezeWith(getTestClient())
+                             .sign(accountKey.get())
+                             .execute(getTestClient())
+                             .getReceipt(getTestClient()),
+               ReceiptStatusException); // TOKEN_NOT_ASSOCIATED_TO_ACCOUNT
+
+  // Clean up
+  ASSERT_NO_THROW(txReceipt = AccountDeleteTransaction()
+                                .setDeleteAccountId(accountId)
+                                .setTransferAccountId(AccountId(2ULL))
+                                .freezeWith(getTestClient())
+                                .sign(accountKey.get())
+                                .execute(getTestClient())
+                                .getReceipt(getTestClient()));
+  ASSERT_NO_THROW(txReceipt =
+                    TokenDeleteTransaction().setTokenId(tokenId).execute(getTestClient()).getReceipt(getTestClient()));
+}

--- a/sdk/tests/unit/CMakeLists.txt
+++ b/sdk/tests/unit/CMakeLists.txt
@@ -65,6 +65,7 @@ add_executable(${TEST_PROJECT_NAME}
         TokenAssociationUnitTests.cc
         TokenCreateTransactionTest.cc
         TokenDeleteTransactionTest.cc
+        TokenDissociateTransactionUnitTests.cc
         TokenIdTest.cc
         TokenMintTransactionUnitTests.cc
         TokenNftAllowanceTest.cc

--- a/sdk/tests/unit/TokenDissociateTransactionUnitTests.cc
+++ b/sdk/tests/unit/TokenDissociateTransactionUnitTests.cc
@@ -1,0 +1,117 @@
+/*-
+ *
+ * Hedera C++ SDK
+ *
+ * Copyright (C) 2020 - 2022 Hedera Hashgraph, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+#include "AccountId.h"
+#include "Client.h"
+#include "ECDSAsecp256k1PrivateKey.h"
+#include "TokenDissociateTransaction.h"
+#include "exceptions/IllegalStateException.h"
+
+#include <gtest/gtest.h>
+#include <proto/transaction_body.pb.h>
+
+using namespace Hedera;
+
+class TokenDissociateTransactionTest : public ::testing::Test
+{
+protected:
+  void SetUp() override { mClient.setOperator(AccountId(), ECDSAsecp256k1PrivateKey::generatePrivateKey().get()); }
+
+  [[nodiscard]] inline const Client& getTestClient() const { return mClient; }
+  [[nodiscard]] inline const AccountId& getTestAccountId() const { return mTestAccountId; }
+  [[nodiscard]] inline const std::vector<TokenId>& getTestTokenIds() const { return mTestTokenIds; }
+
+private:
+  Client mClient;
+  const AccountId mTestAccountId = AccountId(1ULL, 2ULL, 3ULL);
+  const std::vector<TokenId> mTestTokenIds = { TokenId(4ULL, 5ULL, 6ULL),
+                                               TokenId(7ULL, 8ULL, 9ULL),
+                                               TokenId(10ULL, 11ULL, 12ULL) };
+};
+
+//-----
+TEST_F(TokenDissociateTransactionTest, ConstructTokenDissociateTransactionFromTransactionBodyProtobuf)
+{
+  // Given
+  auto body = std::make_unique<proto::TokenDissociateTransactionBody>();
+  body->set_allocated_account(getTestAccountId().toProtobuf().release());
+
+  for (const auto& token : getTestTokenIds())
+  {
+    *body->add_tokens() = *token.toProtobuf();
+  }
+
+  proto::TransactionBody txBody;
+  txBody.set_allocated_tokendissociate(body.release());
+
+  // When
+  const TokenDissociateTransaction tokenDissociateTransaction(txBody);
+
+  // Then
+  EXPECT_EQ(tokenDissociateTransaction.getAccountId(), getTestAccountId());
+  EXPECT_EQ(tokenDissociateTransaction.getTokenIds().size(), getTestTokenIds().size());
+}
+
+//-----
+TEST_F(TokenDissociateTransactionTest, GetSetAccountId)
+{
+  // Given
+  TokenDissociateTransaction transaction;
+
+  // When
+  EXPECT_NO_THROW(transaction.setAccountId(getTestAccountId()));
+
+  // Then
+  EXPECT_EQ(transaction.getAccountId(), getTestAccountId());
+}
+
+//-----
+TEST_F(TokenDissociateTransactionTest, GetSetAccountIdFrozen)
+{
+  // Given
+  TokenDissociateTransaction transaction;
+  ASSERT_NO_THROW(transaction.freezeWith(getTestClient()));
+
+  // When / Then
+  EXPECT_THROW(transaction.setAccountId(getTestAccountId()), IllegalStateException);
+}
+
+//-----
+TEST_F(TokenDissociateTransactionTest, GetSetTokenIds)
+{
+  // Given
+  TokenDissociateTransaction transaction;
+
+  // When
+  EXPECT_NO_THROW(transaction.setTokenIds(getTestTokenIds()));
+
+  // Then
+  EXPECT_EQ(transaction.getTokenIds(), getTestTokenIds());
+}
+
+//-----
+TEST_F(TokenDissociateTransactionTest, GetSetTokenIdFrozen)
+{
+  // Given
+  TokenDissociateTransaction transaction;
+  ASSERT_NO_THROW(transaction.freezeWith(getTestClient()));
+
+  // When / Then
+  EXPECT_THROW(transaction.setTokenIds(getTestTokenIds()), IllegalStateException);
+}

--- a/sdk/tests/unit/TransactionTest.cc
+++ b/sdk/tests/unit/TransactionTest.cc
@@ -35,6 +35,7 @@
 #include "TokenAssociateTransaction.h"
 #include "TokenCreateTransaction.h"
 #include "TokenDeleteTransaction.h"
+#include "TokenDissociateTransaction.h"
 #include "TokenMintTransaction.h"
 #include "TokenUpdateTransaction.h"
 #include "TokenWipeTransaction.h"
@@ -1288,4 +1289,63 @@ TEST_F(TransactionTest, TokenWipeTransactionFromTransactionBytes)
   // Then
   ASSERT_EQ(index, 20);
   EXPECT_NO_THROW(const TokenWipeTransaction tokenWipeTransaction = std::get<20>(txVariant));
+}
+
+//-----
+TEST_F(TransactionTest, TokenDissociateTransactionFromTransactionBodyBytes)
+{
+  // Given
+  proto::TransactionBody txBody;
+  txBody.set_allocated_tokendissociate(new proto::TokenDissociateTransactionBody);
+
+  // When
+  const auto [index, txVariant] = Transaction<TokenDissociateTransaction>::fromBytes(
+    internal::Utilities::stringToByteVector(txBody.SerializeAsString()));
+
+  // Then
+  ASSERT_EQ(index, 21);
+  EXPECT_NO_THROW(const TokenDissociateTransaction tokenDissociateTransaction = std::get<21>(txVariant));
+}
+
+//-----
+TEST_F(TransactionTest, TokenDissociateTransactionFromSignedTransactionBytes)
+{
+  // Given
+  proto::TransactionBody txBody;
+  txBody.set_allocated_tokendissociate(new proto::TokenDissociateTransactionBody);
+
+  proto::SignedTransaction signedTx;
+  signedTx.set_bodybytes(txBody.SerializeAsString());
+  // SignatureMap not required
+
+  // When
+  const auto [index, txVariant] = Transaction<TokenDissociateTransaction>::fromBytes(
+    internal::Utilities::stringToByteVector(txBody.SerializeAsString()));
+
+  // Then
+  ASSERT_EQ(index, 21);
+  EXPECT_NO_THROW(const TokenDissociateTransaction tokenDissociateTransaction = std::get<21>(txVariant));
+}
+
+//-----
+TEST_F(TransactionTest, TokenDissociateTransactionFromTransactionBytes)
+{
+  // Given
+  proto::TransactionBody txBody;
+  txBody.set_allocated_tokendissociate(new proto::TokenDissociateTransactionBody);
+
+  proto::SignedTransaction signedTx;
+  signedTx.set_bodybytes(txBody.SerializeAsString());
+  // SignatureMap not required
+
+  proto::Transaction tx;
+  tx.set_signedtransactionbytes(signedTx.SerializeAsString());
+
+  // When
+  const auto [index, txVariant] = Transaction<TokenDissociateTransaction>::fromBytes(
+    internal::Utilities::stringToByteVector(txBody.SerializeAsString()));
+
+  // Then
+  ASSERT_EQ(index, 21);
+  EXPECT_NO_THROW(const TokenDissociateTransaction tokenDissociateTransaction = std::get<21>(txVariant));
 }


### PR DESCRIPTION
**Description**:
This PR adds the APIs associated with `TokenDissociateTransaction`, which allows users to dissociate tokens from an account.

**Related issue(s)**:

Fixes #389 

**Checklist**

- [x] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
