### PR TITLE
Implement `TokenGrantKycTransaction`

### DIFF
--- a/sdk/examples/TransferTokensExample.cc
+++ b/sdk/examples/TransferTokensExample.cc
@@ -17,9 +17,18 @@
  * limitations under the License.
  *
  */
+#include "AccountCreateTransaction.h"
+#include "AccountDeleteTransaction.h"
 #include "AccountId.h"
 #include "Client.h"
 #include "ED25519PrivateKey.h"
+#include "Status.h"
+#include "TokenAssociateTransaction.h"
+#include "TokenCreateTransaction.h"
+#include "TokenDeleteTransaction.h"
+#include "TokenGrantKycTransaction.h"
+#include "TokenId.h"
+#include "TokenWipeTransaction.h"
 #include "TransactionRecord.h"
 #include "TransactionResponse.h"
 #include "TransferTransaction.h"
@@ -30,39 +39,170 @@ using namespace Hedera;
 
 int main(int argc, char** argv)
 {
-  if (argc < 5)
+  if (argc < 3)
   {
-    std::cout
-      << "Please input operator account ID, operator private key, token ID to transfer, and account ID to transfer to"
-      << std::endl;
+    std::cout << "Please input account ID and private key" << std::endl;
     return 1;
   }
 
   // Get a client for the Hedera testnet, and set the operator account ID and key such that all generated transactions
   // will be paid for by this account and be signed by this key.
+  const AccountId operatorAccountId = AccountId::fromString(argv[1]);
+  const std::shared_ptr<PrivateKey> operatorKey = ED25519PrivateKey::fromString(argv[2]);
+
   Client client = Client::forTestnet();
-  const AccountId operatorId = AccountId::fromString(argv[1]);
-  client.setOperator(operatorId, ED25519PrivateKey::fromString(argv[2]).get());
-  const TokenId tokenId = TokenId::fromString(argv[3]);
-  const AccountId recipientId = AccountId::fromString(argv[4]);
+  client.setOperator(operatorAccountId, operatorKey.get());
 
-  const int64_t amount = 10LL;
+  // Generate two accounts.
+  const std::unique_ptr<PrivateKey> privateKey1 = ED25519PrivateKey::generatePrivateKey();
+  const std::unique_ptr<PrivateKey> privateKey2 = ED25519PrivateKey::generatePrivateKey();
 
-  TransactionResponse txResponse = TransferTransaction()
-                                     .addTokenTransfer(tokenId, operatorId, -amount)
-                                     .addTokenTransfer(tokenId, recipientId, amount)
-                                     .execute(client);
+  const AccountId accountId1 = AccountCreateTransaction()
+                                 .setKey(privateKey1.get())
+                                 .setInitialBalance(Hbar(1LL))
+                                 .execute(client)
+                                 .getReceipt(client)
+                                 .mAccountId.value();
+  std::cout << "Generated account with account ID " << accountId1.toString() << std::endl;
 
-  TransactionRecord txRecord = txResponse.getRecord(client);
+  const AccountId accountId2 = AccountCreateTransaction()
+                                 .setKey(privateKey2.get())
+                                 .setInitialBalance(Hbar(1LL))
+                                 .execute(client)
+                                 .getReceipt(client)
+                                 .mAccountId.value();
+  std::cout << "Generated account with account ID " << accountId2.toString() << std::endl;
 
-  std::cout << "List of token transfers received in TransactionRecord:" << std::endl;
-  for (const TokenTransfer& transfer : txRecord.mTokenTransferList)
-  {
-    std::cout << "---TRANSFER---" << std::endl;
-    std::cout << " - Token ID: " << transfer.getTokenId().toString() << std::endl;
-    std::cout << " - Account ID: " << transfer.getAccountId().toString() << std::endl;
-    std::cout << " - Amount: " << transfer.getAmount() << std::endl;
-  }
+  // Create a token to transfer.
+  const TokenId tokenId = TokenCreateTransaction()
+                            .setTokenName("ffff")
+                            .setTokenSymbol("F")
+                            .setTreasuryAccountId(operatorAccountId)
+                            .setInitialSupply(100000ULL)
+                            .setAdminKey(operatorKey)
+                            .setKycKey(operatorKey)
+                            .setWipeKey(operatorKey)
+                            .execute(client)
+                            .getReceipt(client)
+                            .mTokenId.value();
+  std::cout << "Generated token with token ID " << tokenId.toString() << std::endl;
+
+  // Associate the token with the two accounts.
+  std::cout << "Associate the token with account 1: "
+            << gStatusToString.at(TokenAssociateTransaction()
+                                    .setAccountId(accountId1)
+                                    .setTokenIds({ tokenId })
+                                    .freezeWith(client)
+                                    .sign(privateKey1.get())
+                                    .execute(client)
+                                    .getReceipt(client)
+                                    .mStatus)
+            << std::endl;
+
+  std::cout << "Associate the token with account 2: "
+            << gStatusToString.at(TokenAssociateTransaction()
+                                    .setAccountId(accountId2)
+                                    .setTokenIds({ tokenId })
+                                    .freezeWith(client)
+                                    .sign(privateKey2.get())
+                                    .execute(client)
+                                    .getReceipt(client)
+                                    .mStatus)
+            << std::endl;
+
+  // Grant KYC to these accounts for this token.
+  std::cout << "Grant KYC to account 1 for the token: "
+            << gStatusToString.at(TokenGrantKycTransaction()
+                                    .setAccountId(accountId1)
+                                    .setTokenId(tokenId)
+                                    .freezeWith(client)
+                                    .sign(privateKey1.get())
+                                    .execute(client)
+                                    .getReceipt(client)
+                                    .mStatus)
+            << std::endl;
+
+  std::cout << "Grant KYC to account 2 for the token: "
+            << gStatusToString.at(TokenGrantKycTransaction()
+                                    .setAccountId(accountId2)
+                                    .setTokenId(tokenId)
+                                    .freezeWith(client)
+                                    .sign(privateKey2.get())
+                                    .execute(client)
+                                    .getReceipt(client)
+                                    .mStatus)
+            << std::endl;
+
+  // Send ten tokens to account 1.
+  std::cout << "Send 10 tokens from the treasury to account 1: "
+            << gStatusToString.at(TransferTransaction()
+                                    .addTokenTransfer(tokenId, operatorAccountId, -10LL)
+                                    .addTokenTransfer(tokenId, accountId1, 10LL)
+                                    .execute(client)
+                                    .getReceipt(client)
+                                    .mStatus)
+            << std::endl;
+
+  // Send the ten tokens from account 1 to account 2.
+  std::cout << "Send 10 tokens from account 1 to account 2: "
+            << gStatusToString.at(TransferTransaction()
+                                    .addTokenTransfer(tokenId, accountId1, -10LL)
+                                    .addTokenTransfer(tokenId, accountId2, 10LL)
+                                    .freezeWith(client)
+                                    .sign(privateKey1.get())
+                                    .execute(client)
+                                    .getReceipt(client)
+                                    .mStatus)
+            << std::endl;
+
+  // Send the ten tokens from account 2 back to account 1.
+  std::cout << "Send 10 tokens from account 2 back to account 1: "
+            << gStatusToString.at(TransferTransaction()
+                                    .addTokenTransfer(tokenId, accountId1, 10LL)
+                                    .addTokenTransfer(tokenId, accountId2, -10LL)
+                                    .freezeWith(client)
+                                    .sign(privateKey2.get())
+                                    .execute(client)
+                                    .getReceipt(client)
+                                    .mStatus)
+            << std::endl;
+
+  // Wipe the account of the 10 tokens.
+  std::cout << "Wipe the 10 tokens from account 1: "
+            << gStatusToString.at(TokenWipeTransaction()
+                                    .setTokenId(tokenId)
+                                    .setAccountId(accountId1)
+                                    .setAmount(10LL)
+                                    .execute(client)
+                                    .getReceipt(client)
+                                    .mStatus)
+            << std::endl;
+
+  // Delete the tokens and the accounts.
+  std::cout << "Delete the token: "
+            << gStatusToString.at(
+                 TokenDeleteTransaction().setTokenId(tokenId).execute(client).getReceipt(client).mStatus)
+            << std::endl;
+  std::cout << "Delete account 1: "
+            << gStatusToString.at(AccountDeleteTransaction()
+                                    .setTransferAccountId(operatorAccountId)
+                                    .setDeleteAccountId(accountId1)
+                                    .freezeWith(client)
+                                    .sign(privateKey1.get())
+                                    .execute(client)
+                                    .getReceipt(client)
+                                    .mStatus)
+            << std::endl;
+  std::cout << "Delete account 2: "
+            << gStatusToString.at(AccountDeleteTransaction()
+                                    .setTransferAccountId(operatorAccountId)
+                                    .setDeleteAccountId(accountId2)
+                                    .freezeWith(client)
+                                    .sign(privateKey2.get())
+                                    .execute(client)
+                                    .getReceipt(client)
+                                    .mStatus)
+            << std::endl;
 
   return 0;
 }

