### PR TITLE
Implement `NetworkVersionInfoQuery`

### DIFF
--- a/sdk/main/CMakeLists.txt
+++ b/sdk/main/CMakeLists.txt
@@ -64,6 +64,8 @@ add_library(${PROJECT_NAME} STATIC
         src/LedgerId.cc
         src/Mnemonic.cc
         src/MnemonicBIP39.cc
+        src/NetworkVersionInfo.cc
+        src/NetworkVersionInfoQuery.cc
         src/NftId.cc
         src/PrivateKey.cc
         src/PublicKey.cc
@@ -74,6 +76,7 @@ add_library(${PROJECT_NAME} STATIC
         src/ScheduleInfo.cc
         src/ScheduleInfoQuery.cc
         src/ScheduleSignTransaction.cc
+        src/SemanticVersion.cc
         src/StakingInfo.cc
         src/Status.cc
         src/SubscriptionHandle.cc

--- a/sdk/main/include/NetworkVersionInfo.h
+++ b/sdk/main/include/NetworkVersionInfo.h
@@ -1,0 +1,95 @@
+/*-
+ *
+ * Hedera C++ SDK
+ *
+ * Copyright (C) 2020 - 2022 Hedera Hashgraph, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+#ifndef HEDERA_SDK_CPP_NETWORK_VERSION_INFO_H_
+#define HEDERA_SDK_CPP_NETWORK_VERSION_INFO_H_
+
+#include "SemanticVersion.h"
+
+#include <cstddef>
+#include <memory>
+#include <vector>
+
+namespace proto
+{
+class NetworkGetVersionInfoResponse;
+}
+
+namespace Hedera
+{
+/**
+ * Contains information about the network's version.
+ */
+class NetworkVersionInfo
+{
+public:
+  NetworkVersionInfo() = default;
+
+  /**
+   * Construct from a protobuf schema SemanticVersion and a Hedera services SemanticVersion.
+   *
+   * @param hapi   The SemanticVersion of the protobuf schema.
+   * @param hedera The SemanticVersion of the Hedera services.
+   */
+  NetworkVersionInfo(const SemanticVersion& hapi, const SemanticVersion& hedera);
+
+  /**
+   * Construct a NetworkVersionInfo object from a NetworkGetVersionInfoResponse protobuf object.
+   *
+   * @param proto The NetworkGetVersionInfoResponse protobuf object from which to construct a NetworkVersionInfo object.
+   * @return The constructed NetworkVersionInfo object.
+   */
+  [[nodiscard]] static NetworkVersionInfo fromProtobuf(const proto::NetworkGetVersionInfoResponse& proto);
+
+  /**
+   * Construct a NetworkVersionInfo object from a byte array.
+   *
+   * @param bytes The byte array from which to construct a NetworkVersionInfo object.
+   * @return The constructed NetworkVersionInfo object.
+   */
+  [[nodiscard]] static NetworkVersionInfo fromBytes(const std::vector<std::byte>& bytes);
+
+  /**
+   * Construct a NetworkGetVersionInfoResponse protobuf object from this NetworkVersionInfo object.
+   *
+   * @return A pointer to the created NetworkVersionInfo protobuf object.
+   */
+  [[nodiscard]] std::unique_ptr<proto::NetworkGetVersionInfoResponse> toProtobuf() const;
+
+  /**
+   * Construct a representative byte array from this NetworkVersionInfo object.
+   *
+   * @return The byte array representing this NetworkVersionInfo object.
+   */
+  [[nodiscard]] std::vector<std::byte> toBytes() const;
+
+  /**
+   * The version of the protobuf schema in use by the network.
+   */
+  SemanticVersion mProtobufVersion;
+
+  /**
+   * The version of the Hedera services in use by the network.
+   */
+  SemanticVersion mServicesVersion;
+};
+
+} // namespace Hedera
+
+#endif // HEDERA_SDK_CPP_NETWORK_VERSION_INFO_H_

--- a/sdk/main/include/NetworkVersionInfoQuery.h
+++ b/sdk/main/include/NetworkVersionInfoQuery.h
@@ -1,0 +1,83 @@
+/*-
+ *
+ * Hedera C++ SDK
+ *
+ * Copyright (C) 2020 - 2022 Hedera Hashgraph, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+#ifndef HEDERA_SDK_CPP_NETWORK_VERSION_INFO_QUERY_H_
+#define HEDERA_SDK_CPP_NETWORK_VERSION_INFO_QUERY_H_
+
+#include "Query.h"
+
+namespace Hedera
+{
+class NetworkVersionInfo;
+}
+
+namespace Hedera
+{
+/**
+ * Get the deployed versions of Hedera Services and the HAPI proto in semantic version format.
+ */
+class NetworkVersionInfoQuery : public Query<NetworkVersionInfoQuery, NetworkVersionInfo>
+{
+private:
+  /**
+   * Derived from Executable. Construct a Query protobuf object from this NetworkVersionInfoQuery object.
+   *
+   * @param client The Client trying to construct this NetworkVersionInfoQuery.
+   * @param node   The Node to which this NetworkVersionInfoQuery will be sent.
+   * @return A Query protobuf object filled with this NetworkVersionInfoQuery object's data.
+   */
+  [[nodiscard]] proto::Query makeRequest(const Client& client,
+                                         const std::shared_ptr<internal::Node>& node) const override;
+
+  /**
+   * Derived from Executable. Construct a NetworkVersionInfo object from a Response protobuf object.
+   *
+   * @param response The Response protobuf object from which to construct a NetworkVersionInfo object.
+   * @return A NetworkVersionInfo object filled with the Response protobuf object's data.
+   */
+  [[nodiscard]] NetworkVersionInfo mapResponse(const proto::Response& response) const override;
+
+  /**
+   * Derived from Executable. Get the status response code for a submitted NetworkVersionInfoQuery from a Response
+   * protobuf object.
+   *
+   * @param response The Response protobuf object from which to grab the NetworkVersionInfoQuery status response code.
+   * @return The NetworkVersionInfoQuery status response code of the input Response protobuf object.
+   */
+  [[nodiscard]] Status mapResponseStatus(const proto::Response& response) const override;
+
+  /**
+   * Derived from Executable. Submit this NetworkVersionInfoQuery to a Node.
+   *
+   * @param client   The Client submitting this NetworkVersionInfoQuery.
+   * @param deadline The deadline for submitting this NetworkVersionInfoQuery.
+   * @param node     Pointer to the Node to which this NetworkVersionInfoQuery should be submitted.
+   * @param response Pointer to the Response protobuf object that gRPC should populate with the response information
+   *                 from the gRPC server.
+   * @return The gRPC status of the submission.
+   */
+  [[nodiscard]] grpc::Status submitRequest(const Client& client,
+                                           const std::chrono::system_clock::time_point& deadline,
+                                           const std::shared_ptr<internal::Node>& node,
+                                           proto::Response* response) const override;
+};
+
+} // namespace Hedera
+
+#endif // HEDERA_SDK_CPP_NETWORK_VERSION_INFO_QUERY_H_

