### PR TITLE
Implement `TokenUnfreezeTransaction`

### DIFF
--- a/sdk/main/CMakeLists.txt
+++ b/sdk/main/CMakeLists.txt
@@ -87,6 +87,7 @@ add_library(${PROJECT_NAME} STATIC
         src/TokenSupplyType.cc
         src/TokenTransfer.cc
         src/TokenType.cc
+        src/TokenUnfreezeTransaction.cc
         src/TokenUpdateTransaction.cc
         src/TokenWipeTransaction.cc
         src/Transaction.cc

--- a/sdk/main/include/TokenUnfreezeTransaction.h
+++ b/sdk/main/include/TokenUnfreezeTransaction.h
@@ -1,0 +1,147 @@
+/*-
+ *
+ * Hedera C++ SDK
+ *
+ * Copyright (C) 2020 - 2022 Hedera Hashgraph, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+#ifndef HEDERA_SDK_CPP_TOKEN_UNFREEZE_TRANSACTION_H_
+#define HEDERA_SDK_CPP_TOKEN_UNFREEZE_TRANSACTION_H_
+
+#include "AccountId.h"
+#include "TokenId.h"
+#include "Transaction.h"
+
+namespace proto
+{
+class TokenUnfreezeAccountTransactionBody;
+class TransactionBody;
+}
+
+namespace Hedera
+{
+/**
+ * Unfreezes transfers of the specified token for the account. The transaction must be signed by the token's freeze key.
+ *
+ *  - If the provided account is not found, the transaction will resolve to INVALID_ACCOUNT_ID.
+ *  - If the provided account has been deleted, the transaction will resolve to ACCOUNT_DELETED.
+ *  - If the provided token is not found, the transaction will resolve to INVALID_TOKEN_ID.
+ *  - If the provided token has been deleted, the transaction will resolve to TOKEN_WAS_DELETED.
+ *  - If an Association between the provided token and account is not found, the transaction will resolve to
+ *    TOKEN_NOT_ASSOCIATED_TO_ACCOUNT.
+ *  - If no Freeze Key is defined, the transaction will resolve to TOKEN_HAS_NO_FREEZE_KEY.
+ *
+ * Once executed the Account is marked as Unfrozen and will be able to receive or send tokens. The operation is
+ * idempotent.
+ *
+ * Transaction Signing Requirements:
+ *  - Freeze key.
+ *  - Transaction fee payer account key.
+ */
+class TokenUnfreezeTransaction : public Transaction<TokenUnfreezeTransaction>
+{
+public:
+  TokenUnfreezeTransaction() = default;
+
+  /**
+   * Construct from a TransactionBody protobuf object.
+   *
+   * @param transactionBody The TransactionBody protobuf object from which to construct.
+   * @throws std::invalid_argument If the input TransactionBody does not represent a TokenUnfreeze transaction.
+   */
+  explicit TokenUnfreezeTransaction(const proto::TransactionBody& transactionBody);
+
+  /**
+   * Set the ID of the account to be unfrozen for the specified token.
+   *
+   * @param accountId The ID of the account to be unfrozen for the specified token.
+   * @return A reference to this TokenUnfreezeTransaction object with the newly-set account ID.
+   * @throws IllegalStateException If this TokenUnfreezeTransaction is frozen.
+   */
+  TokenUnfreezeTransaction& setAccountId(const AccountId& accountId);
+
+  /**
+   * Set the ID of the token to be unfrozen for the specified account.
+   *
+   * @param tokenId The ID of the token to be unfrozen for the specified account.
+   * @return A reference to this TokenUnfreezeTransaction object with the newly-set token ID.
+   * @throws IllegalStateException If this TokenUnfreezeTransaction is frozen.
+   */
+  TokenUnfreezeTransaction& setTokenId(const TokenId& tokenId);
+
+  /**
+   * Get the ID of the account to be unfrozen for the specified token.
+   *
+   * @return The ID of the account to be unfrozen for the specified token.
+   */
+  [[nodiscard]] inline AccountId getAccountId() const { return mAccountId; }
+
+  /**
+   * Get the ID of the token to be unfrozen for the specified account.
+   *
+   * @return The ID of the token to be unfrozen for the specified account.
+   */
+  [[nodiscard]] inline TokenId getTokenId() const { return mTokenId; }
+
+private:
+  /**
+   * Derived from Executable. Construct a Transaction protobuf object from this TokenUnfreezeTransaction object.
+   *
+   * @param client The Client trying to construct this TokenUnfreezeTransaction.
+   * @param node   The Node to which this TokenUnfreezeTransaction will be sent. This is unused.
+   * @return A Transaction protobuf object filled with this TokenUnfreezeTransaction object's data.
+   * @throws UninitializedException If the input client has no operator with which to sign this
+   * TokenUnfreezeTransaction.
+   */
+  [[nodiscard]] proto::Transaction makeRequest(const Client& client,
+                                               const std::shared_ptr<internal::Node>& /*node*/) const override;
+
+  /**
+   * Derived from Executable. Submit this TokenUnfreezeTransaction to a Node.
+   *
+   * @param client   The Client submitting this TokenUnfreezeTransaction.
+   * @param deadline The deadline for submitting this TokenUnfreezeTransaction.
+   * @param node     Pointer to the Node to which this TokenUnfreezeTransaction should be submitted.
+   * @param response Pointer to the TransactionResponse protobuf object that gRPC should populate with the response
+   *                 information from the gRPC server.
+   * @return The gRPC status of the submission.
+   */
+  [[nodiscard]] grpc::Status submitRequest(const Client& client,
+                                           const std::chrono::system_clock::time_point& deadline,
+                                           const std::shared_ptr<internal::Node>& node,
+                                           proto::TransactionResponse* response) const override;
+
+  /**
+   * Build a TokenUnfreezeAccountTransactionBody protobuf object from this TokenUnfreezeTransaction object.
+   *
+   * @return A pointer to a TokenUnfreezeAccountTransactionBody protobuf object filled with this
+   *         TokenUnfreezeTransaction object's data.
+   */
+  [[nodiscard]] proto::TokenUnfreezeAccountTransactionBody* build() const;
+
+  /**
+   * The ID of the account to be unfrozen for the specified token.
+   */
+  AccountId mAccountId;
+
+  /**
+   * The ID of the token to be unfrozen for the specified account.
+   */
+  TokenId mTokenId;
+};
+
+} // namespace Hedera
+
+#endif // HEDERA_SDK_CPP_TOKEN_UNFREEZE_TRANSACTION_H_

