### PR TITLE
Implement `TokenRevokeKycTransaction`

### DIFF
--- a/sdk/main/CMakeLists.txt
+++ b/sdk/main/CMakeLists.txt
@@ -84,6 +84,7 @@ add_library(${PROJECT_NAME} STATIC
         src/TokenNftAllowance.cc
         src/TokenNftRemoveAllowance.cc
         src/TokenNftTransfer.cc
+        src/TokenRevokeKycTransaction.cc
         src/TokenSupplyType.cc
         src/TokenTransfer.cc
         src/TokenType.cc

--- a/sdk/main/include/TokenRevokeKycTransaction.h
+++ b/sdk/main/include/TokenRevokeKycTransaction.h
@@ -1,0 +1,150 @@
+/*-
+ *
+ * Hedera C++ SDK
+ *
+ * Copyright (C) 2020 - 2022 Hedera Hashgraph, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+#ifndef HEDERA_SDK_CPP_TOKEN_REVOKE_KYC_TRANSACTION_H_
+#define HEDERA_SDK_CPP_TOKEN_REVOKE_KYC_TRANSACTION_H_
+
+#include "AccountId.h"
+#include "TokenId.h"
+#include "Transaction.h"
+
+#include <optional>
+#include <vector>
+
+namespace proto
+{
+class TokenRevokeKycTransactionBody;
+class TransactionBody;
+}
+
+namespace Hedera
+{
+/**
+ * Revokes the KYC flag to the Hedera account for the given Hedera token. This transaction must be signed by the token's
+ * KYC Key. If this key is not set, you can submit a TokenUpdateTransaction to provide the token with this key.
+ *
+ *  - If the provided account is not found, the transaction will resolve to INVALID_ACCOUNT_ID.
+ *  - If the provided account has been deleted, the transaction will resolve to ACCOUNT_DELETED.
+ *  - If the provided token is not found, the transaction will resolve to INVALID_TOKEN_ID.
+ *  - If the provided token has been deleted, the transaction will resolve to TOKEN_WAS_DELETED.
+ *  - If an Association between the provided token and account is not found, the transaction will resolve to
+ *    TOKEN_NOT_ASSOCIATED_TO_ACCOUNT.
+ *  - If no KYC Key is defined, the transaction will resolve to TOKEN_HAS_NO_KYC_KEY.
+ *
+ * Once executed, the account is marked as KYC Revoked.
+ *
+ * Transaction Signing Requirements:
+ *  - KYC key.
+ *  - Transaction fee payer account key.
+ */
+class TokenRevokeKycTransaction : public Transaction<TokenRevokeKycTransaction>
+{
+public:
+  TokenRevokeKycTransaction() = default;
+
+  /**
+   * Construct from a TransactionBody protobuf object.
+   *
+   * @param transactionBody The TransactionBody protobuf object from which to construct.
+   * @throws std::invalid_argument If the input TransactionBody does not represent a TokenRevokeKyc transaction.
+   */
+  explicit TokenRevokeKycTransaction(const proto::TransactionBody& transactionBody);
+
+  /**
+   * Set the ID of the account to have its KYC revoked for this token.
+   *
+   * @param accountId The ID of the account to have its KYC revoked for this token.
+   * @return A reference to this TokenRevokeKycTransaction object with the newly-set account ID.
+   * @throws IllegalStateException If this TokenRevokeKycTransaction is frozen.
+   */
+  TokenRevokeKycTransaction& setAccountId(const AccountId& accountId);
+
+  /**
+   * Set the ID of the token for which the account has revoked KYC.
+   *
+   * @param tokenId The ID of the token for which the account has revoked KYC.
+   * @return A reference to this TokenRevokeKycTransaction object with the newly-set token ID.
+   * @throws IllegalStateException If this TokenRevokeKycTransaction is frozen.
+   */
+  TokenRevokeKycTransaction& setTokenId(const TokenId& tokenId);
+
+  /**
+   * Get the ID of the account to have its KYC revoked for this token.
+   *
+   * @return The ID of the account to have its KYC revoked for this token.
+   */
+  [[nodiscard]] inline AccountId getAccountId() const { return mAccountId; }
+
+  /**
+   * Get the ID of the token for which the account has revoked KYC.
+   *
+   * @return The ID of the token for which the account has revoked KYC.
+   */
+  [[nodiscard]] inline TokenId getTokenId() const { return mTokenId; }
+
+private:
+  /**
+   * Derived from Executable. Construct a Transaction protobuf object from this TokenRevokeKycTransaction object.
+   *
+   * @param client The Client trying to construct this TokenRevokeKycTransaction.
+   * @param node   The Node to which this TokenRevokeKycTransaction will be sent. This is unused.
+   * @return A Transaction protobuf object filled with this TokenRevokeKycTransaction object's data.
+   * @throws UninitializedException If the input client has no operator with which to sign this
+   *                                TokenRevokeKycTransaction.
+   */
+  [[nodiscard]] proto::Transaction makeRequest(const Client& client,
+                                               const std::shared_ptr<internal::Node>& /*node*/) const override;
+
+  /**
+   * Derived from Executable. Submit this TokenRevokeKycTransaction to a Node.
+   *
+   * @param client   The Client submitting this TokenRevokeKycTransaction.
+   * @param deadline The deadline for submitting this TokenRevokeKycTransaction.
+   * @param node     Pointer to the Node to which this TokenRevokeKycTransaction should be submitted.
+   * @param response Pointer to the TransactionResponse protobuf object that gRPC should populate with the response
+   *                 information from the gRPC server.
+   * @return The gRPC status of the submission.
+   */
+  [[nodiscard]] grpc::Status submitRequest(const Client& client,
+                                           const std::chrono::system_clock::time_point& deadline,
+                                           const std::shared_ptr<internal::Node>& node,
+                                           proto::TransactionResponse* response) const override;
+
+  /**
+   * Build a TokenRevokeKycTransactionBody protobuf object from this TokenRevokeKycTransaction object.
+   *
+   * @return A pointer to a TokenRevokeKycTransactionBody protobuf object filled with this TokenRevokeKycTransaction
+   *         object's data.
+   */
+  [[nodiscard]] proto::TokenRevokeKycTransactionBody* build() const;
+
+  /**
+   * The ID of the account to have its KYC revoked for this token.
+   */
+  AccountId mAccountId;
+
+  /**
+   * The ID of the token for which the account has revoked KYC.
+   */
+  TokenId mTokenId;
+};
+
+} // namespace Hedera
+
+#endif // HEDERA_SDK_CPP_TOKEN_REVOKE_KYC_TRANSACTION_H_