--- a/sdk/main/CMakeLists.txt
+++ b/sdk/main/CMakeLists.txt
@@ -74,6 +74,7 @@ add_library(${PROJECT_NAME} STATIC
         src/TokenAssociation.cc
         src/TokenCreateTransaction.cc
         src/TokenDeleteTransaction.cc
+        src/TokenGrantKycTransaction.cc
         src/TokenId.cc
         src/TokenMintTransaction.cc
         src/TokenNftAllowance.cc

--- a/sdk/main/include/TokenGrantKycTransaction.h
+++ b/sdk/main/include/TokenGrantKycTransaction.h
@@ -95,7 +95,7 @@ public:
    *
    * @return The ID of the token for which the account has passed KYC.
    */
-  [[nodiscard]] inline TokenId getTokenIds() const { return mTokenId; }
+  [[nodiscard]] inline TokenId getTokenId() const { return mTokenId; }
 
 private:
   /**

--- a/sdk/main/include/TokenGrantKycTransaction.h
+++ b/sdk/main/include/TokenGrantKycTransaction.h
@@ -1,0 +1,149 @@
+/*-
+ *
+ * Hedera C++ SDK
+ *
+ * Copyright (C) 2020 - 2022 Hedera Hashgraph, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+#ifndef HEDERA_SDK_CPP_TOKEN_GRANT_KYC_TRANSACTION_H_
+#define HEDERA_SDK_CPP_TOKEN_GRANT_KYC_TRANSACTION_H_
+
+#include "AccountId.h"
+#include "TokenId.h"
+#include "Transaction.h"
+
+#include <optional>
+#include <vector>
+
+namespace proto
+{
+class TokenGrantKycTransactionBody;
+class TransactionBody;
+}
+
+namespace Hedera
+{
+/**
+ * Grants KYC to the Hedera accounts for the given Hedera token. This transaction must be signed by the token's KYC Key.
+ *
+ *  - If the provided account is not found, the transaction will resolve to INVALID_ACCOUNT_ID.
+ *  - If the provided account has been deleted, the transaction will resolve to ACCOUNT_DELETED.
+ *  - If the provided token is not found, the transaction will resolve to INVALID_TOKEN_ID.
+ *  - If the provided token has been deleted, the transaction will resolve to TOKEN_WAS_DELETED.
+ *  - If an association between the provided token and account is not found, the transaction will resolve to
+ *    TOKEN_NOT_ASSOCIATED_TO_ACCOUNT.
+ *  - If no KYC Key is defined, the transaction will resolve to TOKEN_HAS_NO_KYC_KEY.
+ *
+ * Once executed the Account is marked as KYC Granted.
+ *
+ * Transaction Signing Requirements:
+ *  - KYC key.
+ *  - Transaction fee payer account key.
+ */
+class TokenGrantKycTransaction : public Transaction<TokenGrantKycTransaction>
+{
+public:
+  TokenGrantKycTransaction() = default;
+
+  /**
+   * Construct from a TransactionBody protobuf object.
+   *
+   * @param transactionBody The TransactionBody protobuf object from which to construct.
+   * @throws std::invalid_argument If the input TransactionBody does not represent a TokenGrantKyc transaction.
+   */
+  explicit TokenGrantKycTransaction(const proto::TransactionBody& transactionBody);
+
+  /**
+   * Set the ID of the account to have passed KYC for this token.
+   *
+   * @param accountId The ID of the account to have passed KYC for this token.
+   * @return A reference to this TokenGrantKycTransaction object with the newly-set account ID.
+   * @throws IllegalStateException If this TokenGrantKycTransaction is frozen.
+   */
+  TokenGrantKycTransaction& setAccountId(const AccountId& accountId);
+
+  /**
+   * Set the ID of the token for which the account has passed KYC.
+   *
+   * @param tokenId The ID of the token for which the account has passed KYC.
+   * @return A reference to this TokenGrantKycTransaction object with the newly-set token ID.
+   * @throws IllegalStateException If this TokenGrantKycTransaction is frozen.
+   */
+  TokenGrantKycTransaction& setTokenId(const TokenId& tokenId);
+
+  /**
+   * Get the ID of the account to have passed KYC for this token.
+   *
+   * @return The ID of the account to have passed KYC for this token.
+   */
+  [[nodiscard]] inline AccountId getAccountId() const { return mAccountId; }
+
+  /**
+   * Get the ID of the token for which the account has passed KYC.
+   *
+   * @return The ID of the token for which the account has passed KYC.
+   */
+  [[nodiscard]] inline TokenId getTokenIds() const { return mTokenId; }
+
+private:
+  /**
+   * Derived from Executable. Construct a Transaction protobuf object from this TokenGrantKycTransaction object.
+   *
+   * @param client The Client trying to construct this TokenGrantKycTransaction.
+   * @param node   The Node to which this TokenGrantKycTransaction will be sent. This is unused.
+   * @return A Transaction protobuf object filled with this TokenGrantKycTransaction object's data.
+   * @throws UninitializedException If the input client has no operator with which to sign this
+   *                                TokenGrantKycTransaction.
+   */
+  [[nodiscard]] proto::Transaction makeRequest(const Client& client,
+                                               const std::shared_ptr<internal::Node>& /*node*/) const override;
+
+  /**
+   * Derived from Executable. Submit this TokenGrantKycTransaction to a Node.
+   *
+   * @param client   The Client submitting this TokenGrantKycTransaction.
+   * @param deadline The deadline for submitting this TokenGrantKycTransaction.
+   * @param node     Pointer to the Node to which this TokenGrantKycTransaction should be submitted.
+   * @param response Pointer to the TransactionResponse protobuf object that gRPC should populate with the response
+   *                 information from the gRPC server.
+   * @return The gRPC status of the submission.
+   */
+  [[nodiscard]] grpc::Status submitRequest(const Client& client,
+                                           const std::chrono::system_clock::time_point& deadline,
+                                           const std::shared_ptr<internal::Node>& node,
+                                           proto::TransactionResponse* response) const override;
+
+  /**
+   * Build a TokenGrantKycTransactionBody protobuf object from this TokenGrantKycTransaction object.
+   *
+   * @return A pointer to a TokenGrantKycTransactionBody protobuf object filled with this TokenGrantKycTransaction
+   *         object's data.
+   */
+  [[nodiscard]] proto::TokenGrantKycTransactionBody* build() const;
+
+  /**
+   * The ID of the account to have passed KYC for this token.
+   */
+  AccountId mAccountId;
+
+  /**
+   * The ID of the token for which the account has passed KYC.
+   */
+  TokenId mTokenId;
+};
+
+} // namespace Hedera
+
+#endif // HEDERA_SDK_CPP_TOKEN_GRANT_KYC_TRANSACTION_H_

--- a/sdk/main/include/Transaction.h
+++ b/sdk/main/include/Transaction.h
@@ -53,6 +53,7 @@ class PrivateKey;
 class TokenAssociateTransaction;
 class TokenCreateTransaction;
 class TokenDeleteTransaction;
+class TokenGrantKycTransaction;
 class TokenMintTransaction;
 class TokenUpdateTransaction;
 class TokenWipeTransaction;
@@ -132,7 +133,8 @@ public:
                                               TokenAssociateTransaction,
                                               TokenMintTransaction,
                                               TokenUpdateTransaction,
-                                              TokenWipeTransaction>>
+                                              TokenWipeTransaction,
+                                              TokenGrantKycTransaction>>
   fromBytes(const std::vector<std::byte>& bytes);
 
   /**

--- a/sdk/main/include/TransactionReceipt.h
+++ b/sdk/main/include/TransactionReceipt.h
@@ -100,7 +100,7 @@ public:
    * In the receipt of a TokenMint, for tokens of type NON_FUNGIBLE_COMMON, these are the serial numbers of the
    * newly-created NFTs.
    */
