### PR TITLE
Implement `TokenPauseTransaction`

### DIFF
--- a/sdk/main/CMakeLists.txt
+++ b/sdk/main/CMakeLists.txt
@@ -84,6 +84,7 @@ add_library(${PROJECT_NAME} STATIC
         src/TokenNftAllowance.cc
         src/TokenNftRemoveAllowance.cc
         src/TokenNftTransfer.cc
+        src/TokenPauseTransaction.cc
         src/TokenSupplyType.cc
         src/TokenTransfer.cc
         src/TokenType.cc

--- a/sdk/main/include/TokenPauseTransaction.h
+++ b/sdk/main/include/TokenPauseTransaction.h
@@ -1,0 +1,133 @@
+/*-
+ *
+ * Hedera C++ SDK
+ *
+ * Copyright (C) 2020 - 2022 Hedera Hashgraph, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+#ifndef HEDERA_SDK_CPP_TOKEN_PAUSE_TRANSACTION_H_
+#define HEDERA_SDK_CPP_TOKEN_PAUSE_TRANSACTION_H_
+
+#include "TokenId.h"
+#include "Transaction.h"
+
+namespace proto
+{
+class TokenPauseTransactionBody;
+class TransactionBody;
+}
+
+namespace Hedera
+{
+/**
+ * A token pause transaction prevents the token from being involved in any kind of operation. The token's pause key is
+ * required to sign the transaction. This is a key that is specified during the creation of a token. If a token has no
+ * pause key, you will not be able to pause the token. If the pause key was not set during the creation of a token, you
+ * will not be able to update the token to add this key.
+ *
+ * The following operations cannot be performed when a token is paused and will result in a TOKEN_IS_PAUSED status:
+ *  - Updating the token
+ *  - Transferring the token
+ *  - Transferring any other token where it has its paused key in a custom fee schedule
+ *  - Deleting the token
+ *  - Minting or burning a token
+ *  - Freezing or unfreezing an account that holds the token
+ *  - Enabling or disabling KYC
+ *  - Associating or disassociating a token
+ *  - Wiping a token
+ *
+ * Once a token is paused, token status will update to paused. To verify if the token's status has been updated to
+ * paused, you can request the token info via the SDK or use the token info mirror node query. If the token is not
+ * paused the token status will be unpaused. The token status for tokens that do not have an assigned pause key will
+ * state PauseNotApplicable.
+ *
+ * Transaction Signing Requirements:
+ *  - The pause key of the token.
+ *  - Transaction fee payer account key.
+ */
+class TokenPauseTransaction : public Transaction<TokenPauseTransaction>
+{
+public:
+  TokenPauseTransaction() = default;
+
+  /**
+   * Construct from a TransactionBody protobuf object.
+   *
+   * @param transactionBody The TransactionBody protobuf object from which to construct.
+   * @throws std::invalid_argument If the input TransactionBody does not represent a TokenPause transaction.
+   */
+  explicit TokenPauseTransaction(const proto::TransactionBody& transactionBody);
+
+  /**
+   * Set the ID of the tokens to pause.
+   *
+   * @param tokenId The ID of the tokens to pause.
+   * @return A reference to this TokenPauseTransaction object with the newly-set token ID.
+   * @throws IllegalStateException If this TokenPauseTransaction is frozen.
+   */
+  TokenPauseTransaction& setTokenId(const TokenId& tokenId);
+
+  /**
+   * Get the ID of the tokens to pause.
+   *
+   * @return The ID of the tokens to pause.
+   */
+  [[nodiscard]] inline TokenId getTokenId() const { return mTokenId; }
+
+private:
+  /**
+   * Derived from Executable. Construct a Transaction protobuf object from this TokenPauseTransaction object.
+   *
+   * @param client The Client trying to construct this TokenPauseTransaction.
+   * @param node   The Node to which this TokenPauseTransaction will be sent. This is unused.
+   * @return A Transaction protobuf object filled with this TokenPauseTransaction object's data.
+   * @throws UninitializedException If the input client has no operator with which to sign this
+   *                                TokenPauseTransaction.
+   */
+  [[nodiscard]] proto::Transaction makeRequest(const Client& client,
+                                               const std::shared_ptr<internal::Node>& /*node*/) const override;
+
+  /**
+   * Derived from Executable. Submit this TokenPauseTransaction to a Node.
+   *
+   * @param client   The Client submitting this TokenPauseTransaction.
+   * @param deadline The deadline for submitting this TokenPauseTransaction.
+   * @param node     Pointer to the Node to which this TokenPauseTransaction should be submitted.
+   * @param response Pointer to the TransactionResponse protobuf object that gRPC should populate with the response
+   *                 information from the gRPC server.
+   * @return The gRPC status of the submission.
+   */
+  [[nodiscard]] grpc::Status submitRequest(const Client& client,
+                                           const std::chrono::system_clock::time_point& deadline,
+                                           const std::shared_ptr<internal::Node>& node,
+                                           proto::TransactionResponse* response) const override;
+
+  /**
+   * Build a TokenPauseTransactionBody protobuf object from this TokenPauseTransaction object.
+   *
+   * @return A pointer to a TokenPauseTransactionBody protobuf object filled with this TokenPauseTransaction object's
+   *         data.
+   */
+  [[nodiscard]] proto::TokenPauseTransactionBody* build() const;
+
+  /**
+   * The ID of the token to pause.
+   */
+  TokenId mTokenId;
+};
+
+} // namespace Hedera
+
+#endif // HEDERA_SDK_CPP_TOKEN_PAUSE_TRANSACTION_H_