--- a/sdk/main/include/Transaction.h
+++ b/sdk/main/include/Transaction.h
@@ -57,6 +57,7 @@ class TokenDeleteTransaction;
 class TokenDissociateTransaction;
 class TokenFeeScheduleUpdateTransaction;
 class TokenMintTransaction;
+class TokenUnfreezeTransaction;
 class TokenUpdateTransaction;
 class TokenWipeTransaction;
 class TransactionResponse;
@@ -138,7 +139,8 @@ public:
                                               TokenWipeTransaction,
                                               TokenBurnTransaction,
                                               TokenDissociateTransaction,
-                                              TokenFeeScheduleUpdateTransaction>>
+                                              TokenFeeScheduleUpdateTransaction,
+                                              TokenUnfreezeTransaction>>
   fromBytes(const std::vector<std::byte>& bytes);
 
   /**

--- a/sdk/main/src/Executable.cc
+++ b/sdk/main/src/Executable.cc
@@ -56,6 +56,7 @@
 #include "TokenInfo.h"
 #include "TokenInfoQuery.h"
 #include "TokenMintTransaction.h"
+#include "TokenUnfreezeTransaction.h"
 #include "TokenUpdateTransaction.h"
 #include "TokenWipeTransaction.h"
 #include "TransactionReceipt.h"
@@ -373,6 +374,10 @@ template class Executable<TokenFeeScheduleUpdateTransaction,
                           TransactionResponse>;
 template class Executable<TokenInfoQuery, proto::Query, proto::Response, TokenInfo>;
 template class Executable<TokenMintTransaction, proto::Transaction, proto::TransactionResponse, TransactionResponse>;
+template class Executable<TokenUnfreezeTransaction,
+                          proto::Transaction,
+                          proto::TransactionResponse,
+                          TransactionResponse>;
 template class Executable<TokenUpdateTransaction, proto::Transaction, proto::TransactionResponse, TransactionResponse>;
 template class Executable<TokenWipeTransaction, proto::Transaction, proto::TransactionResponse, TransactionResponse>;
 template class Executable<TransactionReceiptQuery, proto::Query, proto::Response, TransactionReceipt>;

--- a/sdk/main/src/TokenUnfreezeTransaction.cc
+++ b/sdk/main/src/TokenUnfreezeTransaction.cc
@@ -1,0 +1,106 @@
+/*-
+ *
+ * Hedera C++ SDK
+ *
+ * Copyright (C) 2020 - 2022 Hedera Hashgraph, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+#include "TokenUnfreezeTransaction.h"
+#include "impl/Node.h"
+
+#include <grpcpp/client_context.h>
+#include <proto/token_unfreeze_account.pb.h>
+#include <proto/transaction.pb.h>
+#include <stdexcept>
+
+namespace Hedera
+{
+//-----
+TokenUnfreezeTransaction::TokenUnfreezeTransaction(const proto::TransactionBody& transactionBody)
+  : Transaction<TokenUnfreezeTransaction>(transactionBody)
+{
+  if (!transactionBody.has_tokenunfreeze())
+  {
+    throw std::invalid_argument("Transaction body doesn't contain TokenUnfreeze data");
+  }
+
+  const proto::TokenUnfreezeAccountTransactionBody& body = transactionBody.tokenunfreeze();
+
+  if (body.has_account())
+  {
+    mAccountId = AccountId::fromProtobuf(body.account());
+  }
+
+  if (body.has_token())
+  {
+    mTokenId = TokenId::fromProtobuf(body.token());
+  }
+}
+
+//-----
+TokenUnfreezeTransaction& TokenUnfreezeTransaction::setAccountId(const AccountId& accountId)
+{
+  requireNotFrozen();
+  mAccountId = accountId;
+  return *this;
+}
+
+//-----
+TokenUnfreezeTransaction& TokenUnfreezeTransaction::setTokenId(const TokenId& tokenId)
+{
+  requireNotFrozen();
+  mTokenId = tokenId;
+  return *this;
+}
+
+//-----
+proto::Transaction TokenUnfreezeTransaction::makeRequest(const Client& client,
+                                                         const std::shared_ptr<internal::Node>&) const
+{
+  proto::TransactionBody transactionBody = generateTransactionBody(client);
+  transactionBody.set_allocated_tokenunfreeze(build());
+
+  return signTransaction(transactionBody, client);
+}
+
+//-----
+grpc::Status TokenUnfreezeTransaction::submitRequest(const Client& client,
+                                                     const std::chrono::system_clock::time_point& deadline,
+                                                     const std::shared_ptr<internal::Node>& node,
+                                                     proto::TransactionResponse* response) const
+{
+  return node->submitTransaction(
+    proto::TransactionBody::DataCase::kTokenUnfreeze, makeRequest(client, node), deadline, response);
+}
+
+//-----
+proto::TokenUnfreezeAccountTransactionBody* TokenUnfreezeTransaction::build() const
+{
+  auto body = std::make_unique<proto::TokenUnfreezeAccountTransactionBody>();
+
+  if (!(mAccountId == AccountId()))
+  {
+    body->set_allocated_account(mAccountId.toProtobuf().release());
+  }
+
+  if (!(mTokenId == TokenId()))
+  {
+    body->set_allocated_token(mTokenId.toProtobuf().release());
+  }
+
+  return body.release();
+}
+
+} // namespace Hedera

--- a/sdk/main/src/Transaction.cc
+++ b/sdk/main/src/Transaction.cc
@@ -43,6 +43,7 @@
 #include "TokenDissociateTransaction.h"
 #include "TokenFeeScheduleUpdateTransaction.h"
 #include "TokenMintTransaction.h"
+#include "TokenUnfreezeTransaction.h"
 #include "TokenUpdateTransaction.h"
 #include "TokenWipeTransaction.h"
 #include "TransactionId.h"
@@ -89,7 +90,8 @@ std::pair<int,
                        TokenWipeTransaction,
                        TokenBurnTransaction,
                        TokenDissociateTransaction,
-                       TokenFeeScheduleUpdateTransaction>>
+                       TokenFeeScheduleUpdateTransaction,
+                       TokenUnfreezeTransaction>>
 Transaction<SdkRequestType>::fromBytes(const std::vector<std::byte>& bytes)
 {
   proto::TransactionBody txBody;
@@ -179,6 +181,8 @@ Transaction<SdkRequestType>::fromBytes(const std::vector<std::byte>& bytes)
       return { 22, TokenDissociateTransaction(txBody) };
     case proto::TransactionBody::kTokenFeeScheduleUpdate:
       return { 23, TokenFeeScheduleUpdateTransaction(txBody) };
+    case proto::TransactionBody::kTokenUnfreeze:
+      return { 24, TokenUnfreezeTransaction(txBody) };
     default:
       throw std::invalid_argument("Type of transaction cannot be determined from input bytes");
   }
@@ -501,6 +505,7 @@ template class Transaction<TokenDeleteTransaction>;
 template class Transaction<TokenDissociateTransaction>;
 template class Transaction<TokenFeeScheduleUpdateTransaction>;
 template class Transaction<TokenMintTransaction>;
+template class Transaction<TokenUnfreezeTransaction>;
 template class Transaction<TokenUpdateTransaction>;
 template class Transaction<TokenWipeTransaction>;
 template class Transaction<TransferTransaction>;

--- a/sdk/main/src/impl/Node.cc
+++ b/sdk/main/src/impl/Node.cc
@@ -206,6 +206,8 @@ grpc::Status Node::submitTransaction(proto::TransactionBody::DataCase funcEnum,
       return mTokenStub->updateTokenFeeSchedule(&context, transaction, response);
     case proto::TransactionBody::DataCase::kTokenMint:
       return mTokenStub->mintToken(&context, transaction, response);
+    case proto::TransactionBody::DataCase::kTokenUnfreeze:
+      return mTokenStub->unfreezeTokenAccount(&context, transaction, response);
     case proto::TransactionBody::DataCase::kTokenUpdate:
       return mTokenStub->updateToken(&context, transaction, response);
     default:

--- a/sdk/main/src/impl/Node.cc
+++ b/sdk/main/src/impl/Node.cc
@@ -210,6 +210,8 @@ grpc::Status Node::submitTransaction(proto::TransactionBody::DataCase funcEnum,
       return mTokenStub->unfreezeTokenAccount(&context, transaction, response);
     case proto::TransactionBody::DataCase::kTokenUpdate:
       return mTokenStub->updateToken(&context, transaction, response);
+    case proto::TransactionBody::DataCase::kTokenWipe:
+      return mTokenStub->wipeTokenAccount(&context, transaction, response);
     default:
       // This should never happen
       throw std::invalid_argument("Unrecognized gRPC transaction method case");

--- a/sdk/tests/integration/CMakeLists.txt
+++ b/sdk/tests/integration/CMakeLists.txt
@@ -32,6 +32,7 @@ add_executable(${TEST_PROJECT_NAME}
         TokenFeeScheduleUpdateTransactionIntegrationTests.cc
         TokenInfoQueryIntegrationTests.cc
         TokenMintTransactionIntegrationTests.cc
+        TokenUnfreezeTransactionIntegrationTests.cc
         TokenUpdateTransactionIntegrationTests.cc
         TransactionIntegrationTest.cc
         TransactionReceiptIntegrationTest.cc

--- a/sdk/tests/integration/TokenUnfreezeTransactionIntegrationTests.cc
+++ b/sdk/tests/integration/TokenUnfreezeTransactionIntegrationTests.cc
@@ -1,0 +1,248 @@
+/*-
+ *
+ * Hedera C++ SDK
+ *
+ * Copyright (C) 2020 - 2022 Hedera Hashgraph, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+#include "AccountCreateTransaction.h"
+#include "AccountDeleteTransaction.h"
+#include "AccountId.h"
+#include "BaseIntegrationTest.h"
+#include "Client.h"
+#include "ED25519PrivateKey.h"
+#include "PrivateKey.h"
+#include "TokenAssociateTransaction.h"
+#include "TokenCreateTransaction.h"
+#include "TokenDeleteTransaction.h"
+#include "TokenUnfreezeTransaction.h"
+#include "TokenWipeTransaction.h"
+#include "TransactionReceipt.h"
+#include "TransactionRecord.h"
+#include "TransactionResponse.h"
+#include "TransferTransaction.h"
+#include "exceptions/PrecheckStatusException.h"
+#include "exceptions/ReceiptStatusException.h"
+
+#include <gtest/gtest.h>
+
+using namespace Hedera;
+
+class TokenUnfreezeTransactionIntegrationTest : public BaseIntegrationTest
+{
+};
+
+//-----
+TEST_F(TokenUnfreezeTransactionIntegrationTest, ExecuteTokenUnfreezeTransaction)
+{
+  // Given
+  const int64_t amount = 10LL;
+
+  std::shared_ptr<PrivateKey> operatorKey;
+  std::shared_ptr<PrivateKey> accountKey;
+
+  ASSERT_NO_THROW(
+    operatorKey = ED25519PrivateKey::fromString(
+      "302e020100300506032b65700422042091132178e72057a1d7528025956fe39b0b847f200ab59b2fdd367017f3087137"));
+  ASSERT_NO_THROW(accountKey = ED25519PrivateKey::generatePrivateKey());
+
+  AccountId accountId;
+  ASSERT_NO_THROW(accountId = AccountCreateTransaction()
+                                .setKey(accountKey.get())
+                                .setInitialBalance(Hbar(1LL))
+                                .execute(getTestClient())
+                                .getReceipt(getTestClient())
+                                .mAccountId.value());
+
+  TokenId tokenId;
+  ASSERT_NO_THROW(tokenId = TokenCreateTransaction()
+                              .setTokenName("ffff")
+                              .setTokenSymbol("F")
+                              .setInitialSupply(100000ULL)
+                              .setTreasuryAccountId(AccountId(2ULL))
+                              .setAdminKey(operatorKey)
+                              .setFreezeKey(operatorKey)
+                              .setWipeKey(operatorKey)
+                              .execute(getTestClient())
+                              .getReceipt(getTestClient())
+                              .mTokenId.value());
+
+  ASSERT_NO_THROW(const TransactionReceipt txReceipt = TokenAssociateTransaction()
+                                                         .setAccountId(accountId)
+                                                         .setTokenIds({ tokenId })
+                                                         .freezeWith(getTestClient())
+                                                         .sign(accountKey.get())
+                                                         .execute(getTestClient())
+                                                         .getReceipt(getTestClient()));
+
+  // When
+  EXPECT_NO_THROW(const TransactionReceipt txReceipt = TokenUnfreezeTransaction()
+                                                         .setAccountId(accountId)
+                                                         .setTokenId(tokenId)
+                                                         .freezeWith(getTestClient())
+                                                         .sign(accountKey.get())
+                                                         .execute(getTestClient())
+                                                         .getReceipt(getTestClient()));
+
+  // Then
+  EXPECT_NO_THROW(const TransactionReceipt txReceipt = TransferTransaction()
+                                                         .addTokenTransfer(tokenId, AccountId(2ULL), -amount)
+                                                         .addTokenTransfer(tokenId, accountId, amount)
+                                                         .execute(getTestClient())
+                                                         .getReceipt(getTestClient()));
+
+  // Clean up
+  ASSERT_NO_THROW(const TransactionReceipt txReceipt = TokenWipeTransaction()
+                                                         .setTokenId(tokenId)
+                                                         .setAccountId(accountId)
+                                                         .setAmount(amount)
+                                                         .execute(getTestClient())
+                                                         .getReceipt(getTestClient()));
+
+  ASSERT_NO_THROW(const TransactionReceipt txReceipt = AccountDeleteTransaction()
+                                                         .setDeleteAccountId(accountId)
+                                                         .setTransferAccountId(AccountId(2ULL))
+                                                         .freezeWith(getTestClient())
+                                                         .sign(accountKey.get())
+                                                         .execute(getTestClient())
+                                                         .getReceipt(getTestClient()));
+  ASSERT_NO_THROW(const TransactionReceipt txReceipt =
+                    TokenDeleteTransaction().setTokenId(tokenId).execute(getTestClient()).getReceipt(getTestClient()));
+}
+
+//-----
+TEST_F(TokenUnfreezeTransactionIntegrationTest, CannotUnfreezeWithNoTokenId)
+{
+  // Given
+  std::shared_ptr<PrivateKey> operatorKey;
+  std::shared_ptr<PrivateKey> accountKey;
+
+  ASSERT_NO_THROW(
+    operatorKey = ED25519PrivateKey::fromString(
+      "302e020100300506032b65700422042091132178e72057a1d7528025956fe39b0b847f200ab59b2fdd367017f3087137"));
+  ASSERT_NO_THROW(accountKey = ED25519PrivateKey::generatePrivateKey());
+
+  AccountId accountId;
+  ASSERT_NO_THROW(accountId = AccountCreateTransaction()
+                                .setKey(accountKey.get())
+                                .setInitialBalance(Hbar(1LL))
+                                .execute(getTestClient())
+                                .getReceipt(getTestClient())
+                                .mAccountId.value());
+
+  // When / Then
+  EXPECT_THROW(const TransactionReceipt txReceipt = TokenUnfreezeTransaction()
+                                                      .setAccountId(accountId)
+                                                      .freezeWith(getTestClient())
+                                                      .sign(accountKey.get())
+                                                      .execute(getTestClient())
+                                                      .getReceipt(getTestClient()),
+               PrecheckStatusException); // INVALID_TOKEN_ID
+
+  // Clean up
+  ASSERT_NO_THROW(const TransactionReceipt txReceipt = AccountDeleteTransaction()
+                                                         .setDeleteAccountId(accountId)
+                                                         .setTransferAccountId(AccountId(2ULL))
+                                                         .freezeWith(getTestClient())
+                                                         .sign(accountKey.get())
+                                                         .execute(getTestClient())
+                                                         .getReceipt(getTestClient()));
+}
+
+//-----
+TEST_F(TokenUnfreezeTransactionIntegrationTest, CannotUnfreezeWithNoAccountId)
+{
+  // Given
+  std::shared_ptr<PrivateKey> operatorKey;
+
+  ASSERT_NO_THROW(
+    operatorKey = ED25519PrivateKey::fromString(
+      "302e020100300506032b65700422042091132178e72057a1d7528025956fe39b0b847f200ab59b2fdd367017f3087137"));
+
+  TokenId tokenId;
+  ASSERT_NO_THROW(tokenId = TokenCreateTransaction()
+                              .setTokenName("ffff")
+                              .setTokenSymbol("F")
+                              .setInitialSupply(100000ULL)
+                              .setTreasuryAccountId(AccountId(2ULL))
+                              .setAdminKey(operatorKey)
+                              .setFreezeKey(operatorKey)
+                              .execute(getTestClient())
+                              .getReceipt(getTestClient())
+                              .mTokenId.value());
+
+  // When / Then
+  EXPECT_THROW(const TransactionReceipt txReceipt =
+                 TokenUnfreezeTransaction().setTokenId(tokenId).execute(getTestClient()).getReceipt(getTestClient()),
+               PrecheckStatusException); // INVALID_ACCOUNT_ID
+
+  // Clean up
+  ASSERT_NO_THROW(const TransactionReceipt txReceipt =
+                    TokenDeleteTransaction().setTokenId(tokenId).execute(getTestClient()).getReceipt(getTestClient()));
+}
+
+//-----
+TEST_F(TokenUnfreezeTransactionIntegrationTest, CannotUnfreezeTokenOnAccountWithNoAssociation)
+{
+  // Given
+  std::shared_ptr<PrivateKey> operatorKey;
+  std::shared_ptr<PrivateKey> accountKey;
+
+  ASSERT_NO_THROW(
+    operatorKey = ED25519PrivateKey::fromString(
+      "302e020100300506032b65700422042091132178e72057a1d7528025956fe39b0b847f200ab59b2fdd367017f3087137"));
+  ASSERT_NO_THROW(accountKey = ED25519PrivateKey::generatePrivateKey());
+
+  AccountId accountId;
+  ASSERT_NO_THROW(accountId = AccountCreateTransaction()
+                                .setKey(accountKey.get())
+                                .setInitialBalance(Hbar(1LL))
+                                .execute(getTestClient())
+                                .getReceipt(getTestClient())
+                                .mAccountId.value());
+
+  TokenId tokenId;
+  ASSERT_NO_THROW(tokenId = TokenCreateTransaction()
+                              .setTokenName("ffff")
+                              .setTokenSymbol("F")
+                              .setInitialSupply(100000ULL)
+                              .setTreasuryAccountId(AccountId(2ULL))
+                              .setAdminKey(operatorKey)
+                              .setFreezeKey(operatorKey)
+                              .execute(getTestClient())
+                              .getReceipt(getTestClient())
+                              .mTokenId.value());
+
+  // When / Then
+  EXPECT_THROW(const TransactionReceipt txReceipt = TokenUnfreezeTransaction()
+                                                      .setAccountId(accountId)
+                                                      .setTokenId(tokenId)
+                                                      .freezeWith(getTestClient())
+                                                      .sign(accountKey.get())
+                                                      .execute(getTestClient())
+                                                      .getReceipt(getTestClient()),
+               ReceiptStatusException); // TOKEN_NOT_ASSOCIATED_TO_ACCOUNT
+
+  // Clean up
+  ASSERT_NO_THROW(const TransactionReceipt txReceipt = AccountDeleteTransaction()
+                                                         .setDeleteAccountId(accountId)
+                                                         .setTransferAccountId(AccountId(2ULL))
+                                                         .freezeWith(getTestClient())
+                                                         .sign(accountKey.get())
+                                                         .execute(getTestClient())
+                                                         .getReceipt(getTestClient()));
+  ASSERT_NO_THROW(const TransactionReceipt txReceipt =
+                    TokenDeleteTransaction().setTokenId(tokenId).execute(getTestClient()).getReceipt(getTestClient()));
+}

--- a/sdk/tests/unit/CMakeLists.txt
+++ b/sdk/tests/unit/CMakeLists.txt
@@ -78,6 +78,7 @@ add_executable(${TEST_PROJECT_NAME}
         TokenSupplyTypeTest.cc
         TokenTransferTest.cc
         TokenTypeTest.cc
+        TokenUnfreezeTransactionUnitTests.cc
         TokenUpdateTransactionUnitTests.cc
         TokenWipeTransactionUnitTests.cc
         TransactionIdTest.cc

--- a/sdk/tests/unit/TokenUnfreezeTransactionUnitTests.cc
+++ b/sdk/tests/unit/TokenUnfreezeTransactionUnitTests.cc
@@ -1,0 +1,111 @@
+/*-
+ *
+ * Hedera C++ SDK
+ *
+ * Copyright (C) 2020 - 2022 Hedera Hashgraph, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+#include "AccountId.h"
+#include "Client.h"
+#include "ECDSAsecp256k1PrivateKey.h"
+#include "TokenUnfreezeTransaction.h"
+#include "exceptions/IllegalStateException.h"
+
+#include <gtest/gtest.h>
+#include <proto/transaction_body.pb.h>
+
+using namespace Hedera;
+
+class TokenUnfreezeTransactionTest : public ::testing::Test
+{
+protected:
+  void SetUp() override { mClient.setOperator(AccountId(), ECDSAsecp256k1PrivateKey::generatePrivateKey().get()); }
+
+  [[nodiscard]] inline const Client& getTestClient() const { return mClient; }
+  [[nodiscard]] inline const AccountId& getTestAccountId() const { return mTestAccountId; }
+  [[nodiscard]] inline const TokenId& getTestTokenId() const { return mTestTokenId; }
+
+private:
+  Client mClient;
+  const AccountId mTestAccountId = AccountId(1ULL, 2ULL, 3ULL);
+  const TokenId mTestTokenId = TokenId(4ULL, 5ULL, 6ULL);
+};
+
+//-----
+TEST_F(TokenUnfreezeTransactionTest, ConstructTokenUnfreezeTransactionFromTransactionBodyProtobuf)
+{
+  // Given
+  auto body = std::make_unique<proto::TokenUnfreezeAccountTransactionBody>();
+  body->set_allocated_account(getTestAccountId().toProtobuf().release());
+  body->set_allocated_token(getTestTokenId().toProtobuf().release());
+
+  proto::TransactionBody txBody;
+  txBody.set_allocated_tokenunfreeze(body.release());
+
+  // When
+  const TokenUnfreezeTransaction tokenUnfreezeTransaction(txBody);
+
+  // Then
+  EXPECT_EQ(tokenUnfreezeTransaction.getAccountId(), getTestAccountId());
+  EXPECT_EQ(tokenUnfreezeTransaction.getTokenId(), getTestTokenId());
+}
+
+//-----
+TEST_F(TokenUnfreezeTransactionTest, GetSetAccountId)
+{
+  // Given
+  TokenUnfreezeTransaction transaction;
+
+  // When
+  EXPECT_NO_THROW(transaction.setAccountId(getTestAccountId()));
+
+  // Then
+  EXPECT_EQ(transaction.getAccountId(), getTestAccountId());
+}
+
+//-----
+TEST_F(TokenUnfreezeTransactionTest, GetSetAccountIdFrozen)
+{
+  // Given
+  TokenUnfreezeTransaction transaction;
+  ASSERT_NO_THROW(transaction.freezeWith(getTestClient()));
+
+  // When / Then
+  EXPECT_THROW(transaction.setAccountId(getTestAccountId()), IllegalStateException);
+}
+
+//-----
+TEST_F(TokenUnfreezeTransactionTest, GetSetTokenId)
+{
+  // Given
+  TokenUnfreezeTransaction transaction;
+
+  // When
+  EXPECT_NO_THROW(transaction.setTokenId(getTestTokenId()));
+
+  // Then
+  EXPECT_EQ(transaction.getTokenId(), getTestTokenId());
+}
+
+//-----
+TEST_F(TokenUnfreezeTransactionTest, GetSetTokenIdFrozen)
+{
+  // Given
+  TokenUnfreezeTransaction transaction;
+  ASSERT_NO_THROW(transaction.freezeWith(getTestClient()));
+
+  // When / Then
+  EXPECT_THROW(transaction.setTokenId(getTestTokenId()), IllegalStateException);
+}

--- a/sdk/tests/unit/TransactionTest.cc
+++ b/sdk/tests/unit/TransactionTest.cc
@@ -39,6 +39,7 @@
 #include "TokenDissociateTransaction.h"
 #include "TokenFeeScheduleUpdateTransaction.h"
 #include "TokenMintTransaction.h"
+#include "TokenUnfreezeTransaction.h"
 #include "TokenUpdateTransaction.h"
 #include "TokenWipeTransaction.h"
 #include "TransferTransaction.h"
@@ -1468,4 +1469,63 @@ TEST_F(TransactionTest, TokenFeeScheduleUpdateTransactionFromTransactionBytes)
   // Then
   ASSERT_EQ(index, 23);
   EXPECT_NO_THROW(const TokenFeeScheduleUpdateTransaction tokenFeeScheduleUpdateTransaction = std::get<23>(txVariant));
+}
+
+//-----
+TEST_F(TransactionTest, TokenUnfreezeTransactionFromTransactionBodyBytes)
+{
+  // Given
+  proto::TransactionBody txBody;
+  txBody.set_allocated_tokenunfreeze(new proto::TokenUnfreezeAccountTransactionBody);
+
+  // When
+  const auto [index, txVariant] = Transaction<TokenUnfreezeTransaction>::fromBytes(
+    internal::Utilities::stringToByteVector(txBody.SerializeAsString()));
+
+  // Then
+  ASSERT_EQ(index, 24);
+  EXPECT_NO_THROW(const TokenUnfreezeTransaction tokenUnfreezeTransaction = std::get<24>(txVariant));
+}
+
+//-----
+TEST_F(TransactionTest, TokenUnfreezeTransactionFromSignedTransactionBytes)
+{
+  // Given
+  proto::TransactionBody txBody;
+  txBody.set_allocated_tokenunfreeze(new proto::TokenUnfreezeAccountTransactionBody);
+
+  proto::SignedTransaction signedTx;
+  signedTx.set_bodybytes(txBody.SerializeAsString());
+  // SignatureMap not required
+
+  // When
+  const auto [index, txVariant] = Transaction<TokenUnfreezeTransaction>::fromBytes(
+    internal::Utilities::stringToByteVector(txBody.SerializeAsString()));
+
+  // Then
+  ASSERT_EQ(index, 24);
+  EXPECT_NO_THROW(const TokenUnfreezeTransaction tokenUnfreezeTransaction = std::get<24>(txVariant));
+}
+
+//-----
+TEST_F(TransactionTest, TokenUnfreezeTransactionFromTransactionBytes)
+{
+  // Given
+  proto::TransactionBody txBody;
+  txBody.set_allocated_tokenunfreeze(new proto::TokenUnfreezeAccountTransactionBody);
+
+  proto::SignedTransaction signedTx;
+  signedTx.set_bodybytes(txBody.SerializeAsString());
+  // SignatureMap not required
+
+  proto::Transaction tx;
+  tx.set_signedtransactionbytes(signedTx.SerializeAsString());
+
+  // When
+  const auto [index, txVariant] = Transaction<TokenUnfreezeTransaction>::fromBytes(
+    internal::Utilities::stringToByteVector(txBody.SerializeAsString()));
+
+  // Then
+  ASSERT_EQ(index, 24);
+  EXPECT_NO_THROW(const TokenUnfreezeTransaction tokenUnfreezeTransaction = std::get<24>(txVariant));
 }


### PR DESCRIPTION
**Description**:
This PR implements the APIs associated with `TokenUnfreezeTransaction`, which allows users to unfreeze token functions for an account.

**Related issue(s)**:

Fixes #381 

**Checklist**

- [x] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
