### PR TITLE
Implement `TokenNftInfoQuery`

### DIFF
--- a/sdk/main/CMakeLists.txt
+++ b/sdk/main/CMakeLists.txt
@@ -82,6 +82,8 @@ add_library(${PROJECT_NAME} STATIC
         src/TokenInfoQuery.cc
         src/TokenMintTransaction.cc
         src/TokenNftAllowance.cc
+        src/TokenNftInfo.cc
+        src/TokenNftInfoQuery.cc
         src/TokenNftRemoveAllowance.cc
         src/TokenNftTransfer.cc
         src/TokenSupplyType.cc

--- a/sdk/main/include/TokenNftInfo.h
+++ b/sdk/main/include/TokenNftInfo.h
@@ -1,0 +1,108 @@
+/*-
+ *
+ * Hedera C++ SDK
+ *
+ * Copyright (C) 2020 - 2022 Hedera Hashgraph, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+#ifndef HEDERA_SDK_CPP_TOKEN_NFT_INFO_H_
+#define HEDERA_SDK_CPP_TOKEN_NFT_INFO_H_
+
+#include "AccountId.h"
+#include "LedgerId.h"
+#include "NftId.h"
+
+#include <chrono>
+#include <cstddef>
+#include <optional>
+#include <vector>
+
+namespace proto
+{
+class TokenNftInfo;
+}
+
+namespace Hedera
+{
+/**
+ * Response from a Hedera network when the client sends an TokenNftInfoQuery.
+ */
+class TokenNftInfo
+{
+public:
+  /**
+   * Construct a TokenNftInfo object from a TokenNftInfo protobuf object.
+   *
+   * @param proto The TokenNftInfo protobuf object from which to construct a TokenNftInfo object.
+   * @return The constructed TokenNftInfo object.
+   */
+  [[nodiscard]] static TokenNftInfo fromProtobuf(const proto::TokenNftInfo& proto);
+
+  /**
+   * Construct a TokenNftInfo object from a byte array.
+   *
+   * @param bytes The byte array representing a TokenNftInfo object.
+   * @return The constructed TokenNftInfo object.
+   */
+  [[nodiscard]] static TokenNftInfo fromBytes(const std::vector<std::byte>& bytes);
+
+  /**
+   * Construct a TokenNftInfo protobuf object from this TokenNftInfo object.
+   *
+   * @return A pointer to the created TokenNftInfo protobuf object.
+   */
+  [[nodiscard]] std::unique_ptr<proto::TokenNftInfo> toProtobuf() const;
+
+  /**
+   * Construct a representative byte array from this TokenNftInfo object.
+   *
+   * @return The byte array representing this TokenNftInfo object.
+   */
+  [[nodiscard]] std::vector<std::byte> toBytes() const;
+
+  /**
+   * The ID of the NFT.
+   */
+  NftId mNftId;
+
+  /**
+   * The current owner of the NFT.
+   */
+  AccountId mAccountId;
+
+  /**
+   * The effective consensus timestamp at which the NFT was minted.
+   */
+  std::chrono::system_clock::time_point mCreationTime;
+
+  /**
+   * The unique metadata of the NFT.
+   */
+  std::vector<std::byte> mMetadata;
+
+  /**
+   * The ID of the ledger from which this response was returned.
+   */
+  LedgerId mLedgerId;
+
+  /**
+   * The corresponding spender account if an allowance is granted for the NFT.
+   */
+  std::optional<AccountId> mSpenderId;
+};
+
+} // namespace Hedera
+
+#endif // HEDERA_SDK_CPP_TOKEN_NFT_INFO_H_