--- a/sdk/main/include/Transaction.h
+++ b/sdk/main/include/Transaction.h
@@ -57,6 +57,7 @@ class TokenDeleteTransaction;
 class TokenDissociateTransaction;
 class TokenFeeScheduleUpdateTransaction;
 class TokenMintTransaction;
+class TokenPauseTransaction;
 class TokenUpdateTransaction;
 class TokenWipeTransaction;
 class TransactionResponse;
@@ -138,7 +139,8 @@ public:
                                               TokenWipeTransaction,
                                               TokenBurnTransaction,
                                               TokenDissociateTransaction,
-                                              TokenFeeScheduleUpdateTransaction>>
+                                              TokenFeeScheduleUpdateTransaction,
+                                              TokenPauseTransaction>>
   fromBytes(const std::vector<std::byte>& bytes);
 
   /**

--- a/sdk/main/src/Executable.cc
+++ b/sdk/main/src/Executable.cc
@@ -56,6 +56,7 @@
 #include "TokenInfo.h"
 #include "TokenInfoQuery.h"
 #include "TokenMintTransaction.h"
+#include "TokenPauseTransaction.h"
 #include "TokenUpdateTransaction.h"
 #include "TokenWipeTransaction.h"
 #include "TransactionReceipt.h"
@@ -373,6 +374,7 @@ template class Executable<TokenFeeScheduleUpdateTransaction,
                           TransactionResponse>;
 template class Executable<TokenInfoQuery, proto::Query, proto::Response, TokenInfo>;
 template class Executable<TokenMintTransaction, proto::Transaction, proto::TransactionResponse, TransactionResponse>;
+template class Executable<TokenPauseTransaction, proto::Transaction, proto::TransactionResponse, TransactionResponse>;
 template class Executable<TokenUpdateTransaction, proto::Transaction, proto::TransactionResponse, TransactionResponse>;
 template class Executable<TokenWipeTransaction, proto::Transaction, proto::TransactionResponse, TransactionResponse>;
 template class Executable<TransactionReceiptQuery, proto::Query, proto::Response, TransactionReceipt>;

--- a/sdk/main/src/TokenPauseTransaction.cc
+++ b/sdk/main/src/TokenPauseTransaction.cc
@@ -1,0 +1,88 @@
+/*-
+ *
+ * Hedera C++ SDK
+ *
+ * Copyright (C) 2020 - 2022 Hedera Hashgraph, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+#include "TokenPauseTransaction.h"
+#include "impl/Node.h"
+
+#include <grpcpp/client_context.h>
+#include <proto/token_pause.pb.h>
+#include <proto/transaction.pb.h>
+#include <stdexcept>
+
+namespace Hedera
+{
+//-----
+TokenPauseTransaction::TokenPauseTransaction(const proto::TransactionBody& transactionBody)
+  : Transaction<TokenPauseTransaction>(transactionBody)
+{
+  if (!transactionBody.has_token_pause())
+  {
+    throw std::invalid_argument("Transaction body doesn't contain TokenPause data");
+  }
+
+  const proto::TokenPauseTransactionBody& body = transactionBody.token_pause();
+
+  if (body.has_token())
+  {
+    mTokenId = TokenId::fromProtobuf(body.token());
+  }
+}
+
+//-----
+TokenPauseTransaction& TokenPauseTransaction::setTokenId(const TokenId& tokenId)
+{
+  requireNotFrozen();
+  mTokenId = tokenId;
+  return *this;
+}
+
+//-----
+proto::Transaction TokenPauseTransaction::makeRequest(const Client& client,
+                                                      const std::shared_ptr<internal::Node>&) const
+{
+  proto::TransactionBody transactionBody = generateTransactionBody(client);
+  transactionBody.set_allocated_token_pause(build());
+
+  return signTransaction(transactionBody, client);
+}
+
+//-----
+grpc::Status TokenPauseTransaction::submitRequest(const Client& client,
+                                                  const std::chrono::system_clock::time_point& deadline,
+                                                  const std::shared_ptr<internal::Node>& node,
+                                                  proto::TransactionResponse* response) const
+{
+  return node->submitTransaction(
+    proto::TransactionBody::DataCase::kTokenPause, makeRequest(client, node), deadline, response);
+}
+
+//-----
+proto::TokenPauseTransactionBody* TokenPauseTransaction::build() const
+{
+  auto body = std::make_unique<proto::TokenPauseTransactionBody>();
+
+  if (!(mTokenId == TokenId()))
+  {
+    body->set_allocated_token(mTokenId.toProtobuf().release());
+  }
+
+  return body.release();
+}
+
+} // namespace Hedera

--- a/sdk/main/src/Transaction.cc
+++ b/sdk/main/src/Transaction.cc
@@ -43,6 +43,7 @@
 #include "TokenDissociateTransaction.h"
 #include "TokenFeeScheduleUpdateTransaction.h"
 #include "TokenMintTransaction.h"
+#include "TokenPauseTransaction.h"
 #include "TokenUpdateTransaction.h"
 #include "TokenWipeTransaction.h"
 #include "TransactionId.h"
@@ -89,7 +90,8 @@ std::pair<int,
                        TokenWipeTransaction,
                        TokenBurnTransaction,
                        TokenDissociateTransaction,
-                       TokenFeeScheduleUpdateTransaction>>
+                       TokenFeeScheduleUpdateTransaction,
+                       TokenPauseTransaction>>
 Transaction<SdkRequestType>::fromBytes(const std::vector<std::byte>& bytes)
 {
   proto::TransactionBody txBody;
@@ -179,6 +181,8 @@ Transaction<SdkRequestType>::fromBytes(const std::vector<std::byte>& bytes)
       return { 22, TokenDissociateTransaction(txBody) };
     case proto::TransactionBody::kTokenFeeScheduleUpdate:
       return { 23, TokenFeeScheduleUpdateTransaction(txBody) };
+    case proto::TransactionBody::kTokenPause:
+      return { 24, TokenPauseTransaction(txBody) };
     default:
       throw std::invalid_argument("Type of transaction cannot be determined from input bytes");
   }
@@ -501,6 +505,7 @@ template class Transaction<TokenDeleteTransaction>;
 template class Transaction<TokenDissociateTransaction>;
 template class Transaction<TokenFeeScheduleUpdateTransaction>;
 template class Transaction<TokenMintTransaction>;
+template class Transaction<TokenPauseTransaction>;
 template class Transaction<TokenUpdateTransaction>;
 template class Transaction<TokenWipeTransaction>;
 template class Transaction<TransferTransaction>;

--- a/sdk/main/src/impl/Node.cc
+++ b/sdk/main/src/impl/Node.cc
@@ -206,6 +206,8 @@ grpc::Status Node::submitTransaction(proto::TransactionBody::DataCase funcEnum,
       return mTokenStub->updateTokenFeeSchedule(&context, transaction, response);
     case proto::TransactionBody::DataCase::kTokenMint:
       return mTokenStub->mintToken(&context, transaction, response);
+    case proto::TransactionBody::DataCase::kTokenPause:
+      return mTokenStub->pauseToken(&context, transaction, response);
     case proto::TransactionBody::DataCase::kTokenUpdate:
       return mTokenStub->updateToken(&context, transaction, response);
     default:

--- a/sdk/tests/integration/CMakeLists.txt
+++ b/sdk/tests/integration/CMakeLists.txt
@@ -32,6 +32,7 @@ add_executable(${TEST_PROJECT_NAME}
         TokenFeeScheduleUpdateTransactionIntegrationTests.cc
         TokenInfoQueryIntegrationTests.cc
         TokenMintTransactionIntegrationTests.cc
+        TokenPauseTransactionIntegrationTests.cc
         TokenUpdateTransactionIntegrationTests.cc
         TransactionIntegrationTest.cc
         TransactionReceiptIntegrationTest.cc

--- a/sdk/tests/integration/TokenPauseTransactionIntegrationTests.cc
+++ b/sdk/tests/integration/TokenPauseTransactionIntegrationTests.cc
@@ -1,0 +1,115 @@
+/*-
+ *
+ * Hedera C++ SDK
+ *
+ * Copyright (C) 2020 - 2022 Hedera Hashgraph, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+#include "AccountCreateTransaction.h"
+#include "AccountDeleteTransaction.h"
+#include "AccountId.h"
+#include "BaseIntegrationTest.h"
+#include "Client.h"
+#include "ED25519PrivateKey.h"
+#include "PrivateKey.h"
+#include "TokenAssociateTransaction.h"
+#include "TokenCreateTransaction.h"
+#include "TokenDeleteTransaction.h"
+#include "TokenPauseTransaction.h"
+#include "TransactionReceipt.h"
+#include "TransactionResponse.h"
+#include "TransferTransaction.h"
+#include "exceptions/PrecheckStatusException.h"
+#include "exceptions/ReceiptStatusException.h"
+
+#include <gtest/gtest.h>
+
+using namespace Hedera;
+
+class TokenPauseTransactionIntegrationTest : public BaseIntegrationTest
+{
+};
+
+//-----
+TEST_F(TokenPauseTransactionIntegrationTest, ExecuteTokenPauseTransaction)
+{
+  // Given
+  const int64_t amount = 10LL;
+
+  std::shared_ptr<PrivateKey> operatorKey;
+  std::shared_ptr<PrivateKey> accountKey;
+
+  ASSERT_NO_THROW(
+    operatorKey = ED25519PrivateKey::fromString(
+      "302e020100300506032b65700422042091132178e72057a1d7528025956fe39b0b847f200ab59b2fdd367017f3087137"));
+  ASSERT_NO_THROW(accountKey = ED25519PrivateKey::generatePrivateKey());
+
+  AccountId accountId;
+  ASSERT_NO_THROW(accountId = AccountCreateTransaction()
+                                .setInitialBalance(Hbar(1LL))
+                                .setKey(accountKey.get())
+                                .execute(getTestClient())
+                                .getReceipt(getTestClient())
+                                .mAccountId.value());
+
+  TokenId tokenId;
+  ASSERT_NO_THROW(tokenId = TokenCreateTransaction()
+                              .setTokenName("ffff")
+                              .setTokenSymbol("F")
+                              .setInitialSupply(100000ULL)
+                              .setTreasuryAccountId(AccountId(2ULL))
+                              .setAdminKey(operatorKey)
+                              .setPauseKey(operatorKey)
+                              .execute(getTestClient())
+                              .getReceipt(getTestClient())
+                              .mTokenId.value());
+
+  ASSERT_NO_THROW(const TransactionReceipt txReceipt = TokenAssociateTransaction()
+                                                         .setAccountId(accountId)
+                                                         .setTokenIds({ tokenId })
+                                                         .freezeWith(getTestClient())
+                                                         .sign(accountKey.get())
+                                                         .execute(getTestClient())
+                                                         .getReceipt(getTestClient()));
+
+  ASSERT_NO_THROW(const TransactionReceipt txReceipt = TransferTransaction()
+                                                         .addTokenTransfer(tokenId, accountId, amount)
+                                                         .addTokenTransfer(tokenId, AccountId(2ULL), -amount)
+                                                         .execute(getTestClient())
+                                                         .getReceipt(getTestClient()));
+
+  // When
+  EXPECT_NO_THROW(const TransactionReceipt txReceipt =
+                    TokenPauseTransaction().setTokenId(tokenId).execute(getTestClient()).getReceipt(getTestClient()));
+
+  // Then
+  EXPECT_THROW(const TransactionReceipt txReceipt = TransferTransaction()
+                                                      .addTokenTransfer(tokenId, accountId, -amount)
+                                                      .addTokenTransfer(tokenId, AccountId(2ULL), amount)
+                                                      .freezeWith(getTestClient())
+                                                      .sign(accountKey.get())
+                                                      .execute(getTestClient())
+                                                      .getReceipt(getTestClient()),
+               ReceiptStatusException); // TOKEN_IS_PAUSED
+}
+
+//-----
+TEST_F(TokenPauseTransactionIntegrationTest, CannotPauseWithNoTokenId)
+{
+  // Given / When / Then
+  EXPECT_THROW(const TransactionReceipt txReceipt =
+                 TokenPauseTransaction().execute(getTestClient()).getReceipt(getTestClient()),
+               PrecheckStatusException); // INVALID_TOKEN_ID
+}

--- a/sdk/tests/unit/CMakeLists.txt
+++ b/sdk/tests/unit/CMakeLists.txt
@@ -75,6 +75,7 @@ add_executable(${TEST_PROJECT_NAME}
         TokenNftAllowanceTest.cc
         TokenNftRemoveAllowanceTest.cc
         TokenNftTransferTest.cc
+        TokenPauseTransactionUnitTests.cc
         TokenSupplyTypeTest.cc
         TokenTransferTest.cc
         TokenTypeTest.cc

--- a/sdk/tests/unit/TokenPauseTransactionUnitTests.cc
+++ b/sdk/tests/unit/TokenPauseTransactionUnitTests.cc
@@ -1,0 +1,82 @@
+/*-
+ *
+ * Hedera C++ SDK
+ *
+ * Copyright (C) 2020 - 2022 Hedera Hashgraph, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+#include "Client.h"
+#include "ECDSAsecp256k1PrivateKey.h"
+#include "TokenPauseTransaction.h"
+#include "exceptions/IllegalStateException.h"
+
+#include <gtest/gtest.h>
+#include <proto/transaction_body.pb.h>
+
+using namespace Hedera;
+
+class TokenPauseTransactionTest : public ::testing::Test
+{
+protected:
+  void SetUp() override { mClient.setOperator(AccountId(), ECDSAsecp256k1PrivateKey::generatePrivateKey().get()); }
+
+  [[nodiscard]] inline const Client& getTestClient() const { return mClient; }
+  [[nodiscard]] inline const TokenId& getTestTokenId() const { return mTestTokenId; }
+
+private:
+  Client mClient;
+  const TokenId mTestTokenId = TokenId(1ULL);
+};
+
+//-----
+TEST_F(TokenPauseTransactionTest, ConstructTokenPauseTransactionFromTransactionBodyProtobuf)
+{
+  // Given
+  auto body = std::make_unique<proto::TokenPauseTransactionBody>();
+  body->set_allocated_token(getTestTokenId().toProtobuf().release());
+
+  proto::TransactionBody txBody;
+  txBody.set_allocated_token_pause(body.release());
+
+  // When
+  const TokenPauseTransaction tokenPauseTransaction(txBody);
+
+  // Then
+  EXPECT_EQ(tokenPauseTransaction.getTokenId(), getTestTokenId());
+}
+
+//-----
+TEST_F(TokenPauseTransactionTest, GetSetTokenId)
+{
+  // Given
+  TokenPauseTransaction transaction;
+
+  // When
+  EXPECT_NO_THROW(transaction.setTokenId(getTestTokenId()));
+
+  // Then
+  EXPECT_EQ(transaction.getTokenId(), getTestTokenId());
+}
+
+//-----
+TEST_F(TokenPauseTransactionTest, GetSetTokenIdFrozen)
+{
+  // Given
+  TokenPauseTransaction transaction;
+  ASSERT_NO_THROW(transaction.freezeWith(getTestClient()));
+
+  // When / Then
+  EXPECT_THROW(transaction.setTokenId(getTestTokenId()), IllegalStateException);
+}

--- a/sdk/tests/unit/TransactionTest.cc
+++ b/sdk/tests/unit/TransactionTest.cc
@@ -39,6 +39,7 @@
 #include "TokenDissociateTransaction.h"
 #include "TokenFeeScheduleUpdateTransaction.h"
 #include "TokenMintTransaction.h"
+#include "TokenPauseTransaction.h"
 #include "TokenUpdateTransaction.h"
 #include "TokenWipeTransaction.h"
 #include "TransferTransaction.h"
@@ -1468,4 +1469,63 @@ TEST_F(TransactionTest, TokenFeeScheduleUpdateTransactionFromTransactionBytes)
   // Then
   ASSERT_EQ(index, 23);
   EXPECT_NO_THROW(const TokenFeeScheduleUpdateTransaction tokenFeeScheduleUpdateTransaction = std::get<23>(txVariant));
+}
+
+//-----
+TEST_F(TransactionTest, TokenPauseTransactionFromTransactionBodyBytes)
+{
+  // Given
+  proto::TransactionBody txBody;
+  txBody.set_allocated_token_pause(new proto::TokenPauseTransactionBody);
+
+  // When
+  const auto [index, txVariant] =
+    Transaction<TokenPauseTransaction>::fromBytes(internal::Utilities::stringToByteVector(txBody.SerializeAsString()));
+
+  // Then
+  ASSERT_EQ(index, 24);
+  EXPECT_NO_THROW(const TokenPauseTransaction tokenPauseTransaction = std::get<24>(txVariant));
+}
+
+//-----
+TEST_F(TransactionTest, TokenPauseTransactionFromSignedTransactionBytes)
+{
+  // Given
+  proto::TransactionBody txBody;
+  txBody.set_allocated_token_pause(new proto::TokenPauseTransactionBody);
+
+  proto::SignedTransaction signedTx;
+  signedTx.set_bodybytes(txBody.SerializeAsString());
+  // SignatureMap not required
+
+  // When
+  const auto [index, txVariant] =
+    Transaction<TokenPauseTransaction>::fromBytes(internal::Utilities::stringToByteVector(txBody.SerializeAsString()));
+
+  // Then
+  ASSERT_EQ(index, 24);
+  EXPECT_NO_THROW(const TokenPauseTransaction tokenPauseTransaction = std::get<24>(txVariant));
+}
+
+//-----
+TEST_F(TransactionTest, TokenPauseTransactionFromTransactionBytes)
+{
+  // Given
+  proto::TransactionBody txBody;
+  txBody.set_allocated_token_pause(new proto::TokenPauseTransactionBody);
+
+  proto::SignedTransaction signedTx;
+  signedTx.set_bodybytes(txBody.SerializeAsString());
+  // SignatureMap not required
+
+  proto::Transaction tx;
+  tx.set_signedtransactionbytes(signedTx.SerializeAsString());
+
+  // When
+  const auto [index, txVariant] =
+    Transaction<TokenPauseTransaction>::fromBytes(internal::Utilities::stringToByteVector(txBody.SerializeAsString()));
+
+  // Then
+  ASSERT_EQ(index, 24);
+  EXPECT_NO_THROW(const TokenPauseTransaction tokenPauseTransaction = std::get<24>(txVariant));
 }


### PR DESCRIPTION
**Description**:
This PR implements the APIs associated with `TokenPauseTransaction` which allows a user to pause all transactions involving a token.

**Related issue(s)**:

Fixes #385 

**Checklist**

- [x] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