--- a/sdk/main/include/SemanticVersion.h
+++ b/sdk/main/include/SemanticVersion.h
@@ -1,0 +1,123 @@
+/*-
+ *
+ * Hedera C++ SDK
+ *
+ * Copyright (C) 2020 - 2022 Hedera Hashgraph, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+#ifndef HEDERA_SDK_CPP_SEMANTIC_VERSION_H_
+#define HEDERA_SDK_CPP_SEMANTIC_VERSION_H_
+
+#include <cstddef>
+#include <memory>
+#include <string>
+#include <string_view>
+#include <vector>
+
+namespace proto
+{
+class SemanticVersion;
+}
+
+namespace Hedera
+{
+/**
+ * Hedera follows semantic versioning for both the HAPI protobufs and the Services software. This type allows the
+ * getVersionInfo query in the NetworkService to return the deployed versions of both protobufs and software on the node
+ * answering the query.
+ */
+class SemanticVersion
+{
+public:
+  SemanticVersion() = default;
+
+  /**
+   * Construct from a major, minor, and patch number.
+   *
+   * @param major The major number.
+   * @param minor The minor number.
+   * @param patch The patch number.
+   * @param pre   The pre-release version number.
+   * @param build The build metadata.
+   */
+  SemanticVersion(int major, int minor, int patch, std::string_view pre = "", std::string_view build = "");
+
+  /**
+   * Construct a SemanticVersion object from a SemanticVersion protobuf object.
+   *
+   * @param proto The SemanticVersion protobuf object from which to construct a SemanticVersion object.
+   * @return The constructed SemanticVersion object.
+   */
+  [[nodiscard]] static SemanticVersion fromProtobuf(const proto::SemanticVersion& proto);
+
+  /**
+   * Construct a SemanticVersion object from a byte array.
+   *
+   * @param bytes The byte array representing a SemanticVersion object.
+   * @return The constructed SemanticVersion object.
+   */
+  [[nodiscard]] static SemanticVersion fromBytes(const std::vector<std::byte>& bytes);
+
+  /**
+   * Construct a SemanticVersion protobuf object from this SemanticVersion object.
+   *
+   * @return A pointer to the created SemanticVersion protobuf object.
+   */
+  [[nodiscard]] std::unique_ptr<proto::SemanticVersion> toProtobuf() const;
+
+  /**
+   * Construct a representative byte array from this SemanticVersion object.
+   *
+   * @return The byte array representing this SemanticVersion object.
+   */
+  [[nodiscard]] std::vector<std::byte> toBytes() const;
+
+  /**
+   * Construct a string representation of this SemanticVersion object.
+   *
+   * @return The string representation of this SemanticVersion object.
+   */
+  [[nodiscard]] std::string toString() const;
+
+  /**
+   * Major number. Increases with incompatible API changes.
+   */
+  int mMajor = 0;
+
+  /**
+   * Minor number. Increases with backwards-compatible new functionality.
+   */
+  int mMinor = 0;
+
+  /**
+   * Patch number. Increases with backwards-compatible bug fixes.
+   */
+  int mPatch = 0;
+
+  /**
+   * Pre-release version. This may be denoted by appending a hyphen and a series of dot-separated identifiers.
+   */
+  std::string mPre;
+
+  /**
+   * Build metadata. This may be denoted by appending a plus sign and a series of dot-separated identifiers immediately
+   * following the patch or pre-release version.
+   */
+  std::string mBuild;
+};
+
+} // namespace Hedera
+
+#endif // HEDERA_SDK_CPP_SEMANTIC_VERSION_H_