-  std::vector<int64_t> mSerialNumbers;
+  std::vector<uint64_t> mSerialNumbers;
 };
 
 } // namespace Hedera

--- a/sdk/main/src/Executable.cc
+++ b/sdk/main/src/Executable.cc
@@ -50,6 +50,7 @@
 #include "TokenAssociateTransaction.h"
 #include "TokenCreateTransaction.h"
 #include "TokenDeleteTransaction.h"
+#include "TokenGrantKycTransaction.h"
 #include "TokenMintTransaction.h"
 #include "TokenUpdateTransaction.h"
 #include "TokenWipeTransaction.h"
@@ -357,6 +358,10 @@ template class Executable<TokenAssociateTransaction,
                           TransactionResponse>;
 template class Executable<TokenCreateTransaction, proto::Transaction, proto::TransactionResponse, TransactionResponse>;
 template class Executable<TokenDeleteTransaction, proto::Transaction, proto::TransactionResponse, TransactionResponse>;
+template class Executable<TokenGrantKycTransaction,
+                          proto::Transaction,
+                          proto::TransactionResponse,
+                          TransactionResponse>;
 template class Executable<TokenMintTransaction, proto::Transaction, proto::TransactionResponse, TransactionResponse>;
 template class Executable<TokenUpdateTransaction, proto::Transaction, proto::TransactionResponse, TransactionResponse>;
 template class Executable<TokenWipeTransaction, proto::Transaction, proto::TransactionResponse, TransactionResponse>;