--- a/sdk/main/include/Transaction.h
+++ b/sdk/main/include/Transaction.h
@@ -57,6 +57,7 @@ class TokenDeleteTransaction;
 class TokenDissociateTransaction;
 class TokenFeeScheduleUpdateTransaction;
 class TokenMintTransaction;
+class TokenRevokeKycTransaction;
 class TokenUpdateTransaction;
 class TokenWipeTransaction;
 class TransactionResponse;
@@ -138,7 +139,8 @@ public:
                                               TokenWipeTransaction,
                                               TokenBurnTransaction,
                                               TokenDissociateTransaction,
-                                              TokenFeeScheduleUpdateTransaction>>
+                                              TokenFeeScheduleUpdateTransaction,
+                                              TokenRevokeKycTransaction>>
   fromBytes(const std::vector<std::byte>& bytes);
 
   /**

--- a/sdk/main/src/Executable.cc
+++ b/sdk/main/src/Executable.cc
@@ -56,6 +56,7 @@
 #include "TokenInfo.h"
 #include "TokenInfoQuery.h"
 #include "TokenMintTransaction.h"
+#include "TokenRevokeKycTransaction.h"
 #include "TokenUpdateTransaction.h"
 #include "TokenWipeTransaction.h"
 #include "TransactionReceipt.h"
@@ -373,6 +374,10 @@ template class Executable<TokenFeeScheduleUpdateTransaction,
                           TransactionResponse>;
 template class Executable<TokenInfoQuery, proto::Query, proto::Response, TokenInfo>;
 template class Executable<TokenMintTransaction, proto::Transaction, proto::TransactionResponse, TransactionResponse>;
+template class Executable<TokenRevokeKycTransaction,
+                          proto::Transaction,
+                          proto::TransactionResponse,
+                          TransactionResponse>;
 template class Executable<TokenUpdateTransaction, proto::Transaction, proto::TransactionResponse, TransactionResponse>;
 template class Executable<TokenWipeTransaction, proto::Transaction, proto::TransactionResponse, TransactionResponse>;
 template class Executable<TransactionReceiptQuery, proto::Query, proto::Response, TransactionReceipt>;

--- a/sdk/main/src/TokenRevokeKycTransaction.cc
+++ b/sdk/main/src/TokenRevokeKycTransaction.cc
@@ -31,7 +31,7 @@ namespace Hedera
 TokenRevokeKycTransaction::TokenRevokeKycTransaction(const proto::TransactionBody& transactionBody)
   : Transaction<TokenRevokeKycTransaction>(transactionBody)
 {
-  if (!transactionBody.has_tokengrantkyc())
+  if (!transactionBody.has_tokenrevokekyc())
   {
     throw std::invalid_argument("Transaction body doesn't contain TokenRevokeKyc data");
   }

--- a/sdk/main/src/TokenRevokeKycTransaction.cc
+++ b/sdk/main/src/TokenRevokeKycTransaction.cc
@@ -1,0 +1,106 @@
+/*-
+ *
+ * Hedera C++ SDK
+ *
+ * Copyright (C) 2020 - 2022 Hedera Hashgraph, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+#include "TokenRevokeKycTransaction.h"
+#include "impl/Node.h"
+
+#include <grpcpp/client_context.h>
+#include <proto/token_revoke_kyc.pb.h>
+#include <proto/transaction.pb.h>
+#include <stdexcept>
+
+namespace Hedera
+{
+//-----
+TokenRevokeKycTransaction::TokenRevokeKycTransaction(const proto::TransactionBody& transactionBody)
+  : Transaction<TokenRevokeKycTransaction>(transactionBody)
+{
+  if (!transactionBody.has_tokengrantkyc())
+  {
+    throw std::invalid_argument("Transaction body doesn't contain TokenRevokeKyc data");
+  }
+
+  const proto::TokenRevokeKycTransactionBody& body = transactionBody.tokenrevokekyc();
+
+  if (body.has_account())
+  {
+    mAccountId = AccountId::fromProtobuf(body.account());
+  }
+
+  if (body.has_token())
+  {
+    mTokenId = TokenId::fromProtobuf(body.token());
+  }
+}
+
+//-----
+TokenRevokeKycTransaction& TokenRevokeKycTransaction::setAccountId(const AccountId& accountId)
+{
+  requireNotFrozen();
+  mAccountId = accountId;
+  return *this;
+}
+
+//-----
+TokenRevokeKycTransaction& TokenRevokeKycTransaction::setTokenId(const TokenId& tokenId)
+{
+  requireNotFrozen();
+  mTokenId = tokenId;
+  return *this;
+}
+
+//-----
+proto::Transaction TokenRevokeKycTransaction::makeRequest(const Client& client,
+                                                          const std::shared_ptr<internal::Node>&) const
+{
+  proto::TransactionBody transactionBody = generateTransactionBody(client);
+  transactionBody.set_allocated_tokenrevokekyc(build());
+
+  return signTransaction(transactionBody, client);
+}
+
+//-----
+grpc::Status TokenRevokeKycTransaction::submitRequest(const Client& client,
+                                                      const std::chrono::system_clock::time_point& deadline,
+                                                      const std::shared_ptr<internal::Node>& node,
+                                                      proto::TransactionResponse* response) const
+{
+  return node->submitTransaction(
+    proto::TransactionBody::DataCase::kTokenRevokeKyc, makeRequest(client, node), deadline, response);
+}
+
+//-----
+proto::TokenRevokeKycTransactionBody* TokenRevokeKycTransaction::build() const
+{
+  auto body = std::make_unique<proto::TokenRevokeKycTransactionBody>();
+
+  if (!(mAccountId == AccountId()))
+  {
+    body->set_allocated_account(mAccountId.toProtobuf().release());
+  }
+
+  if (!(mTokenId == TokenId()))
+  {
+    body->set_allocated_token(mTokenId.toProtobuf().release());
+  }
+
+  return body.release();
+}
+
+} // namespace Hedera

--- a/sdk/main/src/Transaction.cc
+++ b/sdk/main/src/Transaction.cc
@@ -43,6 +43,7 @@
 #include "TokenDissociateTransaction.h"
 #include "TokenFeeScheduleUpdateTransaction.h"
 #include "TokenMintTransaction.h"
+#include "TokenRevokeKycTransaction.h"
 #include "TokenUpdateTransaction.h"
 #include "TokenWipeTransaction.h"
 #include "TransactionId.h"
@@ -89,7 +90,8 @@ std::pair<int,
                        TokenWipeTransaction,
                        TokenBurnTransaction,
                        TokenDissociateTransaction,
-                       TokenFeeScheduleUpdateTransaction>>
+                       TokenFeeScheduleUpdateTransaction,
+                       TokenRevokeKycTransaction>>
 Transaction<SdkRequestType>::fromBytes(const std::vector<std::byte>& bytes)
 {
   proto::TransactionBody txBody;
@@ -179,6 +181,8 @@ Transaction<SdkRequestType>::fromBytes(const std::vector<std::byte>& bytes)
       return { 22, TokenDissociateTransaction(txBody) };
     case proto::TransactionBody::kTokenFeeScheduleUpdate:
       return { 23, TokenFeeScheduleUpdateTransaction(txBody) };
+    case proto::TransactionBody::kTokenRevokeKyc:
+      return { 24, TokenRevokeKycTransaction(txBody) };
     default:
       throw std::invalid_argument("Type of transaction cannot be determined from input bytes");
   }
@@ -501,6 +505,7 @@ template class Transaction<TokenDeleteTransaction>;
 template class Transaction<TokenDissociateTransaction>;
 template class Transaction<TokenFeeScheduleUpdateTransaction>;
 template class Transaction<TokenMintTransaction>;
+template class Transaction<TokenRevokeKycTransaction>;
 template class Transaction<TokenUpdateTransaction>;
 template class Transaction<TokenWipeTransaction>;
 template class Transaction<TransferTransaction>;

--- a/sdk/main/src/impl/Node.cc
+++ b/sdk/main/src/impl/Node.cc
@@ -208,6 +208,8 @@ grpc::Status Node::submitTransaction(proto::TransactionBody::DataCase funcEnum,
       return mTokenStub->mintToken(&context, transaction, response);
     case proto::TransactionBody::DataCase::kTokenUpdate:
       return mTokenStub->updateToken(&context, transaction, response);
+    case proto::TransactionBody::DataCase::kTokenRevokeKyc:
+      return mTokenStub->revokeKycFromTokenAccount(&context, transaction, response);
     default:
       // This should never happen
       throw std::invalid_argument("Unrecognized gRPC transaction method case");

--- a/sdk/tests/integration/CMakeLists.txt
+++ b/sdk/tests/integration/CMakeLists.txt
@@ -32,6 +32,7 @@ add_executable(${TEST_PROJECT_NAME}
         TokenFeeScheduleUpdateTransactionIntegrationTests.cc
         TokenInfoQueryIntegrationTests.cc
         TokenMintTransactionIntegrationTests.cc
+        TokenRevokeKycTransactionIntegrationTests.cc
         TokenUpdateTransactionIntegrationTests.cc
         TransactionIntegrationTest.cc
         TransactionReceiptIntegrationTest.cc

--- a/sdk/tests/integration/TokenRevokeKycTransactionIntegrationTests.cc
+++ b/sdk/tests/integration/TokenRevokeKycTransactionIntegrationTests.cc
@@ -1,0 +1,224 @@
+/*-
+ *
+ * Hedera C++ SDK
+ *
+ * Copyright (C) 2020 - 2022 Hedera Hashgraph, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+#include "AccountCreateTransaction.h"
+#include "AccountDeleteTransaction.h"
+#include "AccountId.h"
+#include "BaseIntegrationTest.h"
+#include "ED25519PrivateKey.h"
+#include "TokenAssociateTransaction.h"
+#include "TokenCreateTransaction.h"
+#include "TokenDeleteTransaction.h"
+#include "TokenId.h"
+#include "TokenRevokeKycTransaction.h"
+#include "TransactionReceipt.h"
+#include "TransactionResponse.h"
+#include "exceptions/PrecheckStatusException.h"
+#include "exceptions/ReceiptStatusException.h"
+
+#include <gtest/gtest.h>
+
+using namespace Hedera;
+
+class TokenRevokeKycTransactionIntegrationTest : public BaseIntegrationTest
+{
+};
+
+//-----
+TEST_F(TokenRevokeKycTransactionIntegrationTest, ExecuteTokenRevokeKycTransaction)
+{
+  // Given
+  std::shared_ptr<PrivateKey> operatorKey;
+  std::shared_ptr<ED25519PrivateKey> accountKey;
+
+  ASSERT_NO_THROW(
+    operatorKey = ED25519PrivateKey::fromString(
+      "302e020100300506032b65700422042091132178e72057a1d7528025956fe39b0b847f200ab59b2fdd367017f3087137"));
+  ASSERT_NO_THROW(accountKey = ED25519PrivateKey::generatePrivateKey());
+
+  AccountId accountId;
+  ASSERT_NO_THROW(accountId = AccountCreateTransaction()
+                                .setKey(accountKey.get())
+                                .setInitialBalance(Hbar(1LL))
+                                .execute(getTestClient())
+                                .getReceipt(getTestClient())
+                                .mAccountId.value());
+
+  TokenId tokenId;
+  ASSERT_NO_THROW(tokenId = TokenCreateTransaction()
+                              .setTokenName("ffff")
+                              .setTokenSymbol("F")
+                              .setTreasuryAccountId(AccountId(2ULL))
+                              .setAdminKey(operatorKey)
+                              .setKycKey(operatorKey)
+                              .execute(getTestClient())
+                              .getReceipt(getTestClient())
+                              .mTokenId.value());
+
+  ASSERT_NO_THROW(const TransactionReceipt txReceipt = TokenAssociateTransaction()
+                                                         .setAccountId(accountId)
+                                                         .setTokenIds({ tokenId })
+                                                         .freezeWith(getTestClient())
+                                                         .sign(accountKey.get())
+                                                         .execute(getTestClient())
+                                                         .getReceipt(getTestClient()));
+
+  // When / Then
+  EXPECT_NO_THROW(const TransactionReceipt txReceipt = TokenRevokeKycTransaction()
+                                                         .setAccountId(accountId)
+                                                         .setTokenId(tokenId)
+                                                         .freezeWith(getTestClient())
+                                                         .sign(accountKey.get())
+                                                         .execute(getTestClient())
+                                                         .getReceipt(getTestClient()));
+
+  // Clean up
+  ASSERT_NO_THROW(const TransactionReceipt txReceipt = AccountDeleteTransaction()
+                                                         .setTransferAccountId(AccountId(2ULL))
+                                                         .setDeleteAccountId(accountId)
+                                                         .freezeWith(getTestClient())
+                                                         .sign(accountKey.get())
+                                                         .execute(getTestClient())
+                                                         .getReceipt(getTestClient()));
+  ASSERT_NO_THROW(const TransactionReceipt txReceipt =
+                    TokenDeleteTransaction().setTokenId(tokenId).execute(getTestClient()).getReceipt(getTestClient()));
+}
+
+//-----
+TEST_F(TokenRevokeKycTransactionIntegrationTest, CannotRevokeKycToAccountWithNoTokenId)
+{
+  // Given
+  std::shared_ptr<PrivateKey> operatorKey;
+  std::shared_ptr<ED25519PrivateKey> accountKey;
+
+  ASSERT_NO_THROW(
+    operatorKey = ED25519PrivateKey::fromString(
+      "302e020100300506032b65700422042091132178e72057a1d7528025956fe39b0b847f200ab59b2fdd367017f3087137"));
+  ASSERT_NO_THROW(accountKey = ED25519PrivateKey::generatePrivateKey());
+
+  AccountId accountId;
+  ASSERT_NO_THROW(accountId = AccountCreateTransaction()
+                                .setKey(accountKey.get())
+                                .setInitialBalance(Hbar(1LL))
+                                .execute(getTestClient())
+                                .getReceipt(getTestClient())
+                                .mAccountId.value());
+
+  // When / Then
+  EXPECT_THROW(const TransactionReceipt txReceipt = TokenRevokeKycTransaction()
+                                                      .setAccountId(accountId)
+                                                      .freezeWith(getTestClient())
+                                                      .sign(accountKey.get())
+                                                      .execute(getTestClient())
+                                                      .getReceipt(getTestClient()),
+               PrecheckStatusException); // INVALID_TOKEN_ID
+
+  // Clean up
+  ASSERT_NO_THROW(const TransactionReceipt txReceipt = AccountDeleteTransaction()
+                                                         .setTransferAccountId(AccountId(2ULL))
+                                                         .setDeleteAccountId(accountId)
+                                                         .freezeWith(getTestClient())
+                                                         .sign(accountKey.get())
+                                                         .execute(getTestClient())
+                                                         .getReceipt(getTestClient()));
+}
+
+//-----
+TEST_F(TokenRevokeKycTransactionIntegrationTest, CannotRevokeKycOnNoAccount)
+{
+  // Given
+  std::shared_ptr<PrivateKey> operatorKey;
+
+  ASSERT_NO_THROW(
+    operatorKey = ED25519PrivateKey::fromString(
+      "302e020100300506032b65700422042091132178e72057a1d7528025956fe39b0b847f200ab59b2fdd367017f3087137"));
+
+  TokenId tokenId;
+  ASSERT_NO_THROW(tokenId = TokenCreateTransaction()
+                              .setTokenName("ffff")
+                              .setTokenSymbol("F")
+                              .setTreasuryAccountId(AccountId(2ULL))
+                              .setAdminKey(operatorKey)
+                              .setKycKey(operatorKey)
+                              .execute(getTestClient())
+                              .getReceipt(getTestClient())
+                              .mTokenId.value());
+
+  // When / Then
+  EXPECT_THROW(const TransactionReceipt txReceipt =
+                 TokenRevokeKycTransaction().setTokenId(tokenId).execute(getTestClient()).getReceipt(getTestClient()),
+               PrecheckStatusException); // INVALID_ACCOUNT_ID
+
+  // Clean up
+  ASSERT_NO_THROW(const TransactionReceipt txReceipt =
+                    TokenDeleteTransaction().setTokenId(tokenId).execute(getTestClient()).getReceipt(getTestClient()));
+}
+
+//-----
+TEST_F(TokenRevokeKycTransactionIntegrationTest, CannotRevokeKycToAccountOnTokenIfNotAssociated)
+{
+  // Given
+  std::shared_ptr<PrivateKey> operatorKey;
+  std::shared_ptr<ED25519PrivateKey> accountKey;
+
+  ASSERT_NO_THROW(
+    operatorKey = ED25519PrivateKey::fromString(
+      "302e020100300506032b65700422042091132178e72057a1d7528025956fe39b0b847f200ab59b2fdd367017f3087137"));
+  ASSERT_NO_THROW(accountKey = ED25519PrivateKey::generatePrivateKey());
+
+  AccountId accountId;
+  ASSERT_NO_THROW(accountId = AccountCreateTransaction()
+                                .setKey(accountKey.get())
+                                .setInitialBalance(Hbar(1LL))
+                                .execute(getTestClient())
+                                .getReceipt(getTestClient())
+                                .mAccountId.value());
+
+  TokenId tokenId;
+  ASSERT_NO_THROW(tokenId = TokenCreateTransaction()
+                              .setTokenName("ffff")
+                              .setTokenSymbol("F")
+                              .setTreasuryAccountId(AccountId(2ULL))
+                              .setAdminKey(operatorKey)
+                              .setKycKey(operatorKey)
+                              .execute(getTestClient())
+                              .getReceipt(getTestClient())
+                              .mTokenId.value());
+
+  // When / Then
+  EXPECT_THROW(const TransactionReceipt txReceipt = TokenRevokeKycTransaction()
+                                                      .setAccountId(accountId)
+                                                      .setTokenId(tokenId)
+                                                      .freezeWith(getTestClient())
+                                                      .sign(accountKey.get())
+                                                      .execute(getTestClient())
+                                                      .getReceipt(getTestClient()),
+               ReceiptStatusException); // TOKEN_NOT_ASSOCIATED_TO_ACCOUNT
+
+  // Clean up
+  ASSERT_NO_THROW(const TransactionReceipt txReceipt = AccountDeleteTransaction()
+                                                         .setTransferAccountId(AccountId(2ULL))
+                                                         .setDeleteAccountId(accountId)
+                                                         .freezeWith(getTestClient())
+                                                         .sign(accountKey.get())
+                                                         .execute(getTestClient())
+                                                         .getReceipt(getTestClient()));
+  ASSERT_NO_THROW(const TransactionReceipt txReceipt =
+                    TokenDeleteTransaction().setTokenId(tokenId).execute(getTestClient()).getReceipt(getTestClient()));
+}

--- a/sdk/tests/unit/CMakeLists.txt
+++ b/sdk/tests/unit/CMakeLists.txt
@@ -75,6 +75,7 @@ add_executable(${TEST_PROJECT_NAME}
         TokenNftAllowanceTest.cc
         TokenNftRemoveAllowanceTest.cc
         TokenNftTransferTest.cc
+        TokenRevokeKycTransactionUnitTests.cc
         TokenSupplyTypeTest.cc
         TokenTransferTest.cc
         TokenTypeTest.cc

--- a/sdk/tests/unit/TokenRevokeKycTransactionUnitTests.cc
+++ b/sdk/tests/unit/TokenRevokeKycTransactionUnitTests.cc
@@ -1,0 +1,111 @@
+/*-
+ *
+ * Hedera C++ SDK
+ *
+ * Copyright (C) 2020 - 2022 Hedera Hashgraph, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+#include "AccountId.h"
+#include "Client.h"
+#include "ECDSAsecp256k1PrivateKey.h"
+#include "TokenRevokeKycTransaction.h"
+#include "exceptions/IllegalStateException.h"
+
+#include <gtest/gtest.h>
+#include <proto/transaction_body.pb.h>
+
+using namespace Hedera;
+
+class TokenRevokeKycTransactionTest : public ::testing::Test
+{
+protected:
+  void SetUp() override { mClient.setOperator(AccountId(), ECDSAsecp256k1PrivateKey::generatePrivateKey().get()); }
+
+  [[nodiscard]] inline const Client& getTestClient() const { return mClient; }
+  [[nodiscard]] inline const AccountId& getTestAccountId() const { return mTestAccountId; }
+  [[nodiscard]] inline const TokenId& getTestTokenId() const { return mTestTokenId; }
+
+private:
+  Client mClient;
+  const AccountId mTestAccountId = AccountId(1ULL, 2ULL, 3ULL);
+  const TokenId mTestTokenId = TokenId(4ULL, 5ULL, 6ULL);
+};
+
+//-----
+TEST_F(TokenRevokeKycTransactionTest, ConstructTokenRevokeKycTransactionFromTransactionBodyProtobuf)
+{
+  // Given
+  auto body = std::make_unique<proto::TokenRevokeKycTransactionBody>();
+  body->set_allocated_account(getTestAccountId().toProtobuf().release());
+  body->set_allocated_token(getTestTokenId().toProtobuf().release());
+
+  proto::TransactionBody txBody;
+  txBody.set_allocated_tokenrevokekyc(body.release());
+
+  // When
+  const TokenRevokeKycTransaction tokenRevokeKycTransaction(txBody);
+
+  // Then
+  EXPECT_EQ(tokenRevokeKycTransaction.getAccountId(), getTestAccountId());
+  EXPECT_EQ(tokenRevokeKycTransaction.getTokenId(), getTestTokenId());
+}
+
+//-----
+TEST_F(TokenRevokeKycTransactionTest, GetSetAccountId)
+{
+  // Given
+  TokenRevokeKycTransaction transaction;
+
+  // When
+  EXPECT_NO_THROW(transaction.setAccountId(getTestAccountId()));
+
+  // Then
+  EXPECT_EQ(transaction.getAccountId(), getTestAccountId());
+}
+
+//-----
+TEST_F(TokenRevokeKycTransactionTest, GetSetAccountIdFrozen)
+{
+  // Given
+  TokenRevokeKycTransaction transaction;
+  ASSERT_NO_THROW(transaction.freezeWith(getTestClient()));
+
+  // When / Then
+  EXPECT_THROW(transaction.setAccountId(getTestAccountId()), IllegalStateException);
+}
+
+//-----
+TEST_F(TokenRevokeKycTransactionTest, GetSetTokenId)
+{
+  // Given
+  TokenRevokeKycTransaction transaction;
+
+  // When
+  EXPECT_NO_THROW(transaction.setTokenId(getTestTokenId()));
+
+  // Then
+  EXPECT_EQ(transaction.getTokenId(), getTestTokenId());
+}
+
+//-----
+TEST_F(TokenRevokeKycTransactionTest, GetSetTokenIdFrozen)
+{
+  // Given
+  TokenRevokeKycTransaction transaction;
+  ASSERT_NO_THROW(transaction.freezeWith(getTestClient()));
+
+  // When / Then
+  EXPECT_THROW(transaction.setTokenId(getTestTokenId()), IllegalStateException);
+}

--- a/sdk/tests/unit/TransactionTest.cc
+++ b/sdk/tests/unit/TransactionTest.cc
@@ -39,6 +39,7 @@
 #include "TokenDissociateTransaction.h"
 #include "TokenFeeScheduleUpdateTransaction.h"
 #include "TokenMintTransaction.h"
+#include "TokenRevokeKycTransaction.h"
 #include "TokenUpdateTransaction.h"
 #include "TokenWipeTransaction.h"
 #include "TransferTransaction.h"
@@ -1468,4 +1469,63 @@ TEST_F(TransactionTest, TokenFeeScheduleUpdateTransactionFromTransactionBytes)
   // Then
   ASSERT_EQ(index, 23);
   EXPECT_NO_THROW(const TokenFeeScheduleUpdateTransaction tokenFeeScheduleUpdateTransaction = std::get<23>(txVariant));
+}
+
+//-----
+TEST_F(TransactionTest, TokenRevokeKycTransactionFromTransactionBodyBytes)
+{
+  // Given
+  proto::TransactionBody txBody;
+  txBody.set_allocated_tokenrevokekyc(new proto::TokenRevokeKycTransactionBody);
+
+  // When
+  const auto [index, txVariant] = Transaction<TokenRevokeKycTransaction>::fromBytes(
+    internal::Utilities::stringToByteVector(txBody.SerializeAsString()));
+
+  // Then
+  ASSERT_EQ(index, 24);
+  EXPECT_NO_THROW(const TokenRevokeKycTransaction tokenRevokeKycTransaction = std::get<24>(txVariant));
+}
+
+//-----
+TEST_F(TransactionTest, TokenRevokeKycTransactionFromSignedTransactionBytes)
+{
+  // Given
+  proto::TransactionBody txBody;
+  txBody.set_allocated_tokenrevokekyc(new proto::TokenRevokeKycTransactionBody);
+
+  proto::SignedTransaction signedTx;
+  signedTx.set_bodybytes(txBody.SerializeAsString());
+  // SignatureMap not required
+
+  // When
+  const auto [index, txVariant] = Transaction<TokenRevokeKycTransaction>::fromBytes(
+    internal::Utilities::stringToByteVector(txBody.SerializeAsString()));
+
+  // Then
+  ASSERT_EQ(index, 24);
+  EXPECT_NO_THROW(const TokenRevokeKycTransaction tokenRevokeKycTransaction = std::get<24>(txVariant));
+}
+
+//-----
+TEST_F(TransactionTest, TokenRevokeKycTransactionFromTransactionBytes)
+{
+  // Given
+  proto::TransactionBody txBody;
+  txBody.set_allocated_tokenrevokekyc(new proto::TokenRevokeKycTransactionBody);
+
+  proto::SignedTransaction signedTx;
+  signedTx.set_bodybytes(txBody.SerializeAsString());
+  // SignatureMap not required
+
+  proto::Transaction tx;
+  tx.set_signedtransactionbytes(signedTx.SerializeAsString());
+
+  // When
+  const auto [index, txVariant] = Transaction<TokenRevokeKycTransaction>::fromBytes(
+    internal::Utilities::stringToByteVector(txBody.SerializeAsString()));
+
+  // Then
+  ASSERT_EQ(index, 24);
+  EXPECT_NO_THROW(const TokenRevokeKycTransaction tokenRevokeKycTransaction = std::get<24>(txVariant));
 }


### PR DESCRIPTION
**Description**:
This PR implements the APIs associated with `TokenRevokeKycTransaction`, which allows users to revoke KYC from accounts for specific tokens.

**Related issue(s)**:

Fixes #384 

**Checklist**

- [x] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