--- a/sdk/main/include/TokenNftInfoQuery.h
+++ b/sdk/main/include/TokenNftInfoQuery.h
@@ -1,0 +1,111 @@
+/*-
+ *
+ * Hedera C++ SDK
+ *
+ * Copyright (C) 2020 - 2022 Hedera Hashgraph, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+#ifndef HEDERA_SDK_CPP_TOKEN_NFT_INFO_QUERY_H_
+#define HEDERA_SDK_CPP_TOKEN_NFT_INFO_QUERY_H_
+
+#include "NftId.h"
+#include "Query.h"
+
+namespace Hedera
+{
+class TokenNftInfo;
+class TransactionRecord;
+}
+
+namespace Hedera
+{
+/**
+ * A query that returns information about a non-fungible token (NFT). You request the info for an NFT by specifying the
+ * NFT ID.
+ *
+ * Only when a spender is set on an explicit NFT ID of a token, the spender ID is returned for the respective NFT. If
+ * mApproveTokenNftAllowanceAllSerials is used to approve all NFTs for a given token class and no NFT ID is specified,
+ * the spender ID for all the serial numbers of that token will not be returned.
+ */
+class TokenNftInfoQuery : public Query<TokenNftInfoQuery, TokenNftInfo>
+{
+public:
+  /**
+   * Set the ID of the NFT of which to request the info.
+   *
+   * @param nft The ID of the NFT of which to request the info.
+   * @return A reference to this TokenNftInfoQuery object with the newly-set NFT ID.
+   */
+  TokenNftInfoQuery& setNftId(const NftId& nft);
+
+  /**
+   * Get the ID of the NFT of which this query is currently configured to get the info.
+   *
+   * @return The ID of the NFT for which this query is meant.
+   */
+  [[nodiscard]] inline NftId getNftId() const { return mNftId; }
+
+private:
+  /**
+   * Derived from Executable. Construct a Query protobuf object from this TokenNftInfoQuery object.
+   *
+   * @param client The Client trying to construct this TokenNftInfoQuery.
+   * @param node   The Node to which this TokenNftInfoQuery will be sent.
+   * @return A Query protobuf object filled with this TokenNftInfoQuery object's data.
+   */
+  [[nodiscard]] proto::Query makeRequest(const Client& client,
+                                         const std::shared_ptr<internal::Node>& node) const override;
+
+  /**
+   * Derived from Executable. Construct a TokenNftInfo object from a Response protobuf object.
+   *
+   * @param response The Response protobuf object from which to construct a TokenNftInfo object.
+   * @return A TokenNftInfo object filled with the Response protobuf object's data.
+   */
+  [[nodiscard]] TokenNftInfo mapResponse(const proto::Response& response) const override;
+
+  /**
+   * Derived from Executable. Get the status response code for a submitted TokenNftInfoQuery from a Response protobuf
+   * object.
+   *
+   * @param response The Response protobuf object from which to grab the TokenNftInfoQuery status response code.
+   * @return The TokenNftInfoQuery status response code of the input Response protobuf object.
+   */
+  [[nodiscard]] Status mapResponseStatus(const proto::Response& response) const override;
+
+  /**
+   * Derived from Executable. Submit this TokenNftInfoQuery to a Node.
+   *
+   * @param client   The Client submitting this TokenNftInfoQuery.
+   * @param deadline The deadline for submitting this TokenNftInfoQuery.
+   * @param node     Pointer to the Node to which this TokenNftInfoQuery should be submitted.
+   * @param response Pointer to the Response protobuf object that gRPC should populate with the response information
+   *                 from the gRPC server.
+   * @return The gRPC status of the submission.
+   */
+  [[nodiscard]] grpc::Status submitRequest(const Client& client,
+                                           const std::chrono::system_clock::time_point& deadline,
+                                           const std::shared_ptr<internal::Node>& node,
+                                           proto::Response* response) const override;
+
+  /**
+   * The ID of the NFT of which this query should get the info.
+   */
+  NftId mNftId;
+};
+
+} // namespace Hedera
+
+#endif // HEDERA_SDK_CPP_TOKEN_NFT_INFO_QUERY_H_

--- a/sdk/main/include/TransferTransaction.h
+++ b/sdk/main/include/TransferTransaction.h
@@ -204,6 +204,7 @@ private:
   friend class FileContentsQuery;
   friend class FileInfoQuery;
   friend class TokenInfoQuery;
