### PR TITLE
Implement `AccountStakersQuery`

### DIFF
--- a/sdk/main/CMakeLists.txt
+++ b/sdk/main/CMakeLists.txt
@@ -10,7 +10,7 @@ add_library(${PROJECT_NAME} STATIC
         src/AccountInfoQuery.cc
         src/AccountRecords.cc
         src/AccountRecordsQuery.cc
-        #    src/AccountStakersQuery.cc
+        src/AccountStakersQuery.cc
         src/AccountUpdateTransaction.cc
         src/AssessedCustomFee.cc
         src/ChunkedTransaction.cc
@@ -66,6 +66,7 @@ add_library(${PROJECT_NAME} STATIC
         src/MnemonicBIP39.cc
         src/NftId.cc
         src/PrivateKey.cc
+        src/ProxyStaker.cc
         src/PublicKey.cc
         src/Query.cc
         src/ScheduleCreateTransaction.cc

--- a/sdk/main/include/AccountStakersQuery.h
+++ b/sdk/main/include/AccountStakersQuery.h
@@ -4,7 +4,7 @@
  *
  * Copyright (C) 2020 - 2022 Hedera Hashgraph, LLC
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
+ * Licensed under the Apache License, Version 2.0 (the "License")
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
@@ -17,113 +17,93 @@
  * limitations under the License.
  *
  */
-#ifndef ACCOUNT_STAKERS_QUERY_H_
-#define ACCOUNT_STAKERS_QUERY_H_
+#ifndef HEDERA_SDK_CPP_ACCOUNT_STAKERS_QUERY_H_
+#define HEDERA_SDK_CPP_ACCOUNT_STAKERS_QUERY_H_
 
 #include "AccountId.h"
 #include "Query.h"
 
-#include "helper/InitType.h"
-
 #include <vector>
-
-namespace proto
-{
-class Query;
-class QueryHeader;
-class Response;
-class ResponseHeader;
-}
 
 namespace Hedera
 {
-class Client;
 class ProxyStaker;
 }
 
 namespace Hedera
 {
 /**
- * Get all the accounts that are proxy staking to this account.
- * For each of them, give the amount currently staked.
- *
- * This is not yet implemented, but will be in a future version of the API.
+ * Get all the accounts that are proxy staking to this account. For each of them, give the amount currently staked. This
+ * is not yet implemented, but will be in a future version of the API.
  */
-class AccountStakersQuery : public Query<std::vector<ProxyStaker>, AccountStakersQuery>
+using AccountStakers = std::vector<ProxyStaker>;
+class AccountStakersQuery : public Query<AccountStakersQuery, AccountStakers>
 {
 public:
   /**
-   * Constructor
-   */
-  AccountStakersQuery();
-
-  /**
-   * Derived from Query. Validate the checksums of the account ID.
+   * Set the ID of the account of which to request the stakers.
    *
-   * @param client  The client with which to validate the checksums
-   */
-  virtual void validateChecksums(const Client& client) const override;
-
-  /**
-   * Derived from Query. Fills query with this class's data and attaches the
-   * header.
-   *
-   * @param query  The query object to fill out.
-   * @param header The header for the query.
-   */
-  virtual void onMakeRequest(proto::Query* query, proto::QueryHeader* header) const override;
-
-  /**
-   * Derived from Query. Get the account stakers header from the response.
-   *
-   * @param response The associated response to this query.
-   * @return         The response header for the derived class's query.
-   */
-  virtual proto::ResponseHeader mapResponseHeader(proto::Response* response) const override;
-
-  /**
-   * Derived from Query. Grab the account stakers query header.
-   *
-   * @param query  The query of which to extract the header.
-   * @return       The account stakers query header.
-   */
-  virtual proto::QueryHeader mapRequestHeader(const proto::Query& query) const override;
-
-  /**
-   * Derived from Query. Extract the account stakers data from the response
-   * object.
-   *
-   * @param response  The received response from Hedera.
-   * @param accountId The account ID that made the request.
-   * @param query     The original query.
-   * @return          The account stakers data.
-   */
-  virtual std::vector<ProxyStaker> mapResponse(const proto::Response& response,
-                                               const AccountId& accountId,
-                                               const proto::Query& query) const override;
-
-  /**
-   * Sets the account ID for which information is requested.
-   *
-   * @param accountId The AccountId to be set
-   * @return          The account stakers query.
+   * @param accountId The ID of the account of which to request the stakers.
+   * @return A reference to this AccountStakersQuery object with the newly-set account ID.
    */
   AccountStakersQuery& setAccountId(const AccountId& accountId);
 
   /**
-   * Extract the account id.
+   * Get the ID of the account of which this query is currently configured to get the stakers.
    *
-   * @return The account id.
+   * @return The ID of the account for which this query is meant.
    */
-  inline InitType<AccountId> getAccountId() { return mAccountId; }
+  [[nodiscard]] inline AccountId getAccountId() const { return mAccountId; }
 
 private:
   /**
-   * The account ID of the account of which to get the account information.
+   * Derived from Executable. Construct a Query protobuf object from this AccountStakersQuery object.
+   *
+   * @param client The Client trying to construct this AccountStakersQuery.
+   * @param node   The Node to which this AccountStakersQuery will be sent.
+   * @return A Query protobuf object filled with this AccountStakersQuery object's data.
    */
-  InitType<AccountId> mAccountId;
+  [[nodiscard]] proto::Query makeRequest(const Client& client,
+                                         const std::shared_ptr<internal::Node>& node) const override;
+
+  /**
+   * Derived from Executable. Construct an AccountStakers object from a Response protobuf object.
+   *
+   * @param response The Response protobuf object from which to construct an AccountStakers object.
+   * @return An AccountStakers object filled with the Response protobuf object's data.
+   */
+  [[nodiscard]] AccountStakers mapResponse(const proto::Response& response) const override;
+
+  /**
+   * Derived from Executable. Get the status response code for a submitted AccountStakersQuery from a Response protobuf
+   * object.
+   *
+   * @param response The Response protobuf object from which to grab the AccountStakersQuery status response code.
+   * @return The AccountStakersQuery status response code of the input Response protobuf object.
+   */
+  [[nodiscard]] Status mapResponseStatus(const proto::Response& response) const override;
+
+  /**
+   * Derived from Executable. Submit this AccountStakersQuery to a Node.
+   *
+   * @param client   The Client submitting this AccountStakersQuery.
+   * @param deadline The deadline for submitting this AccountStakersQuery.
+   * @param node     Pointer to the Node to which this AccountStakersQuery should be submitted.
+   * @param response Pointer to the Response protobuf object that gRPC should populate with the response information
+   *                 from the gRPC server.
+   * @return The gRPC status of the submission.
+   */
+  [[nodiscard]] grpc::Status submitRequest(const Client& client,
+                                           const std::chrono::system_clock::time_point& deadline,
+                                           const std::shared_ptr<internal::Node>& node,
+                                           proto::Response* response) const override;
+
+  /**
+   * The ID of the account of which this query should get the stakers.
+   */
+  AccountId mAccountId;
 };
 
 } // namespace Hedera
 
-#endif // ACCOUNT_STAKERS_QUERY_H_
+#endif // HEDERA_SDK_CPP_ACCOUNT_STAKERS_QUERY_H_

--- a/sdk/main/include/AccountStakersQuery.h
+++ b/sdk/main/include/AccountStakersQuery.h
@@ -21,14 +21,10 @@
 #define HEDERA_SDK_CPP_ACCOUNT_STAKERS_QUERY_H_
 
 #include "AccountId.h"
+#include "ProxyStaker.h"
 #include "Query.h"
 
 #include <vector>
-
-namespace Hedera
-{
-class ProxyStaker;
-}
 
 namespace Hedera
 {

--- a/sdk/main/include/ProxyStaker.h
+++ b/sdk/main/include/ProxyStaker.h
@@ -17,8 +17,13 @@
  * limitations under the License.
  *
  */
-#ifndef PROXY_STAKER_H_
-#define PROXY_STAKER_H_
+#ifndef HEDERA_SDK_CPP_PROXY_STAKER_H_
+#define HEDERA_SDK_CPP_PROXY_STAKER_H_
+
+#include "AccountId.h"
+#include "Hbar.h"
+
+#include <cstdint>
 
 namespace proto
 {
@@ -27,15 +32,41 @@ class ProxyStaker;
 
 namespace Hedera
 {
+/**
+ * Information about a single account that is proxy staking.
+ */
 class ProxyStaker
 {
 public:
-  static ProxyStaker fromProtobuf(const proto::ProxyStaker& proto)
-  {
-    return ProxyStaker();
-  }
+  ProxyStaker() = default;
+
+  /**
+   * Construct with an account ID and an amount.
+   *
+   * @param accountID The account ID that is staking.
+   * @param amount    The amount the account is staking.
+   */
+  ProxyStaker(AccountId accountId, int64_t amount);
+
+  /**
+   * Construct a ProxyStaker object from a ProxyStaker protobuf object.
+   *
+   * @param proto The ProxyStaker protobuf object from which to construct a ProxyStaker object.
+   * @return The constructed ProxyStaker object.
+   */
+  [[nodiscard]] static ProxyStaker fromProtobuf(const proto::ProxyStaker& proto);
+
+  /**
+   * The ID of the account that is proxy staking.
+   */
+  AccountId mAccountId;
+
+  /**
+   * The number of Hbars that are currently proxy staked.
+   */
+  Hbar mAmount;
 };
 
 } // namespace Hedera
 
-#endif // PROXY_STAKER_H_
+#endif // HEDERA_SDK_CPP_PROXY_STAKER_H_

--- a/sdk/main/include/TransferTransaction.h
+++ b/sdk/main/include/TransferTransaction.h
@@ -198,6 +198,7 @@ private:
    */
   friend class AccountInfoQuery;
   friend class AccountRecordsQuery;
+  friend class AccountStakersQuery;
   friend class ContractByteCodeQuery;
   friend class ContractCallQuery;
   friend class ContractInfoQuery;

--- a/sdk/main/src/AccountStakersQuery.cc
+++ b/sdk/main/src/AccountStakersQuery.cc
@@ -4,7 +4,7 @@
  *
  * Copyright (C) 2020 - 2022 Hedera Hashgraph, LLC
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
+ * Licensed under the Apache License, Version 2.0 (the "License")
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
@@ -18,10 +18,11 @@
  *
  */
 #include "AccountStakersQuery.h"
-
-#include "AccountId.h"
-#include "AccountInfo.h"
+#include "Client.h"
 #include "ProxyStaker.h"
+#include "TransactionRecord.h"
+#include "TransferTransaction.h"
+#include "impl/Node.h"
 
 #include <proto/crypto_get_stakers.pb.h>
 #include <proto/query.pb.h>
@@ -31,75 +32,61 @@
 namespace Hedera
 {
 //-----
-AccountStakersQuery::AccountStakersQuery()
-  : mAccountId()
+AccountStakersQuery& AccountStakersQuery::setAccountId(const AccountId& accountId)
 {
-}
-
-//-----
-void
-AccountStakersQuery::validateChecksums(const Client& client) const
-{
-  if (mAccountId.isValid())
-  {
-    mAccountId.getValue().validateChecksum(client);
-  }
-}
-
-//-----
-void
-AccountStakersQuery::onMakeRequest(proto::Query* query,
-                                   proto::QueryHeader* header) const
-{
-  proto::CryptoGetStakersQuery* getStakersQuery =
-    query->mutable_cryptogetproxystakers();
-
-  if (mAccountId.isValid())
-  {
-    getStakersQuery->set_allocated_accountid(
-      mAccountId.getValue().toProtobuf());
-  }
-
-  getStakersQuery->set_allocated_header(header);
-}
-
-//-----
-proto::ResponseHeader
-AccountStakersQuery::mapResponseHeader(proto::Response* response) const
-{
-  return response->cryptogetproxystakers().header();
-}
-
-//-----
-proto::QueryHeader
-AccountStakersQuery::mapRequestHeader(const proto::Query& query) const
-{
-  return query.cryptogetproxystakers().header();
-}
-
-//-----
-std::vector<ProxyStaker>
-AccountStakersQuery::mapResponse(const proto::Response& response,
-                                 const AccountId& accountId,
-                                 const proto::Query& query) const
-{
-  std::vector<ProxyStaker> stakers;
-  const proto::AllProxyStakers& stakerData =
-    response.cryptogetproxystakers().stakers();
-  for (size_t i = 0; i < stakerData.proxystaker_size(); ++i)
-  {
-    stakers.push_back(ProxyStaker::fromProtobuf(stakerData.proxystaker(i)));
-  }
-
-  return stakers;
-}
-
-//-----
-AccountStakersQuery&
-AccountStakersQuery::setAccountId(const AccountId& accountId)
-{
-  mAccountId.setValue(accountId);
+  mAccountId = accountId;
   return *this;
+}
+
+//-----
+proto::Query AccountStakersQuery::makeRequest(const Client& client, const std::shared_ptr<internal::Node>& node) const
+{
+  proto::Query query;
+  proto::CryptoGetStakersQuery* getAccountStakersQuery = query.mutable_cryptogetproxystakers();
+
+  proto::QueryHeader* header = getAccountStakersQuery->mutable_header();
+  header->set_responsetype(proto::ANSWER_ONLY);
+
+  TransferTransaction tx = TransferTransaction()
+                             .setTransactionId(TransactionId::generate(*client.getOperatorAccountId()))
+                             .setNodeAccountIds({ node->getAccountId() })
+                             .setMaxTransactionFee(Hbar(1LL))
+                             .addHbarTransfer(*client.getOperatorAccountId(), Hbar(-1LL))
+                             .addHbarTransfer(node->getAccountId(), Hbar(1LL));
+  tx.onSelectNode(node);
+  header->set_allocated_payment(new proto::Transaction(tx.makeRequest(client, node)));
+
+  getAccountStakersQuery->set_allocated_accountid(mAccountId.toProtobuf().release());
+
+  return query;
+}
+
+//-----
+AccountStakers AccountStakersQuery::mapResponse(const proto::Response& response) const
+{
+  AccountStakers accountStakers;
+
+  for (int i = 0; i < response.cryptogetproxystakers().stakers().proxystaker_size(); ++i)
+  {
+  }
+
+  return accountStakers;
+}
+
+//-----
+Status AccountStakersQuery::mapResponseStatus(const proto::Response& response) const
+{
+  return gProtobufResponseCodeToStatus.at(response.cryptogetproxystakers().header().nodetransactionprecheckcode());
+}
+
+//-----
+grpc::Status AccountStakersQuery::submitRequest(const Client& client,
+                                                const std::chrono::system_clock::time_point& deadline,
+                                                const std::shared_ptr<internal::Node>& node,
+                                                proto::Response* response) const
+{
+  return node->submitQuery(
+    proto::Query::QueryCase::kCryptoGetProxyStakers, makeRequest(client, node), deadline, response);
 }
 
 } // namespace Hedera

--- a/sdk/main/src/Executable.cc
+++ b/sdk/main/src/Executable.cc
@@ -28,6 +28,7 @@
 #include "AccountInfoQuery.h"
 #include "AccountRecords.h"
 #include "AccountRecordsQuery.h"
+#include "AccountStakersQuery.h"
 #include "AccountUpdateTransaction.h"
 #include "Client.h"
 #include "ContractByteCodeQuery.h"
@@ -47,6 +48,7 @@
 #include "FileInfo.h"
 #include "FileInfoQuery.h"
 #include "FileUpdateTransaction.h"
+#include "ProxyStaker.h"
 #include "ScheduleCreateTransaction.h"
 #include "ScheduleDeleteTransaction.h"
 #include "ScheduleInfo.h"
@@ -344,6 +346,7 @@ template class Executable<AccountDeleteTransaction,
                           TransactionResponse>;
 template class Executable<AccountInfoQuery, proto::Query, proto::Response, AccountInfo>;
 template class Executable<AccountRecordsQuery, proto::Query, proto::Response, AccountRecords>;
+template class Executable<AccountStakersQuery, proto::Query, proto::Response, AccountStakers>;
 template class Executable<AccountUpdateTransaction,
                           proto::Transaction,
                           proto::TransactionResponse,

--- a/sdk/main/src/ProxyStaker.cc
+++ b/sdk/main/src/ProxyStaker.cc
@@ -1,0 +1,41 @@
+/*-
+ *
+ * Hedera C++ SDK
+ *
+ * Copyright (C) 2020 - 2022 Hedera Hashgraph, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+#include "ProxyStaker.h"
+
+#include <proto/crypto_get_stakers.pb.h>
+
+#include <utility>
+
+namespace Hedera
+{
+//-----
+ProxyStaker::ProxyStaker(AccountId accountId, int64_t amount)
+  : mAccountId(std::move(accountId))
+  , mAmount(Hbar(amount, HbarUnit::TINYBAR()))
+{
+}
+
+//-----
+ProxyStaker ProxyStaker::fromProtobuf(const proto::ProxyStaker& proto)
+{
+  return { AccountId::fromProtobuf(proto.accountid()), proto.amount() };
+}
+
+} // namespace Hedera

--- a/sdk/main/src/Query.cc
+++ b/sdk/main/src/Query.cc
@@ -22,6 +22,7 @@
 #include "AccountBalanceQuery.h"
 #include "AccountRecords.h"
 #include "AccountRecordsQuery.h"
+#include "AccountStakersQuery.h"
 #include "ContractCallQuery.h"
 #include "ContractFunctionResult.h"
 #include "ContractInfo.h"
@@ -49,6 +50,7 @@ namespace Hedera
  */
 template class Query<AccountBalanceQuery, AccountBalance>;
 template class Query<AccountRecordsQuery, AccountRecords>;
+template class Query<AccountStakersQuery, AccountStakers>;
 template class Query<ContractCallQuery, ContractFunctionResult>;
 template class Query<ContractInfoQuery, ContractInfo>;
 template class Query<FileContentsQuery, FileContents>;

--- a/sdk/tests/integration/AccountStakersQueryIntegrationTests.cc
+++ b/sdk/tests/integration/AccountStakersQueryIntegrationTests.cc
@@ -1,0 +1,40 @@
+/*-
+ *
+ * Hedera C++ SDK
+ *
+ * Copyright (C) 2020 - 2022 Hedera Hashgraph, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+#include "AccountStakersQuery.h"
+#include "BaseIntegrationTest.h"
+#include "ProxyStaker.h"
+#include "exceptions/PrecheckStatusException.h"
+
+#include <gtest/gtest.h>
+
+using namespace Hedera;
+
+class AccountStakersQueryIntegrationTest : public BaseIntegrationTest
+{
+};
+
+//-----
+TEST_F(AccountStakersQueryIntegrationTest, ExecuteAccountStakersQuery)
+{
+  // Given / When / Then
+  EXPECT_THROW(const AccountStakers accountStakers =
+                 AccountStakersQuery().setAccountId(AccountId(2ULL)).execute(getTestClient()),
+               PrecheckStatusException); // NOT_SUPPORTED
+}

--- a/sdk/tests/integration/CMakeLists.txt
+++ b/sdk/tests/integration/CMakeLists.txt
@@ -6,6 +6,7 @@ add_executable(${TEST_PROJECT_NAME}
         AccountDeleteTransactionIntegrationTest.cc
         AccountInfoQueryIntegrationTests.cc
         AccountRecordsQueryIntegrationTests.cc
+        AccountStakersQueryIntegrationTests.cc
         AccountUpdateTransactionIntegrationTest.cc
         BaseIntegrationTest.cc
         ContractBytecodeQueryIntegrationTests.cc

--- a/sdk/tests/unit/AccountStakersQueryUnitTests.cc
+++ b/sdk/tests/unit/AccountStakersQueryUnitTests.cc
@@ -1,0 +1,46 @@
+/*-
+ *
+ * Hedera C++ SDK
+ *
+ * Copyright (C) 2020 - 2022 Hedera Hashgraph, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+#include "AccountStakersQuery.h"
+
+#include <gtest/gtest.h>
+
+using namespace Hedera;
+
+class AccountStakersQueryTest : public ::testing::Test
+{
+protected:
+  [[nodiscard]] inline const AccountId& getTestAccountId() const { return mTestAccountId; }
+
+private:
+  const AccountId mTestAccountId = AccountId(1ULL);
+};
+
+//-----
+TEST_F(AccountStakersQueryTest, SetAccountId)
+{
+  // Given
+  AccountStakersQuery query;
+
+  // When
+  query.setAccountId(getTestAccountId());
+
+  // Then
+  EXPECT_EQ(query.getAccountId(), getTestAccountId());
+}

--- a/sdk/tests/unit/CMakeLists.txt
+++ b/sdk/tests/unit/CMakeLists.txt
@@ -11,6 +11,7 @@ add_executable(${TEST_PROJECT_NAME}
         AccountInfoTest.cc
         AccountRecordsQueryTest.cc
         AccountRecordsTest.cc
+        AccountStakersQueryUnitTests.cc
         AccountUpdateTransactionTest.cc
         AssessedCustomFeesTest.cc
         ChunkedTransactionTest.cc
@@ -60,6 +61,7 @@ add_executable(${TEST_PROJECT_NAME}
         LedgerIdTest.cc
         NftIdTest.cc
         NodeAddressTest.cc
+        ProxyStakerUnitTests.cc
         ScheduleCreateTransactionUnitTests.cc
         ScheduleDeleteTransactionUnitTests.cc
         ScheduleIdUnitTests.cc

--- a/sdk/tests/unit/ProxyStakerUnitTests.cc
+++ b/sdk/tests/unit/ProxyStakerUnitTests.cc
@@ -1,0 +1,63 @@
+/*-
+ *
+ * Hedera C++ SDK
+ *
+ * Copyright (C) 2020 - 2022 Hedera Hashgraph, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+#include "ProxyStaker.h"
+
+#include <gtest/gtest.h>
+#include <proto/crypto_get_stakers.pb.h>
+
+using namespace Hedera;
+
+class ProxyStakerTest : public ::testing::Test
+{
+protected:
+  [[nodiscard]] inline const AccountId& getTestAccountId() const { return mTestAccountId; }
+  [[nodiscard]] inline const Hbar& getTestAmount() const { return mTestAmount; }
+
+private:
+  const AccountId mTestAccountId = AccountId(1ULL, 2ULL, 3ULL);
+  const Hbar mTestAmount = Hbar(4LL);
+};
+
+//-----
+TEST_F(ProxyStakerTest, ConstructWithValues)
+{
+  // Given / When
+  const ProxyStaker proxyStaker(getTestAccountId(), getTestAmount().toTinybars());
+
+  // Then
+  EXPECT_EQ(proxyStaker.mAccountId, getTestAccountId());
+  EXPECT_EQ(proxyStaker.mAmount, getTestAmount());
+}
+
+//-----
+TEST_F(ProxyStakerTest, FromProtobuf)
+{
+  // Given
+  proto::ProxyStaker protoProxyStaker;
+  protoProxyStaker.set_allocated_accountid(getTestAccountId().toProtobuf().release());
+  protoProxyStaker.set_amount(getTestAmount().toTinybars());
+
+  // When
+  const ProxyStaker proxyStaker = ProxyStaker::fromProtobuf(protoProxyStaker);
+
+  // Then
+  EXPECT_EQ(proxyStaker.mAccountId, getTestAccountId());
+  EXPECT_EQ(proxyStaker.mAmount, getTestAmount());
+}


### PR DESCRIPTION
**Description**:
This PR implements the APIs associated with `AccountStakersQuery`, which allows users to see which accounts are proxy staked to an account.

**Related issue(s)**:

Fixes #484 

**Checklist**

- [x] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