--- a/sdk/main/src/TokenGrantKycTransaction.cc
+++ b/sdk/main/src/TokenGrantKycTransaction.cc
@@ -89,8 +89,17 @@ grpc::Status TokenGrantKycTransaction::submitRequest(const Client& client,
 proto::TokenGrantKycTransactionBody* TokenGrantKycTransaction::build() const
 {
   auto body = std::make_unique<proto::TokenGrantKycTransactionBody>();
-  body->set_allocated_account(mAccountId.toProtobuf().release());
-  body->set_allocated_token(mTokenId.toProtobuf().release());
+
+  if (!(mAccountId == AccountId()))
+  {
+    body->set_allocated_account(mAccountId.toProtobuf().release());
+  }
+
+  if (!(mTokenId == TokenId()))
+  {
+    body->set_allocated_token(mTokenId.toProtobuf().release());
+  }
+
   return body.release();
 }
 

--- a/sdk/main/src/TokenGrantKycTransaction.cc
+++ b/sdk/main/src/TokenGrantKycTransaction.cc
@@ -1,0 +1,97 @@
+/*-
+ *
+ * Hedera C++ SDK
+ *
+ * Copyright (C) 2020 - 2022 Hedera Hashgraph, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+#include "TokenGrantKycTransaction.h"
+#include "impl/Node.h"
+
+#include <grpcpp/client_context.h>
+#include <proto/token_grant_kyc.pb.h>
+#include <proto/transaction.pb.h>
+#include <stdexcept>
+
+namespace Hedera
+{
+//-----
+TokenGrantKycTransaction::TokenGrantKycTransaction(const proto::TransactionBody& transactionBody)
+  : Transaction<TokenGrantKycTransaction>(transactionBody)
+{
+  if (!transactionBody.has_tokengrantkyc())
+  {
+    throw std::invalid_argument("Transaction body doesn't contain TokenGrantKyc data");
+  }
+
+  const proto::TokenGrantKycTransactionBody& body = transactionBody.tokengrantkyc();
+
+  if (body.has_account())
+  {
+    mAccountId = AccountId::fromProtobuf(body.account());
+  }
+
+  if (body.has_token())
+  {
+    mTokenId = TokenId::fromProtobuf(body.token());
+  }
+}
+
+//-----
+TokenGrantKycTransaction& TokenGrantKycTransaction::setAccountId(const AccountId& accountId)
+{
+  requireNotFrozen();
+  mAccountId = accountId;
+  return *this;
+}
+
+//-----
+TokenGrantKycTransaction& TokenGrantKycTransaction::setTokenId(const TokenId& tokenId)
+{
+  requireNotFrozen();
+  mTokenId = tokenId;
+  return *this;
+}
+
+//-----
+proto::Transaction TokenGrantKycTransaction::makeRequest(const Client& client,
+                                                         const std::shared_ptr<internal::Node>&) const
+{
+  proto::TransactionBody transactionBody = generateTransactionBody(client);
+  transactionBody.set_allocated_tokengrantkyc(build());
+
+  return signTransaction(transactionBody, client);
+}
+
+//-----
+grpc::Status TokenGrantKycTransaction::submitRequest(const Client& client,
+                                                     const std::chrono::system_clock::time_point& deadline,
+                                                     const std::shared_ptr<internal::Node>& node,
+                                                     proto::TransactionResponse* response) const
+{
+  return node->submitTransaction(
+    proto::TransactionBody::DataCase::kTokenGrantKyc, makeRequest(client, node), deadline, response);
+}
+
+//-----
+proto::TokenGrantKycTransactionBody* TokenGrantKycTransaction::build() const
+{
+  auto body = std::make_unique<proto::TokenGrantKycTransactionBody>();
+  body->set_allocated_account(mAccountId.toProtobuf().release());
+  body->set_allocated_token(mTokenId.toProtobuf().release());
+  return body.release();
+}
+
+} // namespace Hedera

--- a/sdk/main/src/TokenWipeTransaction.cc
+++ b/sdk/main/src/TokenWipeTransaction.cc
@@ -111,8 +111,17 @@ grpc::Status TokenWipeTransaction::submitRequest(const Client& client,
 proto::TokenWipeAccountTransactionBody* TokenWipeTransaction::build() const
 {
   auto body = std::make_unique<proto::TokenWipeAccountTransactionBody>();
-  body->set_allocated_token(mTokenId.toProtobuf().release());
-  body->set_allocated_account(mAccountId.toProtobuf().release());
+
+  if (!(mTokenId == TokenId()))
+  {
+    body->set_allocated_token(mTokenId.toProtobuf().release());
+  }
+
+  if (!(mAccountId == AccountId()))
+  {
+    body->set_allocated_account(mAccountId.toProtobuf().release());
+  }
+
   body->set_amount(mAmount);
 
   for (const auto& num : mSerialNumbers)

--- a/sdk/main/src/Transaction.cc
+++ b/sdk/main/src/Transaction.cc
@@ -39,6 +39,7 @@
 #include "TokenAssociateTransaction.h"
 #include "TokenCreateTransaction.h"
 #include "TokenDeleteTransaction.h"
+#include "TokenGrantKycTransaction.h"
 #include "TokenMintTransaction.h"
 #include "TokenUpdateTransaction.h"
 #include "TokenWipeTransaction.h"
@@ -83,7 +84,8 @@ std::pair<int,
                        TokenAssociateTransaction,
                        TokenMintTransaction,
                        TokenUpdateTransaction,
-                       TokenWipeTransaction>>
+                       TokenWipeTransaction,
+                       TokenGrantKycTransaction>>
 Transaction<SdkRequestType>::fromBytes(const std::vector<std::byte>& bytes)
 {
   proto::TransactionBody txBody;
@@ -167,6 +169,8 @@ Transaction<SdkRequestType>::fromBytes(const std::vector<std::byte>& bytes)
       return { 19, TokenUpdateTransaction(txBody) };
     case proto::TransactionBody::kTokenWipe:
       return { 20, TokenWipeTransaction(txBody) };
+    case proto::TransactionBody::kTokenGrantKyc:
+      return { 21, TokenGrantKycTransaction(txBody) };
     default:
       throw std::invalid_argument("Type of transaction cannot be determined from input bytes");
   }
@@ -485,6 +489,7 @@ template class Transaction<FileUpdateTransaction>;
 template class Transaction<TokenAssociateTransaction>;
 template class Transaction<TokenCreateTransaction>;
 template class Transaction<TokenDeleteTransaction>;
+template class Transaction<TokenGrantKycTransaction>;
 template class Transaction<TokenMintTransaction>;
 template class Transaction<TokenUpdateTransaction>;
 template class Transaction<TokenWipeTransaction>;

--- a/sdk/main/src/TransactionReceipt.cc
+++ b/sdk/main/src/TransactionReceipt.cc
@@ -59,7 +59,7 @@ TransactionReceipt TransactionReceipt::fromProtobuf(const proto::TransactionRece
 
   for (int i = 0; i < proto.serialnumbers_size(); ++i)
   {
-    receipt.mSerialNumbers.push_back(proto.serialnumbers(i));
+    receipt.mSerialNumbers.push_back(static_cast<uint64_t>(proto.serialnumbers(i)));
   }
 
   return receipt;

--- a/sdk/main/src/impl/Node.cc
+++ b/sdk/main/src/impl/Node.cc
@@ -202,6 +202,8 @@ grpc::Status Node::submitTransaction(proto::TransactionBody::DataCase funcEnum,
       return mTokenStub->mintToken(&context, transaction, response);
     case proto::TransactionBody::DataCase::kTokenUpdate:
       return mTokenStub->updateToken(&context, transaction, response);
+    case proto::TransactionBody::DataCase::kTokenWipe:
+      return mTokenStub->wipeTokenAccount(&context, transaction, response);
     default:
       // This should never happen
       throw std::invalid_argument("Unrecognized gRPC transaction method case");

--- a/sdk/main/src/impl/Node.cc
+++ b/sdk/main/src/impl/Node.cc
@@ -196,6 +196,8 @@ grpc::Status Node::submitTransaction(proto::TransactionBody::DataCase funcEnum,
       return mTokenStub->createToken(&context, transaction, response);
     case proto::TransactionBody::DataCase::kTokenDeletion:
       return mTokenStub->deleteToken(&context, transaction, response);
+    case proto::TransactionBody::DataCase::kTokenGrantKyc:
+      return mTokenStub->grantKycToTokenAccount(&context, transaction, response);
     case proto::TransactionBody::DataCase::kTokenMint:
       return mTokenStub->mintToken(&context, transaction, response);
     case proto::TransactionBody::DataCase::kTokenUpdate:

--- a/sdk/tests/integration/CMakeLists.txt
+++ b/sdk/tests/integration/CMakeLists.txt
@@ -27,6 +27,7 @@ add_executable(${TEST_PROJECT_NAME}
         TokenAssociateTransactionIntegrationTests.cc
         TokenCreateTransactionIntegrationTests.cc
         TokenDeleteTransactionIntegrationTests.cc
+        TokenGrantKycTransactionIntegrationTests.cc
         TokenMintTransactionIntegrationTests.cc
         TokenUpdateTransactionIntegrationTests.cc
         TransactionIntegrationTest.cc

--- a/sdk/tests/integration/CMakeLists.txt
+++ b/sdk/tests/integration/CMakeLists.txt
@@ -30,6 +30,7 @@ add_executable(${TEST_PROJECT_NAME}
         TokenGrantKycTransactionIntegrationTests.cc
         TokenMintTransactionIntegrationTests.cc
         TokenUpdateTransactionIntegrationTests.cc
+        TokenWipeTransactionIntegrationTests.cc
         TransactionIntegrationTest.cc
         TransactionReceiptIntegrationTest.cc
         TransactionReceiptQueryIntegrationTest.cc

--- a/sdk/tests/integration/TokenGrantKycTransactionIntegrationTests.cc
+++ b/sdk/tests/integration/TokenGrantKycTransactionIntegrationTests.cc
@@ -1,0 +1,224 @@
+/*-
+ *
+ * Hedera C++ SDK
+ *
+ * Copyright (C) 2020 - 2022 Hedera Hashgraph, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+#include "AccountCreateTransaction.h"
+#include "AccountDeleteTransaction.h"
+#include "AccountId.h"
+#include "BaseIntegrationTest.h"
+#include "ED25519PrivateKey.h"
+#include "TokenAssociateTransaction.h"
+#include "TokenCreateTransaction.h"
+#include "TokenDeleteTransaction.h"
+#include "TokenGrantKycTransaction.h"
+#include "TokenId.h"
+#include "TransactionReceipt.h"
+#include "TransactionResponse.h"
+#include "exceptions/PrecheckStatusException.h"
+#include "exceptions/ReceiptStatusException.h"
+
+#include <gtest/gtest.h>
+
+using namespace Hedera;
+
+class TokenGrantKycTransactionIntegrationTest : public BaseIntegrationTest
+{
+};
+
+//-----
+TEST_F(TokenGrantKycTransactionIntegrationTest, ExecuteTokenGrantKycTransaction)
+{
+  // Given
+  std::shared_ptr<PrivateKey> operatorKey;
+  std::shared_ptr<ED25519PrivateKey> accountKey;
+
+  ASSERT_NO_THROW(
+    operatorKey = ED25519PrivateKey::fromString(
+      "302e020100300506032b65700422042091132178e72057a1d7528025956fe39b0b847f200ab59b2fdd367017f3087137"));
+  ASSERT_NO_THROW(accountKey = ED25519PrivateKey::generatePrivateKey());
+
+  AccountId accountId;
+  ASSERT_NO_THROW(accountId = AccountCreateTransaction()
+                                .setKey(accountKey.get())
+                                .setInitialBalance(Hbar(1LL))
+                                .execute(getTestClient())
+                                .getReceipt(getTestClient())
+                                .mAccountId.value());
+
+  TokenId tokenId;
+  ASSERT_NO_THROW(tokenId = TokenCreateTransaction()
+                              .setTokenName("ffff")
+                              .setTokenSymbol("F")
+                              .setTreasuryAccountId(AccountId(2ULL))
+                              .setAdminKey(operatorKey)
+                              .setKycKey(operatorKey)
+                              .execute(getTestClient())
+                              .getReceipt(getTestClient())
+                              .mTokenId.value());
+
+  ASSERT_NO_THROW(const TransactionReceipt txReceipt = TokenAssociateTransaction()
+                                                         .setAccountId(accountId)
+                                                         .setTokenIds({ tokenId })
+                                                         .freezeWith(getTestClient())
+                                                         .sign(accountKey.get())
+                                                         .execute(getTestClient())
+                                                         .getReceipt(getTestClient()));
+
+  // When / Then
+  EXPECT_NO_THROW(const TransactionReceipt txReceipt = TokenGrantKycTransaction()
+                                                         .setAccountId(accountId)
+                                                         .setTokenId(tokenId)
+                                                         .freezeWith(getTestClient())
+                                                         .sign(accountKey.get())
+                                                         .execute(getTestClient())
+                                                         .getReceipt(getTestClient()));
+
+  // Clean up
+  ASSERT_NO_THROW(const TransactionReceipt txReceipt = AccountDeleteTransaction()
+                                                         .setTransferAccountId(AccountId(2ULL))
+                                                         .setDeleteAccountId(accountId)
+                                                         .freezeWith(getTestClient())
+                                                         .sign(accountKey.get())
+                                                         .execute(getTestClient())
+                                                         .getReceipt(getTestClient()));
+  ASSERT_NO_THROW(const TransactionReceipt txReceipt =
+                    TokenDeleteTransaction().setTokenId(tokenId).execute(getTestClient()).getReceipt(getTestClient()));
+}
+
+//-----
+TEST_F(TokenGrantKycTransactionIntegrationTest, CannotGrantKycToAccountWithNoTokenId)
+{
+  // Given
+  std::shared_ptr<PrivateKey> operatorKey;
+  std::shared_ptr<ED25519PrivateKey> accountKey;
+
+  ASSERT_NO_THROW(
+    operatorKey = ED25519PrivateKey::fromString(
+      "302e020100300506032b65700422042091132178e72057a1d7528025956fe39b0b847f200ab59b2fdd367017f3087137"));
+  ASSERT_NO_THROW(accountKey = ED25519PrivateKey::generatePrivateKey());
+
+  AccountId accountId;
+  ASSERT_NO_THROW(accountId = AccountCreateTransaction()
+                                .setKey(accountKey.get())
+                                .setInitialBalance(Hbar(1LL))
+                                .execute(getTestClient())
+                                .getReceipt(getTestClient())
+                                .mAccountId.value());
+
+  // When / Then
+  EXPECT_THROW(const TransactionReceipt txReceipt = TokenGrantKycTransaction()
+                                                      .setAccountId(accountId)
+                                                      .freezeWith(getTestClient())
+                                                      .sign(accountKey.get())
+                                                      .execute(getTestClient())
+                                                      .getReceipt(getTestClient()),
+               PrecheckStatusException); // INVALID_TOKEN_ID
+
+  // Clean up
+  ASSERT_NO_THROW(const TransactionReceipt txReceipt = AccountDeleteTransaction()
+                                                         .setTransferAccountId(AccountId(2ULL))
+                                                         .setDeleteAccountId(accountId)
+                                                         .freezeWith(getTestClient())
+                                                         .sign(accountKey.get())
+                                                         .execute(getTestClient())
+                                                         .getReceipt(getTestClient()));
+}
+
+//-----
+TEST_F(TokenGrantKycTransactionIntegrationTest, CannotGrantKycOnNoAccount)
+{
+  // Given
+  std::shared_ptr<PrivateKey> operatorKey;
+
+  ASSERT_NO_THROW(
+    operatorKey = ED25519PrivateKey::fromString(
+      "302e020100300506032b65700422042091132178e72057a1d7528025956fe39b0b847f200ab59b2fdd367017f3087137"));
+
+  TokenId tokenId;
+  ASSERT_NO_THROW(tokenId = TokenCreateTransaction()
+                              .setTokenName("ffff")
+                              .setTokenSymbol("F")
+                              .setTreasuryAccountId(AccountId(2ULL))
+                              .setAdminKey(operatorKey)
+                              .setKycKey(operatorKey)
+                              .execute(getTestClient())
+                              .getReceipt(getTestClient())
+                              .mTokenId.value());
+
+  // When / Then
+  EXPECT_THROW(const TransactionReceipt txReceipt =
+                 TokenGrantKycTransaction().setTokenId(tokenId).execute(getTestClient()).getReceipt(getTestClient()),
+               PrecheckStatusException); // INVALID_ACCOUNT_ID
+
+  // Clean up
+  ASSERT_NO_THROW(const TransactionReceipt txReceipt =
+                    TokenDeleteTransaction().setTokenId(tokenId).execute(getTestClient()).getReceipt(getTestClient()));
+}
+
+//-----
+TEST_F(TokenGrantKycTransactionIntegrationTest, CannotGrantKycToAccountOnTokenIfNotAssociated)
+{
+  // Given
+  std::shared_ptr<PrivateKey> operatorKey;
+  std::shared_ptr<ED25519PrivateKey> accountKey;
+
+  ASSERT_NO_THROW(
+    operatorKey = ED25519PrivateKey::fromString(
+      "302e020100300506032b65700422042091132178e72057a1d7528025956fe39b0b847f200ab59b2fdd367017f3087137"));
+  ASSERT_NO_THROW(accountKey = ED25519PrivateKey::generatePrivateKey());
+
+  AccountId accountId;
+  ASSERT_NO_THROW(accountId = AccountCreateTransaction()
+                                .setKey(accountKey.get())
+                                .setInitialBalance(Hbar(1LL))
+                                .execute(getTestClient())
+                                .getReceipt(getTestClient())
+                                .mAccountId.value());
+
+  TokenId tokenId;
+  ASSERT_NO_THROW(tokenId = TokenCreateTransaction()
+                              .setTokenName("ffff")
+                              .setTokenSymbol("F")
+                              .setTreasuryAccountId(AccountId(2ULL))
+                              .setAdminKey(operatorKey)
+                              .setKycKey(operatorKey)
+                              .execute(getTestClient())
+                              .getReceipt(getTestClient())
+                              .mTokenId.value());
+
+  // When / Then
+  EXPECT_THROW(const TransactionReceipt txReceipt = TokenGrantKycTransaction()
+                                                      .setAccountId(accountId)
+                                                      .setTokenId(tokenId)
+                                                      .freezeWith(getTestClient())
+                                                      .sign(accountKey.get())
+                                                      .execute(getTestClient())
+                                                      .getReceipt(getTestClient()),
+               ReceiptStatusException); // TOKEN_NOT_ASSOCIATED_TO_ACCOUNT
+
+  // Clean up
+  ASSERT_NO_THROW(const TransactionReceipt txReceipt = AccountDeleteTransaction()
+                                                         .setTransferAccountId(AccountId(2ULL))
+                                                         .setDeleteAccountId(accountId)
+                                                         .freezeWith(getTestClient())
+                                                         .sign(accountKey.get())
+                                                         .execute(getTestClient())
+                                                         .getReceipt(getTestClient()));
+  ASSERT_NO_THROW(const TransactionReceipt txReceipt =
+                    TokenDeleteTransaction().setTokenId(tokenId).execute(getTestClient()).getReceipt(getTestClient()));
+}

--- a/sdk/tests/integration/TokenWipeTransactionIntegrationTests.cc
+++ b/sdk/tests/integration/TokenWipeTransactionIntegrationTests.cc
@@ -1,0 +1,465 @@
+/*-
+ *
+ * Hedera C++ SDK
+ *
+ * Copyright (C) 2020 - 2022 Hedera Hashgraph, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+#include "AccountCreateTransaction.h"
+#include "AccountDeleteTransaction.h"
+#include "AccountId.h"
+#include "BaseIntegrationTest.h"
+#include "ED25519PrivateKey.h"
+#include "PrivateKey.h"
+#include "TokenAssociateTransaction.h"
+#include "TokenCreateTransaction.h"
+#include "TokenDeleteTransaction.h"
+#include "TokenGrantKycTransaction.h"
+#include "TokenMintTransaction.h"
+#include "TokenWipeTransaction.h"
+#include "TransactionReceipt.h"
+#include "TransactionResponse.h"
+#include "TransferTransaction.h"
+#include "exceptions/PrecheckStatusException.h"
+#include "exceptions/ReceiptStatusException.h"
+#include "impl/Utilities.h"
+
+#include <gtest/gtest.h>
+#include <vector>
+
+using namespace Hedera;
+
+class TokenWipeTransactionIntegrationTest : public BaseIntegrationTest
+{
+};
+
+//-----
+TEST_F(TokenWipeTransactionIntegrationTest, ExecuteTokenWipeTransaction)
+{
+  // Given
+  const int64_t amount = 10LL;
+
+  std::shared_ptr<PrivateKey> operatorKey;
+  std::shared_ptr<PrivateKey> accountKey;
+
+  ASSERT_NO_THROW(
+    operatorKey = ED25519PrivateKey::fromString(
+      "302e020100300506032b65700422042091132178e72057a1d7528025956fe39b0b847f200ab59b2fdd367017f3087137"));
+  ASSERT_NO_THROW(accountKey = ED25519PrivateKey::generatePrivateKey());
+
+  AccountId accountId;
+  ASSERT_NO_THROW(accountId = AccountCreateTransaction()
+                                .setKey(accountKey.get())
+                                .setInitialBalance(Hbar(1LL))
+                                .execute(getTestClient())
+                                .getReceipt(getTestClient())
+                                .mAccountId.value());
+
+  TokenId tokenId;
+  ASSERT_NO_THROW(tokenId = TokenCreateTransaction()
+                              .setTokenName("ffff")
+                              .setTokenSymbol("F")
+                              .setInitialSupply(100000ULL)
+                              .setTreasuryAccountId(AccountId(2ULL))
+                              .setAdminKey(operatorKey)
+                              .setFreezeKey(operatorKey)
+                              .setWipeKey(operatorKey)
+                              .setKycKey(operatorKey)
+                              .setSupplyKey(operatorKey)
+                              .setFeeScheduleKey(operatorKey)
+                              .execute(getTestClient())
+                              .getReceipt(getTestClient())
+                              .mTokenId.value());
+
+  ASSERT_NO_THROW(const TransactionReceipt txReceipt = TokenAssociateTransaction()
+                                                         .setAccountId(accountId)
+                                                         .setTokenIds({ tokenId })
+                                                         .freezeWith(getTestClient())
+                                                         .sign(accountKey.get())
+                                                         .execute(getTestClient())
+                                                         .getReceipt(getTestClient()));
+  ASSERT_NO_THROW(const TransactionReceipt txReceipt = TokenGrantKycTransaction()
+                                                         .setAccountId(accountId)
+                                                         .setTokenId(tokenId)
+                                                         .execute(getTestClient())
+                                                         .getReceipt(getTestClient()));
+  ASSERT_NO_THROW(const TransactionReceipt txReceipt = TransferTransaction()
+                                                         .addTokenTransfer(tokenId, AccountId(2ULL), -amount)
+                                                         .addTokenTransfer(tokenId, accountId, amount)
+                                                         .execute(getTestClient())
+                                                         .getReceipt(getTestClient()));
+
+  // When / Then
+  EXPECT_NO_THROW(const TransactionReceipt txReceipt = TokenWipeTransaction()
+                                                         .setTokenId(tokenId)
+                                                         .setAccountId(accountId)
+                                                         .setAmount(amount)
+                                                         .execute(getTestClient())
+                                                         .getReceipt(getTestClient()));
+
+  // Clean up
+  ASSERT_NO_THROW(const TransactionReceipt txReceipt =
+                    TokenDeleteTransaction().setTokenId(tokenId).execute(getTestClient()).getReceipt(getTestClient()));
+}
+
+//-----
+TEST_F(TokenWipeTransactionIntegrationTest, CanWipeNfts)
+{
+  // Given
+  std::shared_ptr<PrivateKey> operatorKey;
+  std::shared_ptr<PrivateKey> accountKey;
+
+  ASSERT_NO_THROW(
+    operatorKey = ED25519PrivateKey::fromString(
+      "302e020100300506032b65700422042091132178e72057a1d7528025956fe39b0b847f200ab59b2fdd367017f3087137"));
+  ASSERT_NO_THROW(accountKey = ED25519PrivateKey::generatePrivateKey());
+
+  AccountId accountId;
+  ASSERT_NO_THROW(accountId = AccountCreateTransaction()
+                                .setKey(accountKey.get())
+                                .setInitialBalance(Hbar(1LL))
+                                .execute(getTestClient())
+                                .getReceipt(getTestClient())
+                                .mAccountId.value());
+
+  TokenId tokenId;
+  ASSERT_NO_THROW(tokenId = TokenCreateTransaction()
+                              .setTokenName("ffff")
+                              .setTokenSymbol("F")
+                              .setTokenType(TokenType::NON_FUNGIBLE_UNIQUE)
+                              .setTreasuryAccountId(AccountId(2ULL))
+                              .setAdminKey(operatorKey)
+                              .setFreezeKey(operatorKey)
+                              .setWipeKey(operatorKey)
+                              .setKycKey(operatorKey)
+                              .setSupplyKey(operatorKey)
+                              .setFeeScheduleKey(operatorKey)
+                              .execute(getTestClient())
+                              .getReceipt(getTestClient())
+                              .mTokenId.value());
+
+  std::vector<uint64_t> serialNumbers;
+  ASSERT_NO_THROW(serialNumbers = TokenMintTransaction()
+                                    .setTokenId(tokenId)
+                                    .setMetadata({ { std::byte(0x01) }, { std::byte(0x02) }, { std::byte(0x03) } })
+                                    .execute(getTestClient())
+                                    .getReceipt(getTestClient())
+                                    .mSerialNumbers);
+
+  ASSERT_NO_THROW(const TransactionReceipt txReceipt = TokenAssociateTransaction()
+                                                         .setAccountId(accountId)
+                                                         .setTokenIds({ tokenId })
+                                                         .freezeWith(getTestClient())
+                                                         .sign(accountKey.get())
+                                                         .execute(getTestClient())
+                                                         .getReceipt(getTestClient()));
+  ASSERT_NO_THROW(const TransactionReceipt txReceipt = TokenGrantKycTransaction()
+                                                         .setAccountId(accountId)
+                                                         .setTokenId(tokenId)
+                                                         .execute(getTestClient())
+                                                         .getReceipt(getTestClient()));
+  ASSERT_NO_THROW(const TransactionReceipt txReceipt =
+                    TransferTransaction()
+                      .addNftTransfer(NftId(tokenId, serialNumbers.at(0)), AccountId(2ULL), accountId)
+                      .execute(getTestClient())
+                      .getReceipt(getTestClient()));
+
+  // When / Then
+  EXPECT_NO_THROW(const TransactionReceipt txReceipt = TokenWipeTransaction()
+                                                         .setTokenId(tokenId)
+                                                         .setAccountId(accountId)
+                                                         .setSerialNumbers({ serialNumbers.at(0) })
+                                                         .execute(getTestClient())
+                                                         .getReceipt(getTestClient()));
+
+  // Clean up
+  ASSERT_NO_THROW(const TransactionReceipt txReceipt =
+                    TokenDeleteTransaction().setTokenId(tokenId).execute(getTestClient()).getReceipt(getTestClient()));
+}
+
+//-----
+TEST_F(TokenWipeTransactionIntegrationTest, CannotWipeNftsIfTheAccountDoesNotOwnThem)
+{
+  // Given
+  std::shared_ptr<PrivateKey> operatorKey;
+  std::shared_ptr<PrivateKey> accountKey;
+
+  ASSERT_NO_THROW(
+    operatorKey = ED25519PrivateKey::fromString(
+      "302e020100300506032b65700422042091132178e72057a1d7528025956fe39b0b847f200ab59b2fdd367017f3087137"));
+  ASSERT_NO_THROW(accountKey = ED25519PrivateKey::generatePrivateKey());
+
+  AccountId accountId;
+  ASSERT_NO_THROW(accountId = AccountCreateTransaction()
+                                .setKey(accountKey.get())
+                                .setInitialBalance(Hbar(1LL))
+                                .execute(getTestClient())
+                                .getReceipt(getTestClient())
+                                .mAccountId.value());
+
+  TokenId tokenId;
+  ASSERT_NO_THROW(tokenId = TokenCreateTransaction()
+                              .setTokenName("ffff")
+                              .setTokenSymbol("F")
+                              .setTokenType(TokenType::NON_FUNGIBLE_UNIQUE)
+                              .setTreasuryAccountId(AccountId(2ULL))
+                              .setAdminKey(operatorKey)
+                              .setFreezeKey(operatorKey)
+                              .setWipeKey(operatorKey)
+                              .setKycKey(operatorKey)
+                              .setSupplyKey(operatorKey)
+                              .setFeeScheduleKey(operatorKey)
+                              .execute(getTestClient())
+                              .getReceipt(getTestClient())
+                              .mTokenId.value());
+
+  std::vector<uint64_t> serialNumbers;
+  ASSERT_NO_THROW(serialNumbers = TokenMintTransaction()
+                                    .setTokenId(tokenId)
+                                    .setMetadata({ { std::byte(0x01) }, { std::byte(0x02) }, { std::byte(0x03) } })
+                                    .execute(getTestClient())
+                                    .getReceipt(getTestClient())
+                                    .mSerialNumbers);
+
+  ASSERT_NO_THROW(const TransactionReceipt txReceipt = TokenAssociateTransaction()
+                                                         .setAccountId(accountId)
+                                                         .setTokenIds({ tokenId })
+                                                         .freezeWith(getTestClient())
+                                                         .sign(accountKey.get())
+                                                         .execute(getTestClient())
+                                                         .getReceipt(getTestClient()));
+  ASSERT_NO_THROW(const TransactionReceipt txReceipt = TokenGrantKycTransaction()
+                                                         .setAccountId(accountId)
+                                                         .setTokenId(tokenId)
+                                                         .execute(getTestClient())
+                                                         .getReceipt(getTestClient()));
+
+  // When / Then
+  EXPECT_THROW(const TransactionReceipt txReceipt = TokenWipeTransaction()
+                                                      .setTokenId(tokenId)
+                                                      .setAccountId(accountId)
+                                                      .setSerialNumbers({ serialNumbers.at(0) })
+                                                      .execute(getTestClient())
+                                                      .getReceipt(getTestClient()),
+               ReceiptStatusException); // ACCOUNT_DOES_NOT_OWN_WIPED_NFT
+
+  // Clean up
+  ASSERT_NO_THROW(const TransactionReceipt txReceipt =
+                    TokenDeleteTransaction().setTokenId(tokenId).execute(getTestClient()).getReceipt(getTestClient()));
+}
+
+//-----
+TEST_F(TokenWipeTransactionIntegrationTest, CannotWipeTokensIfNoAccountId)
+{
+  // Given
+  const int64_t amount = 10LL;
+
+  std::shared_ptr<PrivateKey> operatorKey;
+  std::shared_ptr<PrivateKey> accountKey;
+
+  ASSERT_NO_THROW(
+    operatorKey = ED25519PrivateKey::fromString(
+      "302e020100300506032b65700422042091132178e72057a1d7528025956fe39b0b847f200ab59b2fdd367017f3087137"));
+  ASSERT_NO_THROW(accountKey = ED25519PrivateKey::generatePrivateKey());
+
+  AccountId accountId;
+  ASSERT_NO_THROW(accountId = AccountCreateTransaction()
+                                .setKey(accountKey.get())
+                                .setInitialBalance(Hbar(1LL))
+                                .execute(getTestClient())
+                                .getReceipt(getTestClient())
+                                .mAccountId.value());
+
+  TokenId tokenId;
+  ASSERT_NO_THROW(tokenId = TokenCreateTransaction()
+                              .setTokenName("ffff")
+                              .setTokenSymbol("F")
+                              .setInitialSupply(100000ULL)
+                              .setTreasuryAccountId(AccountId(2ULL))
+                              .setAdminKey(operatorKey)
+                              .setFreezeKey(operatorKey)
+                              .setWipeKey(operatorKey)
+                              .setKycKey(operatorKey)
+                              .setSupplyKey(operatorKey)
+                              .setFeeScheduleKey(operatorKey)
+                              .execute(getTestClient())
+                              .getReceipt(getTestClient())
+                              .mTokenId.value());
+
+  ASSERT_NO_THROW(const TransactionReceipt txReceipt = TokenAssociateTransaction()
+                                                         .setAccountId(accountId)
+                                                         .setTokenIds({ tokenId })
+                                                         .freezeWith(getTestClient())
+                                                         .sign(accountKey.get())
+                                                         .execute(getTestClient())
+                                                         .getReceipt(getTestClient()));
+  ASSERT_NO_THROW(const TransactionReceipt txReceipt = TokenGrantKycTransaction()
+                                                         .setAccountId(accountId)
+                                                         .setTokenId(tokenId)
+                                                         .execute(getTestClient())
+                                                         .getReceipt(getTestClient()));
+  ASSERT_NO_THROW(const TransactionReceipt txReceipt = TransferTransaction()
+                                                         .addTokenTransfer(tokenId, AccountId(2ULL), -amount)
+                                                         .addTokenTransfer(tokenId, accountId, amount)
+                                                         .execute(getTestClient())
+                                                         .getReceipt(getTestClient()));
+
+  // When / Then
+  EXPECT_THROW(
+    const TransactionReceipt txReceipt =
+      TokenWipeTransaction().setTokenId(tokenId).setAmount(amount).execute(getTestClient()).getReceipt(getTestClient()),
+    PrecheckStatusException); // INVALID_ACCOUNT_ID
+
+  // Clean up
+  ASSERT_NO_THROW(const TransactionReceipt txReceipt =
+                    TokenDeleteTransaction().setTokenId(tokenId).execute(getTestClient()).getReceipt(getTestClient()));
+}
+
+//-----
+TEST_F(TokenWipeTransactionIntegrationTest, CannotWipeAccountIfNoTokenId)
+{
+  // Given
+  const int64_t amount = 10LL;
+
+  std::shared_ptr<PrivateKey> operatorKey;
+  std::shared_ptr<PrivateKey> accountKey;
+
+  ASSERT_NO_THROW(
+    operatorKey = ED25519PrivateKey::fromString(
+      "302e020100300506032b65700422042091132178e72057a1d7528025956fe39b0b847f200ab59b2fdd367017f3087137"));
+  ASSERT_NO_THROW(accountKey = ED25519PrivateKey::generatePrivateKey());
+
+  AccountId accountId;
+  ASSERT_NO_THROW(accountId = AccountCreateTransaction()
+                                .setKey(accountKey.get())
+                                .setInitialBalance(Hbar(1LL))
+                                .execute(getTestClient())
+                                .getReceipt(getTestClient())
+                                .mAccountId.value());
+
+  TokenId tokenId;
+  ASSERT_NO_THROW(tokenId = TokenCreateTransaction()
+                              .setTokenName("ffff")
+                              .setTokenSymbol("F")
+                              .setInitialSupply(100000ULL)
+                              .setTreasuryAccountId(AccountId(2ULL))
+                              .setAdminKey(operatorKey)
+                              .setFreezeKey(operatorKey)
+                              .setWipeKey(operatorKey)
+                              .setKycKey(operatorKey)
+                              .setSupplyKey(operatorKey)
+                              .setFeeScheduleKey(operatorKey)
+                              .execute(getTestClient())
+                              .getReceipt(getTestClient())
+                              .mTokenId.value());
+
+  ASSERT_NO_THROW(const TransactionReceipt txReceipt = TokenAssociateTransaction()
+                                                         .setAccountId(accountId)
+                                                         .setTokenIds({ tokenId })
+                                                         .freezeWith(getTestClient())
+                                                         .sign(accountKey.get())
+                                                         .execute(getTestClient())
+                                                         .getReceipt(getTestClient()));
+  ASSERT_NO_THROW(const TransactionReceipt txReceipt = TokenGrantKycTransaction()
+                                                         .setAccountId(accountId)
+                                                         .setTokenId(tokenId)
+                                                         .execute(getTestClient())
+                                                         .getReceipt(getTestClient()));
+  ASSERT_NO_THROW(const TransactionReceipt txReceipt = TransferTransaction()
+                                                         .addTokenTransfer(tokenId, AccountId(2ULL), -amount)
+                                                         .addTokenTransfer(tokenId, accountId, amount)
+                                                         .execute(getTestClient())
+                                                         .getReceipt(getTestClient()));
+
+  // When / Then
+  EXPECT_THROW(const TransactionReceipt txReceipt = TokenWipeTransaction()
+                                                      .setAccountId(accountId)
+                                                      .setAmount(amount)
+                                                      .execute(getTestClient())
+                                                      .getReceipt(getTestClient()),
+               PrecheckStatusException); // INVALID_TOKEN_ID
+
+  // Clean up
+  ASSERT_NO_THROW(const TransactionReceipt txReceipt =
+                    TokenDeleteTransaction().setTokenId(tokenId).execute(getTestClient()).getReceipt(getTestClient()));
+}
+
+//-----
+TEST_F(TokenWipeTransactionIntegrationTest, CanWipeAccountWithNoBalance)
+{
+  // Given
+  const int64_t amount = 10LL;
+
+  std::shared_ptr<PrivateKey> operatorKey;
+  std::shared_ptr<PrivateKey> accountKey;
+
+  ASSERT_NO_THROW(
+    operatorKey = ED25519PrivateKey::fromString(
+      "302e020100300506032b65700422042091132178e72057a1d7528025956fe39b0b847f200ab59b2fdd367017f3087137"));
+  ASSERT_NO_THROW(accountKey = ED25519PrivateKey::generatePrivateKey());
+
+  AccountId accountId;
+  ASSERT_NO_THROW(accountId = AccountCreateTransaction()
+                                .setKey(accountKey.get())
+                                .setInitialBalance(Hbar(1LL))
+                                .execute(getTestClient())
+                                .getReceipt(getTestClient())
+                                .mAccountId.value());
+
+  TokenId tokenId;
+  ASSERT_NO_THROW(tokenId = TokenCreateTransaction()
+                              .setTokenName("ffff")
+                              .setTokenSymbol("F")
+                              .setInitialSupply(100000ULL)
+                              .setTreasuryAccountId(AccountId(2ULL))
+                              .setAdminKey(operatorKey)
+                              .setFreezeKey(operatorKey)
+                              .setWipeKey(operatorKey)
+                              .setKycKey(operatorKey)
+                              .setSupplyKey(operatorKey)
+                              .setFeeScheduleKey(operatorKey)
+                              .execute(getTestClient())
+                              .getReceipt(getTestClient())
+                              .mTokenId.value());
+
+  ASSERT_NO_THROW(const TransactionReceipt txReceipt = TokenAssociateTransaction()
+                                                         .setAccountId(accountId)
+                                                         .setTokenIds({ tokenId })
+                                                         .freezeWith(getTestClient())
+                                                         .sign(accountKey.get())
+                                                         .execute(getTestClient())
+                                                         .getReceipt(getTestClient()));
+  ASSERT_NO_THROW(const TransactionReceipt txReceipt = TokenGrantKycTransaction()
+                                                         .setAccountId(accountId)
+                                                         .setTokenId(tokenId)
+                                                         .execute(getTestClient())
+                                                         .getReceipt(getTestClient()));
+  ASSERT_NO_THROW(const TransactionReceipt txReceipt = TransferTransaction()
+                                                         .addTokenTransfer(tokenId, AccountId(2ULL), -amount)
+                                                         .addTokenTransfer(tokenId, accountId, amount)
+                                                         .execute(getTestClient())
+                                                         .getReceipt(getTestClient()));
+
+  // When / Then
+  EXPECT_NO_THROW(const TransactionReceipt txReceipt = TokenWipeTransaction()
+                                                         .setAccountId(accountId)
+                                                         .setTokenId(tokenId)
+                                                         .execute(getTestClient())
+                                                         .getReceipt(getTestClient()));
+
+  // Clean up
+  ASSERT_NO_THROW(const TransactionReceipt txReceipt =
+                    TokenDeleteTransaction().setTokenId(tokenId).execute(getTestClient()).getReceipt(getTestClient()));
+}

--- a/sdk/tests/unit/CMakeLists.txt
+++ b/sdk/tests/unit/CMakeLists.txt
@@ -65,6 +65,7 @@ add_executable(${TEST_PROJECT_NAME}
         TokenAssociationUnitTests.cc
         TokenCreateTransactionTest.cc
         TokenDeleteTransactionTest.cc
+        TokenGrantKycTransactionUnitTests.cc
         TokenIdTest.cc
         TokenMintTransactionUnitTests.cc
         TokenNftAllowanceTest.cc

--- a/sdk/tests/unit/TokenGrantKycTransactionUnitTests.cc
+++ b/sdk/tests/unit/TokenGrantKycTransactionUnitTests.cc
@@ -1,0 +1,111 @@
+/*-
+ *
+ * Hedera C++ SDK
+ *
+ * Copyright (C) 2020 - 2022 Hedera Hashgraph, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+#include "AccountId.h"
+#include "Client.h"
+#include "ECDSAsecp256k1PrivateKey.h"
+#include "TokenGrantKycTransaction.h"
+#include "exceptions/IllegalStateException.h"
+
+#include <gtest/gtest.h>
+#include <proto/transaction_body.pb.h>
+
+using namespace Hedera;
+
+class TokenGrantKycTransactionTest : public ::testing::Test
+{
+protected:
+  void SetUp() override { mClient.setOperator(AccountId(), ECDSAsecp256k1PrivateKey::generatePrivateKey().get()); }
+
+  [[nodiscard]] inline const Client& getTestClient() const { return mClient; }
+  [[nodiscard]] inline const AccountId& getTestAccountId() const { return mTestAccountId; }
+  [[nodiscard]] inline const TokenId& getTestTokenId() const { return mTestTokenId; }
+
+private:
+  Client mClient;
+  const AccountId mTestAccountId = AccountId(1ULL, 2ULL, 3ULL);
+  const TokenId mTestTokenId = TokenId(4ULL, 5ULL, 6ULL);
+};
+
+//-----
+TEST_F(TokenGrantKycTransactionTest, ConstructTokenGrantKycTransactionFromTransactionBodyProtobuf)
+{
+  // Given
+  auto body = std::make_unique<proto::TokenGrantKycTransactionBody>();
+  body->set_allocated_account(getTestAccountId().toProtobuf().release());
+  body->set_allocated_token(getTestTokenId().toProtobuf().release());
+
+  proto::TransactionBody txBody;
+  txBody.set_allocated_tokengrantkyc(body.release());
+
+  // When
+  const TokenGrantKycTransaction tokenGrantKycTransaction(txBody);
+
+  // Then
+  EXPECT_EQ(tokenGrantKycTransaction.getAccountId(), getTestAccountId());
+  EXPECT_EQ(tokenGrantKycTransaction.getTokenId(), getTestTokenId());
+}
+
+//-----
+TEST_F(TokenGrantKycTransactionTest, GetSetAccountId)
+{
+  // Given
+  TokenGrantKycTransaction transaction;
+
+  // When
+  EXPECT_NO_THROW(transaction.setAccountId(getTestAccountId()));
+
+  // Then
+  EXPECT_EQ(transaction.getAccountId(), getTestAccountId());
+}
+
+//-----
+TEST_F(TokenGrantKycTransactionTest, GetSetAccountIdFrozen)
+{
+  // Given
+  TokenGrantKycTransaction transaction;
+  ASSERT_NO_THROW(transaction.freezeWith(getTestClient()));
+
+  // When / Then
+  EXPECT_THROW(transaction.setAccountId(getTestAccountId()), IllegalStateException);
+}
+
+//-----
+TEST_F(TokenGrantKycTransactionTest, GetSetTokenId)
+{
+  // Given
+  TokenGrantKycTransaction transaction;
+
+  // When
+  EXPECT_NO_THROW(transaction.setTokenId(getTestTokenId()));
+
+  // Then
+  EXPECT_EQ(transaction.getTokenId(), getTestTokenId());
+}
+
+//-----
+TEST_F(TokenGrantKycTransactionTest, GetSetTokenIdFrozen)
+{
+  // Given
+  TokenGrantKycTransaction transaction;
+  ASSERT_NO_THROW(transaction.freezeWith(getTestClient()));
+
+  // When / Then
+  EXPECT_THROW(transaction.setTokenId(getTestTokenId()), IllegalStateException);
+}

--- a/sdk/tests/unit/TransactionTest.cc
+++ b/sdk/tests/unit/TransactionTest.cc
@@ -35,6 +35,7 @@
 #include "TokenAssociateTransaction.h"
 #include "TokenCreateTransaction.h"
 #include "TokenDeleteTransaction.h"
+#include "TokenGrantKycTransaction.h"
 #include "TokenMintTransaction.h"
 #include "TokenUpdateTransaction.h"
 #include "TokenWipeTransaction.h"
@@ -1288,4 +1289,63 @@ TEST_F(TransactionTest, TokenWipeTransactionFromTransactionBytes)
   // Then
   ASSERT_EQ(index, 20);
   EXPECT_NO_THROW(const TokenWipeTransaction tokenWipeTransaction = std::get<20>(txVariant));
+}
+
+//-----
+TEST_F(TransactionTest, TokenGrantKycTransactionFromTransactionBodyBytes)
+{
+  // Given
+  proto::TransactionBody txBody;
+  txBody.set_allocated_tokengrantkyc(new proto::TokenGrantKycTransactionBody);
+
+  // When
+  const auto [index, txVariant] = Transaction<TokenGrantKycTransaction>::fromBytes(
+    internal::Utilities::stringToByteVector(txBody.SerializeAsString()));
+
+  // Then
+  ASSERT_EQ(index, 21);
+  EXPECT_NO_THROW(const TokenGrantKycTransaction tokenGrantKycTransaction = std::get<21>(txVariant));
+}
+
+//-----
+TEST_F(TransactionTest, TokenGrantKycTransactionFromSignedTransactionBytes)
+{
+  // Given
+  proto::TransactionBody txBody;
+  txBody.set_allocated_tokengrantkyc(new proto::TokenGrantKycTransactionBody);
+
+  proto::SignedTransaction signedTx;
+  signedTx.set_bodybytes(txBody.SerializeAsString());
+  // SignatureMap not required
+
+  // When
+  const auto [index, txVariant] = Transaction<TokenGrantKycTransaction>::fromBytes(
+    internal::Utilities::stringToByteVector(txBody.SerializeAsString()));
+
+  // Then
+  ASSERT_EQ(index, 21);
+  EXPECT_NO_THROW(const TokenGrantKycTransaction tokenGrantKycTransaction = std::get<21>(txVariant));
+}
+
+//-----
+TEST_F(TransactionTest, TokenGrantKycTransactionFromTransactionBytes)
+{
+  // Given
+  proto::TransactionBody txBody;
+  txBody.set_allocated_tokengrantkyc(new proto::TokenGrantKycTransactionBody);
+
+  proto::SignedTransaction signedTx;
+  signedTx.set_bodybytes(txBody.SerializeAsString());
+  // SignatureMap not required
+
+  proto::Transaction tx;
+  tx.set_signedtransactionbytes(signedTx.SerializeAsString());
+
+  // When
+  const auto [index, txVariant] = Transaction<TokenGrantKycTransaction>::fromBytes(
+    internal::Utilities::stringToByteVector(txBody.SerializeAsString()));
+
+  // Then
+  ASSERT_EQ(index, 21);
+  EXPECT_NO_THROW(const TokenGrantKycTransaction tokenGrantKycTransaction = std::get<21>(txVariant));
 }


### PR DESCRIPTION
**Description**:
This PR implements the APIs associated with `TokenGrantKycTransaction`, which grants accounts KYC for a token. It also updates `TransferTokensExample`, as well as adding integration tests for `TokenWipeTransaction`.

**Related issue(s)**:

Fixes #386 

**Checklist**

- [x] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
