### PR TITLE
Upgrade to `v0.41.0` of Hedera C++ Protobuf API (PR)

### DIFF
--- a/HederaApi.cmake
+++ b/HederaApi.cmake
@@ -1,5 +1,5 @@
-set(HAPI_LIBRARY_HASH "e9855ecf47fbb3f211955b6e2cfc4cb034be59578faba1cde5b3592f7f056f2c" CACHE STRING "Use the configured hash to verify the Hedera API protobuf library release")
-set(HAPI_LIBRARY_URL "https://github.com/hashgraph/hedera-protobufs-cpp/releases/download/v0.40.0/hapi-library-76f75308.tar.gz" CACHE STRING "Use the configured URL to download the Hedera API protobuf library package")
+set(HAPI_LIBRARY_HASH "29f23820c613a756f8de46e0a83971d168e39a9d3dab8a064271dc88d489ec90" CACHE STRING "Use the configured hash to verify the Hedera API protobuf library release")
+set(HAPI_LIBRARY_URL "https://github.com/hashgraph/hedera-protobufs-cpp/releases/download/v0.41.0/hapi-library-30ee152c.tar.gz" CACHE STRING "Use the configured URL to download the Hedera API protobuf library package")
 
 set(HAPI_LOCAL_LIBRARY_PATH "" CACHE STRING "Overrides the configured HAPI_LIBRARY_URL setting and instead uses the local path to retrieve the artifacts")
 

--- a/HederaApi.cmake
+++ b/HederaApi.cmake
@@ -1,4 +1,4 @@
-set(HAPI_LIBRARY_HASH "29f23820c613a756f8de46e0a83971d168e39a9d3dab8a064271dc88d489ec90" CACHE STRING "Use the configured hash to verify the Hedera API protobuf library release")
+set(HAPI_LIBRARY_HASH "29f23820c613a756f8de46e0a83971d168e39a9d3dab8a064271ec88d489ec90" CACHE STRING "Use the configured hash to verify the Hedera API protobuf library release")
 set(HAPI_LIBRARY_URL "https://github.com/hashgraph/hedera-protobufs-cpp/releases/download/v0.41.0/hapi-library-30ee152c.tar.gz" CACHE STRING "Use the configured URL to download the Hedera API protobuf library package")
 
 set(HAPI_LOCAL_LIBRARY_PATH "" CACHE STRING "Overrides the configured HAPI_LIBRARY_URL setting and instead uses the local path to retrieve the artifacts")

--- a/sdk/main/src/NftId.cc
+++ b/sdk/main/src/NftId.cc
@@ -71,12 +71,12 @@ NftId NftId::fromProtobuf(const proto::NftID& proto)
 {
   NftId nftId;
 
-  if (proto.has_tokenid())
+  if (proto.has_token_id())
   {
-    nftId.mTokenId = TokenId::fromProtobuf(proto.tokenid());
+    nftId.mTokenId = TokenId::fromProtobuf(proto.token_id());
   }
 
-  nftId.mSerialNum = static_cast<uint64_t>(proto.serialnumber());
+  nftId.mSerialNum = static_cast<uint64_t>(proto.serial_number());
   return nftId;
 }
 
@@ -84,8 +84,8 @@ NftId NftId::fromProtobuf(const proto::NftID& proto)
 std::unique_ptr<proto::NftID> NftId::toProtobuf() const
 {
   auto nftId = std::make_unique<proto::NftID>();
-  nftId->set_allocated_tokenid(mTokenId.toProtobuf().release());
-  nftId->set_serialnumber(static_cast<int64_t>(mSerialNum));
+  nftId->set_allocated_token_id(mTokenId.toProtobuf().release());
+  nftId->set_serial_number(static_cast<int64_t>(mSerialNum));
   return nftId;
 }
 

--- a/sdk/tests/unit/NftIdTest.cc
+++ b/sdk/tests/unit/NftIdTest.cc
@@ -98,11 +98,11 @@ TEST_F(NftIdTest, ProtobufNftId)
 
   // Serialize token ID and serial number
   std::unique_ptr<proto::NftID> protoNftID = nftId.toProtobuf();
-  EXPECT_EQ(TokenId::fromProtobuf(protoNftID->tokenid()), getTestTokenId());
-  EXPECT_EQ(protoNftID->serialnumber(), getTestSerialNum());
+  EXPECT_EQ(TokenId::fromProtobuf(protoNftID->token_id()), getTestTokenId());
+  EXPECT_EQ(protoNftID->serial_number(), getTestSerialNum());
 
   // Adjust protobuf fields
-  protoNftID->set_serialnumber(static_cast<int64_t>(getTestSerialNum() - 1ULL));
+  protoNftID->set_serial_number(static_cast<int64_t>(getTestSerialNum() - 1ULL));
 
   // Deserialize token ID and serial number
   nftId = NftId::fromProtobuf(*protoNftID);


### PR DESCRIPTION
**Description**:

This PR updates the CMake to pull [v0.41.0](https://github.com/hashgraph/hedera-protobufs-cpp/releases/tag/v0.41.0) of [Hedera C++ Protobuf API](https://github.com/hashgraph/hedera-protobufs-cpp).

**Related issue(s)**:

**Fixes:** https://github.com/hashgraph/hedera-sdk-cpp/issues/466

**Notes for reviewer**:

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