--- a/sdk/main/include/SemanticVersion.h
+++ b/sdk/main/include/SemanticVersion.h
@@ -55,6 +55,14 @@ public:
   SemanticVersion(int major, int minor, int patch, std::string_view pre = "", std::string_view build = "");
 
   /**
+   * Compare this SemanticVersion to another SemanticVersion and determine if they represent the same semantic version.
+   *
+   * @param other The other SemanticVersion with which to compare this SemanticVersion.
+   * @return \c TRUE if this SemanticVersion is the same as the input SemanticVersion, otherwise \c FALSE.
+   */
+  bool operator==(const SemanticVersion& other) const;
+
+  /**
    * Construct a SemanticVersion object from a SemanticVersion protobuf object.
    *
    * @param proto The SemanticVersion protobuf object from which to construct a SemanticVersion object.

--- a/sdk/main/include/TransferTransaction.h
+++ b/sdk/main/include/TransferTransaction.h
@@ -203,6 +203,7 @@ private:
   friend class ContractInfoQuery;
   friend class FileContentsQuery;
   friend class FileInfoQuery;
+  friend class NetworkVersionInfoQuery;
   friend class ScheduleInfoQuery;
   friend class TokenInfoQuery;
   friend class TokenNftInfoQuery;

--- a/sdk/main/include/impl/Node.h
+++ b/sdk/main/include/impl/Node.h
@@ -23,6 +23,7 @@
 #include <proto/consensus_service.grpc.pb.h>
 #include <proto/crypto_service.grpc.pb.h>
 #include <proto/file_service.grpc.pb.h>
+#include <proto/network_service.grpc.pb.h>
 #include <proto/schedule_service.grpc.pb.h>
 #include <proto/smart_contract_service.grpc.pb.h>
 #include <proto/token_service.grpc.pb.h>
@@ -195,6 +196,11 @@ private:
    * Pointer to the gRPC stub used to communicate with the file service living on the remote node.
    */
   std::unique_ptr<proto::FileService::Stub> mFileStub = nullptr;
