### PR TITLE
Fix `ContractExecuteTransactionIntegrationTest::CannotExecuteContractWithNoGas`

### DIFF
--- a/sdk/tests/integration/ContractExecuteTransactionIntegrationTests.cc
+++ b/sdk/tests/integration/ContractExecuteTransactionIntegrationTests.cc
@@ -34,6 +34,7 @@
 #include "PrivateKey.h"
 #include "TransactionReceipt.h"
 #include "TransactionResponse.h"
+#include "exceptions/PrecheckStatusException.h"
 #include "exceptions/ReceiptStatusException.h"
 #include "impl/Utilities.h"
 
@@ -186,7 +187,7 @@ TEST_F(ContractExecuteTransactionIntegrationTest, CannotExecuteContractWithNoGas
                    .setFunction("setMessage", ContractFunctionParameters().addString("new message"))
                    .execute(getTestClient())
                    .getReceipt(getTestClient()),
-               ReceiptStatusException); // INSUFFICIENT_GAS
+               PrecheckStatusException); // INSUFFICIENT_GAS
 
   // Clean up
   TransactionReceipt txReceipt;


### PR DESCRIPTION
**Description**:
This PR fixes a failed test caused by changes on the Hedera services side, which now checks the `gasLimit` in the transaction pre-check.

**Related issue(s)**:

Fixes #439 

**Checklist**

- [x] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