+  friend class TokenNftInfoQuery;
   friend class TransactionRecordQuery;
 
   /**

--- a/sdk/main/src/Executable.cc
+++ b/sdk/main/src/Executable.cc
@@ -56,6 +56,8 @@
 #include "TokenInfo.h"
 #include "TokenInfoQuery.h"
 #include "TokenMintTransaction.h"
+#include "TokenNftInfo.h"
+#include "TokenNftInfoQuery.h"
 #include "TokenUpdateTransaction.h"
 #include "TokenWipeTransaction.h"
 #include "TransactionReceipt.h"
@@ -373,6 +375,7 @@ template class Executable<TokenFeeScheduleUpdateTransaction,
                           TransactionResponse>;
 template class Executable<TokenInfoQuery, proto::Query, proto::Response, TokenInfo>;
 template class Executable<TokenMintTransaction, proto::Transaction, proto::TransactionResponse, TransactionResponse>;
+template class Executable<TokenNftInfoQuery, proto::Query, proto::Response, TokenNftInfo>;
 template class Executable<TokenUpdateTransaction, proto::Transaction, proto::TransactionResponse, TransactionResponse>;
 template class Executable<TokenWipeTransaction, proto::Transaction, proto::TransactionResponse, TransactionResponse>;
 template class Executable<TransactionReceiptQuery, proto::Query, proto::Response, TransactionReceipt>;

--- a/sdk/main/src/Query.cc
+++ b/sdk/main/src/Query.cc
@@ -31,6 +31,8 @@
 #include "FileInfoQuery.h"
 #include "TokenInfo.h"
 #include "TokenInfoQuery.h"
+#include "TokenNftInfo.h"
+#include "TokenNftInfoQuery.h"
 #include "TransactionReceipt.h"
 #include "TransactionReceiptQuery.h"
 #include "TransactionRecord.h"
@@ -48,6 +50,7 @@ template class Query<ContractInfoQuery, ContractInfo>;
 template class Query<FileContentsQuery, FileContents>;
 template class Query<FileInfoQuery, FileInfo>;
 template class Query<TokenInfoQuery, TokenInfo>;
+template class Query<TokenNftInfoQuery, TokenNftInfo>;
 template class Query<TransactionReceiptQuery, TransactionReceipt>;
 template class Query<TransactionRecordQuery, TransactionRecord>;
 

--- a/sdk/main/src/TokenNftInfo.cc
+++ b/sdk/main/src/TokenNftInfo.cc
@@ -1,0 +1,91 @@
+/*-
+ *
+ * Hedera C++ SDK
+ *
+ * Copyright (C) 2020 - 2022 Hedera Hashgraph, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+#include "TokenNftInfo.h"
+#include "impl/TimestampConverter.h"
+#include "impl/Utilities.h"
+
+#include <proto/token_get_nft_info.pb.h>
+
+namespace Hedera
+{
+//-----
+TokenNftInfo TokenNftInfo::fromProtobuf(const proto::TokenNftInfo& proto)
+{
+  TokenNftInfo tokenNftInfo;
+
+  if (proto.has_nftid())
+  {
+    tokenNftInfo.mNftId = NftId::fromProtobuf(proto.nftid());
+  }
+
+  if (proto.has_accountid())
+  {
+    tokenNftInfo.mAccountId = AccountId::fromProtobuf(proto.accountid());
+  }
+
+  if (proto.has_creationtime())
+  {
+    tokenNftInfo.mCreationTime = internal::TimestampConverter::fromProtobuf(proto.creationtime());
+  }
+
+  tokenNftInfo.mMetadata = internal::Utilities::stringToByteVector(proto.metadata());
+  tokenNftInfo.mLedgerId = LedgerId(internal::Utilities::stringToByteVector(proto.ledger_id()));
+
+  if (proto.has_spender_id())
+  {
+    tokenNftInfo.mSpenderId = AccountId::fromProtobuf(proto.spender_id());
+  }
+
+  return tokenNftInfo;
+}
+
+//-----
+TokenNftInfo TokenNftInfo::fromBytes(const std::vector<std::byte>& bytes)
+{
+  proto::TokenNftInfo proto;
+  proto.ParseFromArray(bytes.data(), static_cast<int>(bytes.size()));
+  return fromProtobuf(proto);
+}
+
+//-----
+std::unique_ptr<proto::TokenNftInfo> TokenNftInfo::toProtobuf() const
+{
+  auto protoTokenNftInfo = std::make_unique<proto::TokenNftInfo>();
+  protoTokenNftInfo->set_allocated_nftid(mNftId.toProtobuf().release());
+  protoTokenNftInfo->set_allocated_accountid(mAccountId.toProtobuf().release());
+  protoTokenNftInfo->set_allocated_creationtime(internal::TimestampConverter::toProtobuf(mCreationTime));
+  protoTokenNftInfo->set_metadata(internal::Utilities::byteVectorToString(mMetadata));
+  protoTokenNftInfo->set_ledger_id(internal::Utilities::byteVectorToString(mLedgerId.toBytes()));
+
+  if (mSpenderId.has_value())
+  {
+    protoTokenNftInfo->set_allocated_spender_id(mSpenderId->toProtobuf().release());
+  }
+
+  return protoTokenNftInfo;
+}
+
+//-----
+std::vector<std::byte> TokenNftInfo::toBytes() const
+{
+  return internal::Utilities::stringToByteVector(toProtobuf()->SerializeAsString());
+}
+
+} // namespace Hedera

--- a/sdk/main/src/TokenNftInfoQuery.cc
+++ b/sdk/main/src/TokenNftInfoQuery.cc
@@ -1,0 +1,85 @@
+/*-
+ *
+ * Hedera C++ SDK
+ *
+ * Copyright (C) 2020 - 2022 Hedera Hashgraph, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+#include "TokenNftInfoQuery.h"
+#include "Client.h"
+#include "TokenNftInfo.h"
+#include "TransactionRecord.h"
+#include "TransferTransaction.h"
+#include "impl/Node.h"
+
+#include <proto/query.pb.h>
+#include <proto/query_header.pb.h>
+#include <proto/response.pb.h>
+#include <proto/token_get_nft_info.pb.h>
+
+namespace Hedera
+{
+//-----
+TokenNftInfoQuery& TokenNftInfoQuery::setNftId(const NftId& nft)
+{
+  mNftId = nft;
+  return *this;
+}
+
+//-----
+proto::Query TokenNftInfoQuery::makeRequest(const Client& client, const std::shared_ptr<internal::Node>& node) const
+{
+  proto::Query query;
+  proto::TokenGetNftInfoQuery* getTokenNftInfoQuery = query.mutable_tokengetnftinfo();
+
+  proto::QueryHeader* header = getTokenNftInfoQuery->mutable_header();
+  header->set_responsetype(proto::ANSWER_ONLY);
+
+  TransferTransaction tx = TransferTransaction()
+                             .setTransactionId(TransactionId::generate(*client.getOperatorAccountId()))
+                             .setNodeAccountIds({ node->getAccountId() })
+                             .setMaxTransactionFee(Hbar(1LL))
+                             .addHbarTransfer(*client.getOperatorAccountId(), Hbar(-1LL))
+                             .addHbarTransfer(node->getAccountId(), Hbar(1LL));
+  tx.onSelectNode(node);
+  header->set_allocated_payment(new proto::Transaction(tx.makeRequest(client, node)));
+
+  getTokenNftInfoQuery->set_allocated_nftid(mNftId.toProtobuf().release());
+
+  return query;
+}
+
+//-----
+TokenNftInfo TokenNftInfoQuery::mapResponse(const proto::Response& response) const
+{
+  return TokenNftInfo::fromProtobuf(response.tokengetnftinfo().nft());
+}
+
+//-----
+Status TokenNftInfoQuery::mapResponseStatus(const proto::Response& response) const
+{
+  return gProtobufResponseCodeToStatus.at(response.tokengetnftinfo().header().nodetransactionprecheckcode());
+}
+
+//-----
+grpc::Status TokenNftInfoQuery::submitRequest(const Client& client,
+                                              const std::chrono::system_clock::time_point& deadline,
+                                              const std::shared_ptr<internal::Node>& node,
+                                              proto::Response* response) const
+{
+  return node->submitQuery(proto::Query::QueryCase::kTokenGetNftInfo, makeRequest(client, node), deadline, response);
+}
+
+} // namespace Hedera

--- a/sdk/main/src/impl/Node.cc
+++ b/sdk/main/src/impl/Node.cc
@@ -132,6 +132,8 @@ grpc::Status Node::submitQuery(proto::Query::QueryCase funcEnum,
       return mFileStub->getFileInfo(&context, query, response);
     case proto::Query::QueryCase::kTokenGetInfo:
       return mTokenStub->getTokenInfo(&context, query, response);
+    case proto::Query::QueryCase::kTokenGetNftInfo:
+      return mTokenStub->getTokenNftInfo(&context, query, response);
     case proto::Query::QueryCase::kTransactionGetReceipt:
       return mCryptoStub->getTransactionReceipts(&context, query, response);
     case proto::Query::QueryCase::kTransactionGetRecord:

--- a/sdk/tests/integration/CMakeLists.txt
+++ b/sdk/tests/integration/CMakeLists.txt
@@ -32,6 +32,7 @@ add_executable(${TEST_PROJECT_NAME}
         TokenFeeScheduleUpdateTransactionIntegrationTests.cc
         TokenInfoQueryIntegrationTests.cc
         TokenMintTransactionIntegrationTests.cc
+        TokenNftInfoQueryIntegrationTests.cc
         TokenUpdateTransactionIntegrationTests.cc
         TransactionIntegrationTest.cc
         TransactionReceiptIntegrationTest.cc

--- a/sdk/tests/integration/TokenNftInfoQueryIntegrationTests.cc
+++ b/sdk/tests/integration/TokenNftInfoQueryIntegrationTests.cc
@@ -1,0 +1,131 @@
+/*-
+ *
+ * Hedera C++ SDK
+ *
+ * Copyright (C) 2020 - 2022 Hedera Hashgraph, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+#include "BaseIntegrationTest.h"
+#include "Client.h"
+#include "ED25519PrivateKey.h"
+#include "PrivateKey.h"
+#include "TokenCreateTransaction.h"
+#include "TokenDeleteTransaction.h"
+#include "TokenMintTransaction.h"
+#include "TokenNftInfo.h"
+#include "TokenNftInfoQuery.h"
+#include "TransactionReceipt.h"
+#include "TransactionResponse.h"
+#include "exceptions/PrecheckStatusException.h"
+#include "impl/Utilities.h"
+
+#include <gtest/gtest.h>
+
+using namespace Hedera;
+
+class TokenNftInfoQueryIntegrationTest : public BaseIntegrationTest
+{
+};
+
+//-----
+TEST_F(TokenNftInfoQueryIntegrationTest, ExecuteTokenNftInfoQuery)
+{
+  // Given
+  const std::vector<std::byte> metadata = { std::byte(0x01), std::byte(0x02), std::byte(0x03) };
+
+  std::shared_ptr<PrivateKey> operatorKey;
+  ASSERT_NO_THROW(
+    operatorKey = ED25519PrivateKey::fromString(
+      "302e020100300506032b65700422042091132178e72057a1d7528025956fe39b0b847f200ab59b2fdd367017f3087137"));
+
+  TokenId tokenId;
+  ASSERT_NO_THROW(tokenId = TokenCreateTransaction()
+                              .setTokenName("ffff")
+                              .setTokenSymbol("F")
+                              .setTokenType(TokenType::NON_FUNGIBLE_UNIQUE)
+                              .setTreasuryAccountId(AccountId(2ULL))
+                              .setAdminKey(operatorKey)
+                              .setSupplyKey(operatorKey)
+                              .execute(getTestClient())
+                              .getReceipt(getTestClient())
+                              .mTokenId.value());
+
+  std::vector<uint64_t> serialNumbers;
+  ASSERT_NO_THROW(serialNumbers = TokenMintTransaction()
+                                    .setTokenId(tokenId)
+                                    .addMetadata(metadata)
+                                    .execute(getTestClient())
+                                    .getReceipt(getTestClient())
+                                    .mSerialNumbers);
+  ASSERT_FALSE(serialNumbers.empty());
+
+  const NftId nftId(tokenId, serialNumbers.at(0));
+
+  // When
+  TokenNftInfo tokenNftInfo;
+  EXPECT_NO_THROW(tokenNftInfo = TokenNftInfoQuery().setNftId(nftId).execute(getTestClient()));
+
+  // Then
+  EXPECT_EQ(tokenNftInfo.mNftId, nftId);
+  EXPECT_EQ(tokenNftInfo.mAccountId, AccountId(2ULL));
+  EXPECT_EQ(tokenNftInfo.mMetadata, metadata);
+
+  // Clean up
+  ASSERT_NO_THROW(const TransactionReceipt txReceipt =
+                    TokenDeleteTransaction().setTokenId(tokenId).execute(getTestClient()).getReceipt(getTestClient()));
+}
+
+//-----
+TEST_F(TokenNftInfoQueryIntegrationTest, CannotQueryWithInvalidNftId)
+{
+  // Given
+  const std::vector<std::byte> metadata = { std::byte(0x01), std::byte(0x02), std::byte(0x03) };
+
+  std::shared_ptr<PrivateKey> operatorKey;
+  ASSERT_NO_THROW(
+    operatorKey = ED25519PrivateKey::fromString(
+      "302e020100300506032b65700422042091132178e72057a1d7528025956fe39b0b847f200ab59b2fdd367017f3087137"));
+
+  TokenId tokenId;
+  ASSERT_NO_THROW(tokenId = TokenCreateTransaction()
+                              .setTokenName("ffff")
+                              .setTokenSymbol("F")
+                              .setTokenType(TokenType::NON_FUNGIBLE_UNIQUE)
+                              .setTreasuryAccountId(AccountId(2ULL))
+                              .setAdminKey(operatorKey)
+                              .setSupplyKey(operatorKey)
+                              .execute(getTestClient())
+                              .getReceipt(getTestClient())
+                              .mTokenId.value());
+
+  std::vector<uint64_t> serialNumbers;
+  ASSERT_NO_THROW(serialNumbers = TokenMintTransaction()
+                                    .setTokenId(tokenId)
+                                    .addMetadata(metadata)
+                                    .execute(getTestClient())
+                                    .getReceipt(getTestClient())
+                                    .mSerialNumbers);
+  ASSERT_FALSE(serialNumbers.empty());
+
+  const NftId nftId(tokenId, serialNumbers.at(0) + 1);
+
+  // When / Then
+  EXPECT_THROW(const TokenNftInfo tokenNftInfo = TokenNftInfoQuery().setNftId(nftId).execute(getTestClient()),
+               PrecheckStatusException); // INVALID_NFT_ID
+
+  // Clean up
+  ASSERT_NO_THROW(const TransactionReceipt txReceipt =
+                    TokenDeleteTransaction().setTokenId(tokenId).execute(getTestClient()).getReceipt(getTestClient()));
+}

--- a/sdk/tests/unit/CMakeLists.txt
+++ b/sdk/tests/unit/CMakeLists.txt
@@ -73,6 +73,7 @@ add_executable(${TEST_PROJECT_NAME}
         TokenInfoUnitTests.cc
         TokenMintTransactionUnitTests.cc
         TokenNftAllowanceTest.cc
+        TokenNftInfoQueryUnitTests.cc
         TokenNftRemoveAllowanceTest.cc
         TokenNftTransferTest.cc
         TokenSupplyTypeTest.cc

--- a/sdk/tests/unit/TokenNftInfoQueryUnitTests.cc
+++ b/sdk/tests/unit/TokenNftInfoQueryUnitTests.cc
@@ -1,0 +1,46 @@
+/*-
+ *
+ * Hedera C++ SDK
+ *
+ * Copyright (C) 2020 - 2022 Hedera Hashgraph, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+#include "TokenNftInfoQuery.h"
+
+#include <gtest/gtest.h>
+
+using namespace Hedera;
+
+class TokenNftInfoQueryTest : public ::testing::Test
+{
+protected:
+  [[nodiscard]] inline const NftId& getTestNftId() const { return mTestNftId; }
+
+private:
+  const NftId mTestNftId = NftId(TokenId(1ULL, 2ULL, 3ULL), 4ULL);
+};
+
+//-----
+TEST_F(TokenNftInfoQueryTest, GetSetNftId)
+{
+  // Given
+  TokenNftInfoQuery query;
+
+  // When
+  query.setNftId(getTestNftId());
+
+  // Then
+  EXPECT_EQ(query.getNftId(), getTestNftId());
+}


### PR DESCRIPTION
**Description**:
This PR implements the APIs associated with `TokenNftInfoQuery`, which allows a user to query for info about an NFT.

**Related issue(s)**:

Fixes #412 

**Checklist**

- [x] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