+
+  /**
+   * Pointer to the gRPC stub used to communicate with the network service living on the remote node.
+   */
+  std::unique_ptr<proto::NetworkService::Stub> mNetworkStub = nullptr;
 
   /**
    * Pointer to the gRPC stub used to communicate with the schedule service living on the remote node.

--- a/sdk/main/src/Executable.cc
+++ b/sdk/main/src/Executable.cc
@@ -47,6 +47,8 @@
 #include "FileInfo.h"
 #include "FileInfoQuery.h"
 #include "FileUpdateTransaction.h"
+#include "NetworkVersionInfo.h"
+#include "NetworkVersionInfoQuery.h"
 #include "ScheduleCreateTransaction.h"
 #include "ScheduleDeleteTransaction.h"
 #include "ScheduleInfo.h"
@@ -374,6 +376,7 @@ template class Executable<FileCreateTransaction, proto::Transaction, proto::Tran
 template class Executable<FileDeleteTransaction, proto::Transaction, proto::TransactionResponse, TransactionResponse>;
 template class Executable<FileInfoQuery, proto::Query, proto::Response, FileInfo>;
 template class Executable<FileUpdateTransaction, proto::Transaction, proto::TransactionResponse, TransactionResponse>;
+template class Executable<NetworkVersionInfoQuery, proto::Query, proto::Response, NetworkVersionInfo>;
 template class Executable<ScheduleCreateTransaction,
                           proto::Transaction,
                           proto::TransactionResponse,

--- a/sdk/main/src/NetworkVersionInfo.cc
+++ b/sdk/main/src/NetworkVersionInfo.cc
@@ -1,0 +1,64 @@
+/*-
+ *
+ * Hedera C++ SDK
+ *
+ * Copyright (C) 2020 - 2022 Hedera Hashgraph, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+#include "NetworkVersionInfo.h"
+#include "impl/Utilities.h"
+
+#include <proto/network_get_version_info.pb.h>
+
+namespace Hedera
+{
+//-----
+NetworkVersionInfo::NetworkVersionInfo(const SemanticVersion& hapi, const SemanticVersion& hedera)
+  : mProtobufVersion(hapi)
+  , mServicesVersion(hedera)
+{
+}
+
+//-----
+NetworkVersionInfo NetworkVersionInfo::fromProtobuf(const proto::NetworkGetVersionInfoResponse& proto)
+{
+  return NetworkVersionInfo(SemanticVersion::fromProtobuf(proto.hapiprotoversion()),
+                            SemanticVersion::fromProtobuf(proto.hederaservicesversion()));
+}
+
+//-----
+NetworkVersionInfo NetworkVersionInfo::fromBytes(const std::vector<std::byte>& bytes)
+{
+  proto::NetworkGetVersionInfoResponse networkGetVersionInfoResponse;
+  networkGetVersionInfoResponse.ParseFromArray(bytes.data(), static_cast<int>(bytes.size()));
+  return fromProtobuf(networkGetVersionInfoResponse);
+}
+
+//-----
+std::unique_ptr<proto::NetworkGetVersionInfoResponse> NetworkVersionInfo::toProtobuf() const
+{
+  auto proto = std::make_unique<proto::NetworkGetVersionInfoResponse>();
+  proto->set_allocated_hapiprotoversion(mProtobufVersion.toProtobuf().release());
+  proto->set_allocated_hederaservicesversion(mServicesVersion.toProtobuf().release());
+  return proto;
+}
+
+//-----
+std::vector<std::byte> NetworkVersionInfo::toBytes() const
+{
+  return internal::Utilities::stringToByteVector(toProtobuf()->SerializeAsString());
+}
+
+} // namespace Hedera

--- a/sdk/main/src/NetworkVersionInfoQuery.cc
+++ b/sdk/main/src/NetworkVersionInfoQuery.cc
@@ -1,0 +1,78 @@
+/*-
+ *
+ * Hedera C++ SDK
+ *
+ * Copyright (C) 2020 - 2022 Hedera Hashgraph, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+#include "NetworkVersionInfoQuery.h"
+#include "Client.h"
+#include "NetworkVersionInfo.h"
+#include "Status.h"
+#include "TransferTransaction.h"
+#include "impl/Node.h"
+
+#include <proto/network_get_version_info.pb.h>
+#include <proto/query.pb.h>
+#include <proto/query_header.pb.h>
+#include <proto/response.pb.h>
+
+namespace Hedera
+{
+//-----
+proto::Query NetworkVersionInfoQuery::makeRequest(const Client& client,
+                                                  const std::shared_ptr<internal::Node>& node) const
+{
+  proto::Query query;
+  proto::NetworkGetVersionInfoQuery* getNetworkVersionInfoQuery = query.mutable_networkgetversioninfo();
+
+  proto::QueryHeader* header = getNetworkVersionInfoQuery->mutable_header();
+  header->set_responsetype(proto::ANSWER_ONLY);
+
+  TransferTransaction tx = TransferTransaction()
+                             .setTransactionId(TransactionId::generate(*client.getOperatorAccountId()))
+                             .setNodeAccountIds({ node->getAccountId() })
+                             .setMaxTransactionFee(Hbar(1LL))
+                             .addHbarTransfer(*client.getOperatorAccountId(), Hbar(-1LL))
+                             .addHbarTransfer(node->getAccountId(), Hbar(1LL));
+  tx.onSelectNode(node);
+  header->set_allocated_payment(new proto::Transaction(tx.makeRequest(client, node)));
+
+  return query;
+}
+
+//-----
+NetworkVersionInfo NetworkVersionInfoQuery::mapResponse(const proto::Response& response) const
+{
+  return NetworkVersionInfo::fromProtobuf(response.networkgetversioninfo());
+}
+
+//-----
+Status NetworkVersionInfoQuery::mapResponseStatus(const proto::Response& response) const
+{
+  return gProtobufResponseCodeToStatus.at(response.networkgetversioninfo().header().nodetransactionprecheckcode());
+}
+
+//-----
+grpc::Status NetworkVersionInfoQuery::submitRequest(const Client& client,
+                                                    const std::chrono::system_clock::time_point& deadline,
+                                                    const std::shared_ptr<internal::Node>& node,
+                                                    proto::Response* response) const
+{
+  return node->submitQuery(
+    proto::Query::QueryCase::kNetworkGetVersionInfo, makeRequest(client, node), deadline, response);
+}
+
+} // namespace Hedera

--- a/sdk/main/src/Query.cc
+++ b/sdk/main/src/Query.cc
@@ -29,6 +29,8 @@
 #include "FileContentsQuery.h"
 #include "FileInfo.h"
 #include "FileInfoQuery.h"
+#include "NetworkVersionInfo.h"
+#include "NetworkVersionInfoQuery.h"
 #include "ScheduleInfo.h"
 #include "ScheduleInfoQuery.h"
 #include "TokenInfo.h"
@@ -53,6 +55,7 @@ template class Query<ContractCallQuery, ContractFunctionResult>;
 template class Query<ContractInfoQuery, ContractInfo>;
 template class Query<FileContentsQuery, FileContents>;
 template class Query<FileInfoQuery, FileInfo>;
+template class Query<NetworkVersionInfoQuery, NetworkVersionInfo>;
 template class Query<ScheduleInfoQuery, ScheduleInfo>;
 template class Query<TokenInfoQuery, TokenInfo>;
 template class Query<TokenNftInfoQuery, TokenNftInfo>;

--- a/sdk/main/src/SemanticVersion.cc
+++ b/sdk/main/src/SemanticVersion.cc
@@ -35,9 +35,16 @@ SemanticVersion::SemanticVersion(int major, int minor, int patch, std::string_vi
 }
 
 //-----
+bool SemanticVersion::operator==(const SemanticVersion& other) const
+{
+  return (mMajor == other.mMajor) && (mMinor == other.mMinor) && (mPatch == other.mPatch) && (mPre == other.mPre) &&
+         (mBuild == other.mBuild);
+}
+
+//-----
 SemanticVersion SemanticVersion::fromProtobuf(const proto::SemanticVersion& proto)
 {
-  return SemanticVersion(proto.major(), proto.minor(), proto.patch(), proto.pre(), proto.build());
+  return { proto.major(), proto.minor(), proto.patch(), proto.pre(), proto.build() };
 }
 
 //-----

--- a/sdk/main/src/SemanticVersion.cc
+++ b/sdk/main/src/SemanticVersion.cc
@@ -1,0 +1,87 @@
+/*-
+ *
+ * Hedera C++ SDK
+ *
+ * Copyright (C) 2020 - 2022 Hedera Hashgraph, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+#include "SemanticVersion.h"
+#include "impl/Utilities.h"
+
+#include <proto/basic_types.pb.h>
+
+namespace Hedera
+{
+//-----
+SemanticVersion::SemanticVersion(int major, int minor, int patch, std::string_view pre, std::string_view build)
+  : mMajor(major)
+  , mMinor(minor)
+  , mPatch(patch)
+  , mPre(pre)
+  , mBuild(build)
+{
+}
+
+//-----
+SemanticVersion SemanticVersion::fromProtobuf(const proto::SemanticVersion& proto)
+{
+  return SemanticVersion(proto.major(), proto.minor(), proto.patch(), proto.pre(), proto.build());
+}
+
+//-----
+SemanticVersion SemanticVersion::fromBytes(const std::vector<std::byte>& bytes)
+{
+  proto::SemanticVersion semanticVersion;
+  semanticVersion.ParseFromArray(bytes.data(), static_cast<int>(bytes.size()));
+  return fromProtobuf(semanticVersion);
+}
+
+//-----
+std::unique_ptr<proto::SemanticVersion> SemanticVersion::toProtobuf() const
+{
+  auto proto = std::make_unique<proto::SemanticVersion>();
+  proto->set_major(mMajor);
+  proto->set_minor(mMinor);
+  proto->set_patch(mPatch);
+  proto->set_pre(mPre);
+  proto->set_build(mBuild);
+  return proto;
+}
+
+//-----
+std::vector<std::byte> SemanticVersion::toBytes() const
+{
+  return internal::Utilities::stringToByteVector(toProtobuf()->SerializeAsString());
+}
+
+//-----
+std::string SemanticVersion::toString() const
+{
+  std::string str = std::to_string(mMajor) + '.' + std::to_string(mMinor) + '.' + std::to_string(mPatch);
+
+  if (!mPre.empty())
+  {
+    str += '-' + mPre;
+  }
+
+  if (!mBuild.empty())
+  {
+    str += '+' + mBuild;
+  }
+
+  return str;
+}
+
+} // namespace Hedera

--- a/sdk/main/src/impl/Node.cc
+++ b/sdk/main/src/impl/Node.cc
@@ -76,6 +76,16 @@ void Node::shutdown()
     mCryptoStub.reset();
   }
 
+  if (mFileStub)
+  {
+    mFileStub.reset();
+  }
+
+  if (mNetworkStub)
+  {
+    mNetworkStub.reset();
+  }
+
   if (mScheduleStub)
   {
     mScheduleStub.reset();
@@ -84,11 +94,6 @@ void Node::shutdown()
   if (mSmartContractStub)
   {
     mSmartContractStub.reset();
-  }
-
-  if (mFileStub)
-  {
-    mFileStub.reset();
   }
 
   if (mTokenStub)
@@ -141,6 +146,8 @@ grpc::Status Node::submitQuery(proto::Query::QueryCase funcEnum,
     case proto::Query::QueryCase::kFileGetContents:
       return mFileStub->getFileContent(&context, query, response);
     case proto::Query::QueryCase::kFileGetInfo:
+      return mFileStub->getFileInfo(&context, query, response);
+    case proto::Query::QueryCase::kNetworkGetVersionInfo:
       return mFileStub->getFileInfo(&context, query, response);
     case proto::Query::QueryCase::kScheduleGetInfo:
       return mScheduleStub->getScheduleInfo(&context, query, response);
@@ -368,6 +375,7 @@ bool Node::initializeChannel(const std::chrono::system_clock::time_point& deadli
         mConsensusStub = proto::ConsensusService::NewStub(mChannel);
         mCryptoStub = proto::CryptoService::NewStub(mChannel);
         mFileStub = proto::FileService::NewStub(mChannel);
+        mNetworkStub = proto::NetworkService::NewStub(mChannel);
         mScheduleStub = proto::ScheduleService::NewStub(mChannel);
         mSmartContractStub = proto::SmartContractService::NewStub(mChannel);
         mTokenStub = proto::TokenService::NewStub(mChannel);

--- a/sdk/tests/integration/CMakeLists.txt
+++ b/sdk/tests/integration/CMakeLists.txt
@@ -24,6 +24,7 @@ add_executable(${TEST_PROJECT_NAME}
         FileInfoQueryIntegrationTests.cc
         FileUpdateTransactionIntegrationTests.cc
         JSONIntegrationTest.cc
+        NetworkVersionInfoQueryIntegrationTests.cc
         ScheduleCreateTransactionIntegrationTests.cc
         ScheduleDeleteTransactionIntegrationTests.cc
         ScheduleInfoQueryIntegrationTests.cc

--- a/sdk/tests/integration/NetworkVersionInfoQueryIntegrationTests.cc
+++ b/sdk/tests/integration/NetworkVersionInfoQueryIntegrationTests.cc
@@ -1,0 +1,38 @@
+/*-
+ *
+ * Hedera C++ SDK
+ *
+ * Copyright (C) 2020 - 2022 Hedera Hashgraph, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+#include "BaseIntegrationTest.h"
+#include "NetworkVersionInfo.h"
+#include "NetworkVersionInfoQuery.h"
+#include "TransactionReceipt.h"
+
+#include <gtest/gtest.h>
+
+using namespace Hedera;
+
+class NetworkVersionInfoQueryIntegrationTest : public BaseIntegrationTest
+{
+};
+
+//-----
+TEST_F(NetworkVersionInfoQueryIntegrationTest, ExecuteNetworkVersionInfoQuery)
+{
+  // Given / When / Then
+  EXPECT_NO_THROW(const NetworkVersionInfo networkVersionInfo = NetworkVersionInfoQuery().execute(getTestClient()));
+}

--- a/sdk/tests/unit/CMakeLists.txt
+++ b/sdk/tests/unit/CMakeLists.txt
@@ -58,6 +58,7 @@ add_executable(${TEST_PROJECT_NAME}
         HbarTransferTest.cc
         KeyListTest.cc
         LedgerIdTest.cc
+        NetworkVersionInfoUnitTests.cc
         NftIdTest.cc
         NodeAddressTest.cc
         ScheduleCreateTransactionUnitTests.cc
@@ -66,6 +67,7 @@ add_executable(${TEST_PROJECT_NAME}
         ScheduleInfoQueryUnitTests.cc
         ScheduleInfoUnitTests.cc
         ScheduleSignTransactionUnitTests.cc
+        SemanticVersionUnitTests.cc
         StakingInfoTest.cc
         TokenAllowanceTest.cc
         TokenAssociateTransactionUnitTests.cc

--- a/sdk/tests/unit/NetworkVersionInfoUnitTests.cc
+++ b/sdk/tests/unit/NetworkVersionInfoUnitTests.cc
@@ -1,0 +1,118 @@
+/*-
+ *
+ * Hedera C++ SDK
+ *
+ * Copyright (C) 2020 - 2022 Hedera Hashgraph, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+#include "NetworkVersionInfo.h"
+#include "SemanticVersion.h"
+#include "impl/Utilities.h"
+
+#include <gtest/gtest.h>
+#include <proto/network_get_version_info.pb.h>
+
+using namespace Hedera;
+
+class NetworkVersionInfoTest : public ::testing::Test
+{
+protected:
+  [[nodiscard]] inline const SemanticVersion& getTestHapiVersion() const { return mTestHapiVersion; }
+  [[nodiscard]] inline const SemanticVersion& getTestServicesVersion() const { return mTestServicesVersion; }
+
+private:
+  const SemanticVersion mTestHapiVersion = SemanticVersion(1, 2, 3);
+  const SemanticVersion mTestServicesVersion = SemanticVersion(4, 5, 6);
+};
+
+//-----
+TEST_F(NetworkVersionInfoTest, ConstructWithValues)
+{
+  // Given / When
+  const NetworkVersionInfo networkVersionInfo(getTestHapiVersion(), getTestServicesVersion());
+
+  // Then
+  EXPECT_EQ(networkVersionInfo.mProtobufVersion, getTestHapiVersion());
+  EXPECT_EQ(networkVersionInfo.mServicesVersion, getTestServicesVersion());
+}
+
+//-----
+TEST_F(NetworkVersionInfoTest, FromProtobuf)
+{
+  // Given
+  proto::NetworkGetVersionInfoResponse networkGetVersionInfoResponse;
+  networkGetVersionInfoResponse.set_allocated_hapiprotoversion(getTestHapiVersion().toProtobuf().release());
+  networkGetVersionInfoResponse.set_allocated_hederaservicesversion(getTestServicesVersion().toProtobuf().release());
+
+  // When
+  const NetworkVersionInfo networkVersionInfo = NetworkVersionInfo::fromProtobuf(networkGetVersionInfoResponse);
+
+  // Then
+  EXPECT_EQ(networkVersionInfo.mProtobufVersion, getTestHapiVersion());
+  EXPECT_EQ(networkVersionInfo.mServicesVersion, getTestServicesVersion());
+}
+
+//-----
+TEST_F(NetworkVersionInfoTest, FromBytes)
+{
+  // Given
+  proto::NetworkGetVersionInfoResponse networkGetVersionInfoResponse;
+  networkGetVersionInfoResponse.set_allocated_hapiprotoversion(getTestHapiVersion().toProtobuf().release());
+  networkGetVersionInfoResponse.set_allocated_hederaservicesversion(getTestServicesVersion().toProtobuf().release());
+
+  // When
+  const NetworkVersionInfo networkVersionInfo = NetworkVersionInfo::fromBytes(
+    internal::Utilities::stringToByteVector(networkGetVersionInfoResponse.SerializeAsString()));
+
+  // Then
+  EXPECT_EQ(networkVersionInfo.mProtobufVersion, getTestHapiVersion());
+  EXPECT_EQ(networkVersionInfo.mServicesVersion, getTestServicesVersion());
+}
+
+//-----
+TEST_F(NetworkVersionInfoTest, ToProtobuf)
+{
+  // Given
+  const NetworkVersionInfo networkVersionInfo(getTestHapiVersion(), getTestServicesVersion());
+
+  // When
+  const std::unique_ptr<proto::NetworkGetVersionInfoResponse> protoNetworkVersionInfo = networkVersionInfo.toProtobuf();
+
+  // Then
+  EXPECT_EQ(protoNetworkVersionInfo->hapiprotoversion().major(), getTestHapiVersion().mMajor);
+  EXPECT_EQ(protoNetworkVersionInfo->hapiprotoversion().minor(), getTestHapiVersion().mMinor);
+  EXPECT_EQ(protoNetworkVersionInfo->hapiprotoversion().patch(), getTestHapiVersion().mPatch);
+  EXPECT_EQ(protoNetworkVersionInfo->hapiprotoversion().pre(), getTestHapiVersion().mPre);
+  EXPECT_EQ(protoNetworkVersionInfo->hapiprotoversion().build(), getTestHapiVersion().mBuild);
+
+  EXPECT_EQ(protoNetworkVersionInfo->hederaservicesversion().major(), getTestServicesVersion().mMajor);
+  EXPECT_EQ(protoNetworkVersionInfo->hederaservicesversion().minor(), getTestServicesVersion().mMinor);
+  EXPECT_EQ(protoNetworkVersionInfo->hederaservicesversion().patch(), getTestServicesVersion().mPatch);
+  EXPECT_EQ(protoNetworkVersionInfo->hederaservicesversion().pre(), getTestServicesVersion().mPre);
+  EXPECT_EQ(protoNetworkVersionInfo->hederaservicesversion().build(), getTestServicesVersion().mBuild);
+}
+
+//-----
+TEST_F(NetworkVersionInfoTest, ToBytes)
+{
+  // Given
+  const NetworkVersionInfo networkVersionInfo(getTestHapiVersion(), getTestServicesVersion());
+
+  // When
+  const std::vector<std::byte> bytes = networkVersionInfo.toBytes();
+
+  // Then
+  EXPECT_EQ(bytes, internal::Utilities::stringToByteVector(networkVersionInfo.toProtobuf()->SerializeAsString()));
+}

--- a/sdk/tests/unit/SemanticVersionUnitTests.cc
+++ b/sdk/tests/unit/SemanticVersionUnitTests.cc
@@ -1,0 +1,136 @@
+/*-
+ *
+ * Hedera C++ SDK
+ *
+ * Copyright (C) 2020 - 2022 Hedera Hashgraph, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+#include "SemanticVersion.h"
+#include "impl/Utilities.h"
+
+#include <gtest/gtest.h>
+#include <proto/basic_types.pb.h>
+#include <string>
+
+using namespace Hedera;
+
+class SemanticVersionTest : public ::testing::Test
+{
+protected:
+  [[nodiscard]] inline const int& getTestMajor() const { return mTestMajor; }
+  [[nodiscard]] inline const int& getTestMinor() const { return mTestMinor; }
+  [[nodiscard]] inline const int& getTestPatch() const { return mTestPatch; }
+  [[nodiscard]] inline const std::string& getTestPrerelease() const { return mTestPrerelease; }
+  [[nodiscard]] inline const std::string& getTestBuildMetadata() const { return mTestBuildMetadata; }
+
+private:
+  const int mTestMajor = 1;
+  const int mTestMinor = 2;
+  const int mTestPatch = 3;
+  const std::string mTestPrerelease = "test pre-release";
+  const std::string mTestBuildMetadata = "test build metadata";
+};
+
+//-----
+TEST_F(SemanticVersionTest, ConstructWithValues)
+{
+  // Given / When
+  const SemanticVersion semanticVersion(
+    getTestMajor(), getTestMinor(), getTestPatch(), getTestPrerelease(), getTestBuildMetadata());
+
+  // Then
+  EXPECT_EQ(semanticVersion.mMajor, getTestMajor());
+  EXPECT_EQ(semanticVersion.mMinor, getTestMinor());
+  EXPECT_EQ(semanticVersion.mPatch, getTestPatch());
+  EXPECT_EQ(semanticVersion.mPre, getTestPrerelease());
+  EXPECT_EQ(semanticVersion.mBuild, getTestBuildMetadata());
+}
+
+//-----
+TEST_F(SemanticVersionTest, FromProtobuf)
+{
+  // Given
+  proto::SemanticVersion protoSemanticVersion;
+  protoSemanticVersion.set_major(getTestMajor());
+  protoSemanticVersion.set_minor(getTestMinor());
+  protoSemanticVersion.set_patch(getTestPatch());
+  protoSemanticVersion.set_pre(getTestPrerelease());
+  protoSemanticVersion.set_build(getTestBuildMetadata());
+
+  // When
+  const SemanticVersion semanticVersion = SemanticVersion::fromProtobuf(protoSemanticVersion);
+
+  // Then
+  EXPECT_EQ(semanticVersion.mMajor, getTestMajor());
+  EXPECT_EQ(semanticVersion.mMinor, getTestMinor());
+  EXPECT_EQ(semanticVersion.mPatch, getTestPatch());
+  EXPECT_EQ(semanticVersion.mPre, getTestPrerelease());
+  EXPECT_EQ(semanticVersion.mBuild, getTestBuildMetadata());
+}
+
+//-----
+TEST_F(SemanticVersionTest, FromBytes)
+{
+  // Given
+  proto::SemanticVersion protoSemanticVersion;
+  protoSemanticVersion.set_major(getTestMajor());
+  protoSemanticVersion.set_minor(getTestMinor());
+  protoSemanticVersion.set_patch(getTestPatch());
+  protoSemanticVersion.set_pre(getTestPrerelease());
+  protoSemanticVersion.set_build(getTestBuildMetadata());
+
+  // When
+  const SemanticVersion semanticVersion =
+    SemanticVersion::fromBytes(internal::Utilities::stringToByteVector(protoSemanticVersion.SerializeAsString()));
+
+  // Then
+  EXPECT_EQ(semanticVersion.mMajor, getTestMajor());
+  EXPECT_EQ(semanticVersion.mMinor, getTestMinor());
+  EXPECT_EQ(semanticVersion.mPatch, getTestPatch());
+  EXPECT_EQ(semanticVersion.mPre, getTestPrerelease());
+  EXPECT_EQ(semanticVersion.mBuild, getTestBuildMetadata());
+}
+
+//-----
+TEST_F(SemanticVersionTest, ToProtobuf)
+{
+  // Given
+  const SemanticVersion semanticVersion(
+    getTestMajor(), getTestMinor(), getTestPatch(), getTestPrerelease(), getTestBuildMetadata());
+
+  // When
+  const std::unique_ptr<proto::SemanticVersion> protoSemanticVersion = semanticVersion.toProtobuf();
+
+  // Then
+  EXPECT_EQ(protoSemanticVersion->major(), getTestMajor());
+  EXPECT_EQ(protoSemanticVersion->minor(), getTestMinor());
+  EXPECT_EQ(protoSemanticVersion->patch(), getTestPatch());
+  EXPECT_EQ(protoSemanticVersion->pre(), getTestPrerelease());
+  EXPECT_EQ(protoSemanticVersion->build(), getTestBuildMetadata());
+}
+
+//-----
+TEST_F(SemanticVersionTest, ToBytes)
+{
+  // Given
+  const SemanticVersion semanticVersion(
+    getTestMajor(), getTestMinor(), getTestPatch(), getTestPrerelease(), getTestBuildMetadata());
+
+  // When
+  const std::vector<std::byte> bytes = semanticVersion.toBytes();
+
+  // Then
+  EXPECT_EQ(bytes, internal::Utilities::stringToByteVector(semanticVersion.toProtobuf()->SerializeAsString()));
+}


### PR DESCRIPTION
**Description**:
This PR implements the APIs associated with `NetworkVersionInfoQuery`, which allows users to get information about the current versions of the Hedera protobuf and the Hedera services.

**Related issue(s)**:

Fixes #479 

**Checklist**

- [x] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
