### PR TITLE
Add `AccountCreationWaysExample`

### DIFF
--- a/sdk/examples/AccountCreationWaysExample.cc
+++ b/sdk/examples/AccountCreationWaysExample.cc
@@ -1,0 +1,63 @@
+/*-
+ *
+ * Hedera C++ SDK
+ *
+ * Copyright (C) 2020 - 2023 Hedera Hashgraph, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+#include "AccountId.h"
+#include "ECDSAsecp256k1PrivateKey.h"
+
+#include <iostream>
+
+using namespace Hedera;
+
+int main(int argc, char** argv)
+{
+  /**
+   * Reference: [HIP-583 Expand alias support in CryptoCreate & CryptoTransfer
+   * Transactions](https://hips.hedera.com/hip/hip-583)
+   * In Hedera we have the concept of 4 different account representations:
+   *  - An account can have an account ID in shard.realm.accountNumber format (0.0.10).
+   *  - An account can have a public key alias in
+   *    0.0.302D300706052B8104000A032200036847776633520568B5B4B1D074C647BE63579B3D7DC9E4B638042CB4E041C8B8 format.
+   *  - An account can have an AccountId that is represented in 0x000000000000000000000000000000000000000A (for account
+   *    ID 0.0.10) long zero format.
+   *  - An account can be represented by an Ethereum public address 0xB794F5EA0BA39494CE839613FFFBA74279579268.
+   */
+
+  // An Account ID in shard.realm.number format, i.e. `0.0.10` with the corresponding
+  // `0x000000000000000000000000000000000000000A` ethereum address.
+  const AccountId hederaFormat = AccountId::fromString("0.0.10");
+  std::cout << "Account ID: " + hederaFormat.toString() << std::endl;
+  std::cout << "Account " + hederaFormat.toString() + " corresponding Long-Zero address: "
+            << hederaFormat.toSolidityAddress() << std::endl;
+
+  // The Hedera Long-Form Account ID: 0.0.aliasPublicKey, i.e.
+  // `0.0.302D300706052B8104000A032200036847776633520568B5B4B1D074C647BE63579B3D7DC9E4B638042CB4E041C8B8`
+  const std::unique_ptr<ECDSAsecp256k1PrivateKey> privateKey = ECDSAsecp256k1PrivateKey::generatePrivateKey();
+  const AccountId aliasAccountId = privateKey->getPublicKey()->toAccountId();
+  std::cout << "Hedera Long-Form Account ID: " + aliasAccountId.toString() << std::endl;
+
+  // The Hedera Account Long-Zero address `0x000000000000000000000000000000000000000a` (for accountId 0.0.10)
+  const AccountId longZeroAddress = AccountId::fromString("0x000000000000000000000000000000000000000a");
+  std::cout << "Hedera Account Long-Zero address: " << longZeroAddress.toString() << std::endl;
+
+  // The Ethereum Account Address / public-address `0xb794f5ea0ba39494ce839613fffba74279579268`.
+  const AccountId evmAddress = AccountId::fromString("0xb794f5ea0ba39494ce839613fffba74279579268");
+  std::cout << "Ethereum Account Address / public-address: " << evmAddress.toString() << std::endl;
+
+  return 0;
+}

--- a/sdk/examples/CMakeLists.txt
+++ b/sdk/examples/CMakeLists.txt
@@ -1,6 +1,7 @@
 set(ACCOUNT_ALIAS_EXAMPLE_NAME ${PROJECT_NAME}-account-alias-example)
 set(ACCOUNT_ALLOWANCE_EXAMPLE_NAME ${PROJECT_NAME}-account-allowance-example)
 set(ACCOUNT_CREATE_WITH_HTS_EXAMPLE_NAME ${PROJECT_NAME}-account-create-with-hts-example)
+set(ACCOUNT_CREATION_WAYS_EXAMPLE_NAME ${PROJECT_NAME}-account-creation-ways-example)
 set(CONSENSUS_PUB_SUB_EXAMPLE_NAME ${PROJECT_NAME}-consensus-pub-sub-example)
 set(CREATE_ACCOUNT_EXAMPLE_NAME ${PROJECT_NAME}-create-account-example)
 set(CREATE_SIMPLE_CONTRACT_EXAMPLE_NAME ${PROJECT_NAME}-create-simple-contract-example)
@@ -28,6 +29,7 @@ set(UPDATE_ACCOUNT_PUBLIC_KEY_EXAMPLE_NAME ${PROJECT_NAME}-update-account-public
 add_executable(${ACCOUNT_ALIAS_EXAMPLE_NAME} AccountAliasExample.cc)
 add_executable(${ACCOUNT_ALLOWANCE_EXAMPLE_NAME} AccountAllowanceExample.cc)
 add_executable(${ACCOUNT_CREATE_WITH_HTS_EXAMPLE_NAME} AccountCreateWithHtsExample.cc)
+add_executable(${ACCOUNT_CREATION_WAYS_EXAMPLE_NAME} AccountCreationWaysExample.cc)
 add_executable(${CONSENSUS_PUB_SUB_EXAMPLE_NAME} ConsensusPubSubExample.cc)
 add_executable(${CREATE_ACCOUNT_EXAMPLE_NAME} CreateAccountExample.cc)
 add_executable(${CREATE_SIMPLE_CONTRACT_EXAMPLE_NAME} CreateSimpleContractExample.cc)
@@ -73,6 +75,7 @@ endif ()
 target_link_libraries(${ACCOUNT_ALIAS_EXAMPLE_NAME} PUBLIC ${PROJECT_NAME})
 target_link_libraries(${ACCOUNT_ALLOWANCE_EXAMPLE_NAME} PUBLIC ${PROJECT_NAME})
 target_link_libraries(${ACCOUNT_CREATE_WITH_HTS_EXAMPLE_NAME} PUBLIC ${PROJECT_NAME})
+target_link_libraries(${ACCOUNT_CREATION_WAYS_EXAMPLE_NAME} PUBLIC ${PROJECT_NAME})
 target_link_libraries(${CONSENSUS_PUB_SUB_EXAMPLE_NAME} PUBLIC ${PROJECT_NAME})
 target_link_libraries(${CREATE_ACCOUNT_EXAMPLE_NAME} PUBLIC ${PROJECT_NAME})
 target_link_libraries(${CREATE_SIMPLE_CONTRACT_EXAMPLE_NAME} PUBLIC ${PROJECT_NAME})
@@ -103,6 +106,7 @@ install(TARGETS
         ${ACCOUNT_ALIAS_EXAMPLE_NAME}
         ${ACCOUNT_ALLOWANCE_EXAMPLE_NAME}
         ${ACCOUNT_CREATE_WITH_HTS_EXAMPLE_NAME}
+        ${ACCOUNT_CREATION_WAYS_EXAMPLE_NAME}
         ${CONSENSUS_PUB_SUB_EXAMPLE_NAME}
         ${CREATE_ACCOUNT_EXAMPLE_NAME}
         ${CREATE_SIMPLE_CONTRACT_EXAMPLE_NAME}

--- a/sdk/main/include/AccountId.h
+++ b/sdk/main/include/AccountId.h
@@ -115,6 +115,33 @@ public:
   [[nodiscard]] static AccountId fromString(std::string_view id);
 
   /**
+   * Construct an AccountId object from a string that represents an EvmAddress and, optionally, a shard and realm
+   * number.
+   *
+   * @param evmAddress The string that represents an EvmAddress.
+   * @param shard      The shard number.
+   * @param realm      The realm number.
+   * @return The constructed AccountId object.
+   * @throws std::invalid_argument If the input string is malformed.
+   * @throws OpenSSLException If OpenSSL is unable to convert the string to a byte array.
+   */
+  [[nodiscard]] static AccountId fromEvmAddress(std::string_view evmAddress,
+                                                uint64_t shard = 0ULL,
+                                                uint64_t realm = 0ULL);
+
+  /**
+   * Construct an AccountId object from an EvmAddress object and, optionally, a shard and realm number.
+   *
+   * @param evmAddress The EvmAddress from which to construct an AccountId.
+   * @param shard      The shard number.
+   * @param realm      The realm number.
+   * @return The constructed AccountId object.
+   */
+  [[nodiscard]] static AccountId fromEvmAddress(const EvmAddress& evmAddress,
+                                                uint64_t shard = 0ULL,
+                                                uint64_t realm = 0ULL);
+
+  /**
    * Create an AccountId object from an AccountID protobuf object.
    *
    * @param proto The AccountID protobuf object from which to create an AccountId object.
@@ -130,102 +157,18 @@ public:
   [[nodiscard]] std::unique_ptr<proto::AccountID> toProtobuf() const;
 
   /**
+   * Get a Solidity address representation of this AccountId (Long-Zero address).
+   *
+   * @return A Solidity address representation of this AccountId.
+   */
+  [[nodiscard]] std::string toSolidityAddress() const;
+
+  /**
    * Get a string representation of this AccountId object with the form "<shard>.<realm>.<num>".
    *
    * @return A string representation of this AccountId.
    */
   [[nodiscard]] std::string toString() const;
-
-  /**
-   * Set the shard number.
-   *
-   * @param num The desired shard number to set.
-   * @return A reference to this AccountId object with the newly-set shard number.
-   * @throws std::invalid_argument If the shard number is too big (max value is std::numeric_limits<int64_t>::max()).
-   */
-  AccountId& setShardNum(const uint64_t& num);
-
-  /**
-   * Set the realm number.
-   *
-   * @param num The realm number to set.
-   * @return A reference to this AccountId object with the newly-set realm number.
-   * @throws std::invalid_argument If the realm number is too big (max value is std::numeric_limits<int64_t>::max()).
-   */
-  AccountId& setRealmNum(const uint64_t& num);
-
-  /**
-   * Set the account number. This is mutually exclusive with mPublicKeyAlias and mEvmAddressAlias, and will reset the
-   * value of the mPublicKeyAlias or mEvmAddressAlias if either is set.
-   *
-   * @param num The account number to set.
-   * @return A reference to this AccountId object with the newly-set account number.
-   * @throws std::invalid_argument If the account number is too big (max value is std::numeric_limits<int64_t>::max()).
-   */
-  AccountId& setAccountNum(const uint64_t& num);
-
-  /**
-   * Set the account public key alias. This is mutually exclusive with mAccountNum and mEvmAddressAlias, and will reset
-   * the value of the mAccountNum or mEvmAddressAlias if either is set.
-   *
-   * @param alias The public key alias to set.
-   * @return A reference to this AccountId object with the newly-set account alias.
-   */
-  AccountId& setPublicKeyAlias(const std::shared_ptr<PublicKey>& alias);
-
-  /**
-   * Set the account EVM address alias. This is mutually exclusive with mAccountNum and mPublicKeyAlias, and will reset
-   * the value of the mAccountNum or mPublicKeyAlias if either is set.
-   *
-   * @param address The EVM address alias to set.
-   * @return A reference to this AccountId object with the newly-set account EVM address.
-   */
-  AccountId& setEvmAddressAlias(const EvmAddress& address);
-
-  /**
-   * Get the shard number.
-   *
-   * @return The shard number.
-   */
-  [[nodiscard]] inline uint64_t getShardNum() const { return mShardNum; }
-
-  /**
-   * Get the realm number.
-   *
-   * @return The realm number.
-   */
-  [[nodiscard]] inline uint64_t getRealmNum() const { return mRealmNum; }
-
-  /**
-   * Get the account number.
-   *
-   * @return The account number.
-   */
-  [[nodiscard]] inline std::optional<uint64_t> getAccountNum() const { return mAccountNum; }
-
-  /**
-   * Get the account public key alias.
-   *
-   * @return The account public key alias.
-   */
-  [[nodiscard]] inline std::shared_ptr<PublicKey> getPublicKeyAlias() const { return mPublicKeyAlias; }
-
-  /**
-   * Get the account EVM address alias.
-   *
-   * @return The account EVM address alias.
-   */
-  [[nodiscard]] inline std::optional<EvmAddress> getEvmAddressAlias() const { return mEvmAddressAlias; }
-
-private:
-  /**
-   * Check if the shard, realm, or account numbers (respectively) are too big.
-   *
-   * @throws std::invalid_argument If the shard, realm, or account number (respectively) is too big.
-   */
-  void checkShardNum() const;
-  void checkRealmNum() const;
-  void checkAccountNum() const;
 
   /**
    * The shard number.
@@ -264,6 +207,16 @@ private:
    * ECDSA_SECP256K1 primitive key form.
    */
   std::optional<EvmAddress> mEvmAddressAlias;
+
+private:
+  /**
+   * Check if the shard, realm, or account numbers (respectively) are too big.
+   *
+   * @throws std::invalid_argument If the shard, realm, or account number (respectively) is too big.
+   */
+  void checkShardNum() const;
+  void checkRealmNum() const;
+  void checkAccountNum() const;
 };
 
 } // namespace Hedera

--- a/sdk/main/include/impl/Utilities.h
+++ b/sdk/main/include/impl/Utilities.h
@@ -29,6 +29,24 @@
 namespace Hedera::internal::Utilities
 {
 /**
+ * Reinterpret a pointer to a pointer of a different type.
+ *
+ * @param input The pointer to reinterpret.
+ * @param A pointer to the same input, reinterpreted as a different type.
+ */
+template<typename ReturnType, typename InputType>
+[[nodiscard]] ReturnType* toTypePtr(InputType* input)
+{
+  return reinterpret_cast<ReturnType*>(input);
+}
+
+template<typename ReturnType, typename InputType>
+[[nodiscard]] const ReturnType* toTypePtr(const InputType* input)
+{
+  return reinterpret_cast<const ReturnType*>(input);
+}
+
+/**
  * Swap the endianness of an integral value.
  *
  * @param value The value of which to convert the endianness.
@@ -60,21 +78,26 @@ template<typename T>
 }
 
 /**
- * Reinterpret a pointer to a pointer of a different type.
+ * Get the bytes (in big endian) that represent an integral type.
  *
- * @param input The pointer to reinterpret.
- * @param A pointer to the same input, reinterpreted as a different type.
+ * @tparam T  The type of integer of which to get the bytes.
+ * @param val The value of which to get the bytes.
+ * @return An array of bytes that represents the input value.
  */
-template<typename ReturnType, typename InputType>
-[[nodiscard]] ReturnType* toTypePtr(InputType* input)
+template<typename T>
+[[nodiscard]] std::vector<std::byte> getBytes(const T& val)
 {
-  return reinterpret_cast<ReturnType*>(input);
-}
+  // Only allow integral types
+  static_assert(std::is_integral_v<T>, "getBytes works only with integral types");
 
-template<typename ReturnType, typename InputType>
-[[nodiscard]] const ReturnType* toTypePtr(const InputType* input)
-{
-  return reinterpret_cast<const ReturnType*>(input);
+  std::vector<std::byte> bytes(sizeof(T));
+  auto byte = internal::Utilities::toTypePtr<std::byte>(&val);
+  for (size_t i = 0; i < sizeof(T); ++i)
+  {
+    bytes[sizeof(T) - i - 1] = *byte++;
+  }
+
+  return bytes;
 }
 
 /**

--- a/sdk/tests/unit/AccountIdTest.cc
+++ b/sdk/tests/unit/AccountIdTest.cc
@@ -58,23 +58,23 @@ private:
 TEST_F(AccountIdTest, DefaultConstructAccountId)
 {
   const AccountId accountId;
-  EXPECT_EQ(accountId.getShardNum(), 0ULL);
-  EXPECT_EQ(accountId.getRealmNum(), 0ULL);
-  EXPECT_FALSE(accountId.getAccountNum().has_value());
-  EXPECT_EQ(accountId.getPublicKeyAlias(), nullptr);
-  EXPECT_FALSE(accountId.getEvmAddressAlias().has_value());
+  EXPECT_EQ(accountId.mShardNum, 0ULL);
+  EXPECT_EQ(accountId.mRealmNum, 0ULL);
+  EXPECT_FALSE(accountId.mAccountNum.has_value());
+  EXPECT_EQ(accountId.mPublicKeyAlias, nullptr);
+  EXPECT_FALSE(accountId.mEvmAddressAlias.has_value());
 }
 
 //-----
 TEST_F(AccountIdTest, ConstructWithAccountNum)
 {
   const AccountId accountId(getTestAccountNum());
-  EXPECT_EQ(accountId.getShardNum(), 0ULL);
-  EXPECT_EQ(accountId.getRealmNum(), 0ULL);
-  EXPECT_TRUE(accountId.getAccountNum().has_value());
-  EXPECT_EQ(*accountId.getAccountNum(), getTestAccountNum());
-  EXPECT_EQ(accountId.getPublicKeyAlias(), nullptr);
-  EXPECT_FALSE(accountId.getEvmAddressAlias().has_value());
+  EXPECT_EQ(accountId.mShardNum, 0ULL);
+  EXPECT_EQ(accountId.mRealmNum, 0ULL);
+  EXPECT_TRUE(accountId.mAccountNum.has_value());
+  EXPECT_EQ(*accountId.mAccountNum, getTestAccountNum());
+  EXPECT_EQ(accountId.mPublicKeyAlias, nullptr);
+  EXPECT_FALSE(accountId.mEvmAddressAlias.has_value());
 
   EXPECT_THROW(AccountId{ getTestNumTooBig() }, std::invalid_argument);
 }
@@ -83,44 +83,44 @@ TEST_F(AccountIdTest, ConstructWithAccountNum)
 TEST_F(AccountIdTest, ConstructWithAccountAlias)
 {
   const AccountId ed25519AliasAccountId(getTestEd25519Alias());
-  EXPECT_EQ(ed25519AliasAccountId.getShardNum(), 0ULL);
-  EXPECT_EQ(ed25519AliasAccountId.getRealmNum(), 0ULL);
-  EXPECT_FALSE(ed25519AliasAccountId.getAccountNum().has_value());
-  EXPECT_NE(ed25519AliasAccountId.getPublicKeyAlias(), nullptr);
-  EXPECT_EQ(ed25519AliasAccountId.getPublicKeyAlias()->toStringDer(), getTestEd25519Alias()->toStringDer());
-  EXPECT_FALSE(ed25519AliasAccountId.getEvmAddressAlias().has_value());
+  EXPECT_EQ(ed25519AliasAccountId.mShardNum, 0ULL);
+  EXPECT_EQ(ed25519AliasAccountId.mRealmNum, 0ULL);
+  EXPECT_FALSE(ed25519AliasAccountId.mAccountNum.has_value());
+  EXPECT_NE(ed25519AliasAccountId.mPublicKeyAlias, nullptr);
+  EXPECT_EQ(ed25519AliasAccountId.mPublicKeyAlias->toStringDer(), getTestEd25519Alias()->toStringDer());
+  EXPECT_FALSE(ed25519AliasAccountId.mEvmAddressAlias.has_value());
 
   const AccountId ecdsaAliasAccountId(getTestEcdsaSecp256k1Alias());
-  EXPECT_EQ(ecdsaAliasAccountId.getShardNum(), 0ULL);
-  EXPECT_EQ(ecdsaAliasAccountId.getRealmNum(), 0ULL);
-  EXPECT_FALSE(ecdsaAliasAccountId.getAccountNum().has_value());
-  EXPECT_NE(ecdsaAliasAccountId.getPublicKeyAlias(), nullptr);
-  EXPECT_EQ(ecdsaAliasAccountId.getPublicKeyAlias()->toStringDer(), getTestEcdsaSecp256k1Alias()->toStringDer());
-  EXPECT_FALSE(ecdsaAliasAccountId.getEvmAddressAlias().has_value());
+  EXPECT_EQ(ecdsaAliasAccountId.mShardNum, 0ULL);
+  EXPECT_EQ(ecdsaAliasAccountId.mRealmNum, 0ULL);
+  EXPECT_FALSE(ecdsaAliasAccountId.mAccountNum.has_value());
+  EXPECT_NE(ecdsaAliasAccountId.mPublicKeyAlias, nullptr);
+  EXPECT_EQ(ecdsaAliasAccountId.mPublicKeyAlias->toStringDer(), getTestEcdsaSecp256k1Alias()->toStringDer());
+  EXPECT_FALSE(ecdsaAliasAccountId.mEvmAddressAlias.has_value());
 }
 
 //-----
 TEST_F(AccountIdTest, ConstructWithEvmAddress)
 {
   const AccountId accountId(getTestEvmAddressAlias());
-  EXPECT_EQ(accountId.getShardNum(), 0ULL);
-  EXPECT_EQ(accountId.getRealmNum(), 0ULL);
-  EXPECT_FALSE(accountId.getAccountNum().has_value());
-  EXPECT_EQ(accountId.getPublicKeyAlias(), nullptr);
-  EXPECT_TRUE(accountId.getEvmAddressAlias().has_value());
-  EXPECT_EQ(accountId.getEvmAddressAlias()->toString(), getTestEvmAddressAlias().toString());
+  EXPECT_EQ(accountId.mShardNum, 0ULL);
+  EXPECT_EQ(accountId.mRealmNum, 0ULL);
+  EXPECT_FALSE(accountId.mAccountNum.has_value());
+  EXPECT_EQ(accountId.mPublicKeyAlias, nullptr);
+  EXPECT_TRUE(accountId.mEvmAddressAlias.has_value());
+  EXPECT_EQ(accountId.mEvmAddressAlias->toString(), getTestEvmAddressAlias().toString());
 }
 
 //-----
 TEST_F(AccountIdTest, ConstructWithShardRealmAccountNum)
 {
   const AccountId accountId(getTestShardNum(), getTestRealmNum(), getTestAccountNum());
-  EXPECT_EQ(accountId.getShardNum(), getTestShardNum());
-  EXPECT_EQ(accountId.getRealmNum(), getTestRealmNum());
-  EXPECT_TRUE(accountId.getAccountNum().has_value());
-  EXPECT_EQ(*accountId.getAccountNum(), getTestAccountNum());
-  EXPECT_EQ(accountId.getPublicKeyAlias(), nullptr);
-  EXPECT_FALSE(accountId.getEvmAddressAlias().has_value());
+  EXPECT_EQ(accountId.mShardNum, getTestShardNum());
+  EXPECT_EQ(accountId.mRealmNum, getTestRealmNum());
+  EXPECT_TRUE(accountId.mAccountNum.has_value());
+  EXPECT_EQ(*accountId.mAccountNum, getTestAccountNum());
+  EXPECT_EQ(accountId.mPublicKeyAlias, nullptr);
+  EXPECT_FALSE(accountId.mEvmAddressAlias.has_value());
 
   EXPECT_THROW((AccountId{ getTestNumTooBig(), getTestRealmNum(), getTestAccountNum() }), std::invalid_argument);
   EXPECT_THROW((AccountId{ getTestShardNum(), getTestNumTooBig(), getTestAccountNum() }), std::invalid_argument);
@@ -131,23 +131,23 @@ TEST_F(AccountIdTest, ConstructWithShardRealmAccountNum)
 TEST_F(AccountIdTest, ConstructWithShardRealmAccountAlias)
 {
   const AccountId ed25519AliasAccountId(getTestShardNum(), getTestRealmNum(), getTestEd25519Alias());
-  EXPECT_EQ(ed25519AliasAccountId.getShardNum(), getTestShardNum());
-  EXPECT_EQ(ed25519AliasAccountId.getRealmNum(), getTestRealmNum());
-  EXPECT_FALSE(ed25519AliasAccountId.getAccountNum().has_value());
-  EXPECT_NE(ed25519AliasAccountId.getPublicKeyAlias(), nullptr);
-  EXPECT_EQ(ed25519AliasAccountId.getPublicKeyAlias()->toStringDer(), getTestEd25519Alias()->toStringDer());
-  EXPECT_FALSE(ed25519AliasAccountId.getEvmAddressAlias().has_value());
+  EXPECT_EQ(ed25519AliasAccountId.mShardNum, getTestShardNum());
+  EXPECT_EQ(ed25519AliasAccountId.mRealmNum, getTestRealmNum());
+  EXPECT_FALSE(ed25519AliasAccountId.mAccountNum.has_value());
+  EXPECT_NE(ed25519AliasAccountId.mPublicKeyAlias, nullptr);
+  EXPECT_EQ(ed25519AliasAccountId.mPublicKeyAlias->toStringDer(), getTestEd25519Alias()->toStringDer());
+  EXPECT_FALSE(ed25519AliasAccountId.mEvmAddressAlias.has_value());
 
   EXPECT_THROW((AccountId{ getTestNumTooBig(), getTestRealmNum(), getTestEd25519Alias() }), std::invalid_argument);
   EXPECT_THROW((AccountId{ getTestShardNum(), getTestNumTooBig(), getTestEd25519Alias() }), std::invalid_argument);
 
   const AccountId ecdsaAliasAccountId(getTestShardNum(), getTestRealmNum(), getTestEcdsaSecp256k1Alias());
-  EXPECT_EQ(ecdsaAliasAccountId.getShardNum(), getTestShardNum());
-  EXPECT_EQ(ecdsaAliasAccountId.getRealmNum(), getTestRealmNum());
-  EXPECT_FALSE(ecdsaAliasAccountId.getAccountNum().has_value());
-  EXPECT_NE(ecdsaAliasAccountId.getPublicKeyAlias(), nullptr);
-  EXPECT_EQ(ecdsaAliasAccountId.getPublicKeyAlias()->toStringDer(), getTestEcdsaSecp256k1Alias()->toStringDer());
-  EXPECT_FALSE(ecdsaAliasAccountId.getEvmAddressAlias().has_value());
+  EXPECT_EQ(ecdsaAliasAccountId.mShardNum, getTestShardNum());
+  EXPECT_EQ(ecdsaAliasAccountId.mRealmNum, getTestRealmNum());
+  EXPECT_FALSE(ecdsaAliasAccountId.mAccountNum.has_value());
+  EXPECT_NE(ecdsaAliasAccountId.mPublicKeyAlias, nullptr);
+  EXPECT_EQ(ecdsaAliasAccountId.mPublicKeyAlias->toStringDer(), getTestEcdsaSecp256k1Alias()->toStringDer());
+  EXPECT_FALSE(ecdsaAliasAccountId.mEvmAddressAlias.has_value());
 
   EXPECT_THROW((AccountId{ getTestNumTooBig(), getTestRealmNum(), getTestEcdsaSecp256k1Alias() }),
                std::invalid_argument);
@@ -159,12 +159,12 @@ TEST_F(AccountIdTest, ConstructWithShardRealmAccountAlias)
 TEST_F(AccountIdTest, ConstructWithShardRealmEvmAddress)
 {
   const AccountId accountId(getTestShardNum(), getTestRealmNum(), getTestEvmAddressAlias());
-  EXPECT_EQ(accountId.getShardNum(), getTestShardNum());
-  EXPECT_EQ(accountId.getRealmNum(), getTestRealmNum());
-  EXPECT_FALSE(accountId.getAccountNum().has_value());
-  EXPECT_EQ(accountId.getPublicKeyAlias(), nullptr);
-  EXPECT_TRUE(accountId.getEvmAddressAlias().has_value());
-  EXPECT_EQ(accountId.getEvmAddressAlias()->toString(), getTestEvmAddressAlias().toString());
+  EXPECT_EQ(accountId.mShardNum, getTestShardNum());
+  EXPECT_EQ(accountId.mRealmNum, getTestRealmNum());
+  EXPECT_FALSE(accountId.mAccountNum.has_value());
+  EXPECT_EQ(accountId.mPublicKeyAlias, nullptr);
+  EXPECT_TRUE(accountId.mEvmAddressAlias.has_value());
+  EXPECT_EQ(accountId.mEvmAddressAlias->toString(), getTestEvmAddressAlias().toString());
 
   EXPECT_THROW((AccountId{ getTestNumTooBig(), getTestRealmNum(), getTestAccountNum() }), std::invalid_argument);
   EXPECT_THROW((AccountId{ getTestShardNum(), getTestNumTooBig(), getTestAccountNum() }), std::invalid_argument);
@@ -223,10 +223,10 @@ TEST_F(AccountIdTest, ConstructFromString)
 
   AccountId accountId;
   EXPECT_NO_THROW(accountId = AccountId::fromString(testShardNumStr + '.' + testRealmNumStr + '.' + testAccountNumStr));
-  EXPECT_EQ(accountId.getShardNum(), getTestShardNum());
-  EXPECT_EQ(accountId.getRealmNum(), getTestRealmNum());
-  EXPECT_TRUE(accountId.getAccountNum().has_value());
-  EXPECT_EQ(*accountId.getAccountNum(), getTestAccountNum());
+  EXPECT_EQ(accountId.mShardNum, getTestShardNum());
+  EXPECT_EQ(accountId.mRealmNum, getTestRealmNum());
+  EXPECT_TRUE(accountId.mAccountNum.has_value());
+  EXPECT_EQ(*accountId.mAccountNum, getTestAccountNum());
 
   EXPECT_THROW(accountId = AccountId::fromString(testShardNumStr + testRealmNumStr + testAccountNumStr),
                std::invalid_argument);
@@ -270,10 +270,10 @@ TEST_F(AccountIdTest, ConstructFromString)
 
   const std::string ed25519AliasStr = getTestEd25519Alias()->toStringDer();
   EXPECT_NO_THROW(accountId = AccountId::fromString(testShardNumStr + '.' + testRealmNumStr + '.' + ed25519AliasStr));
-  EXPECT_EQ(accountId.getShardNum(), getTestShardNum());
-  EXPECT_EQ(accountId.getRealmNum(), getTestRealmNum());
-  EXPECT_NE(accountId.getPublicKeyAlias(), nullptr);
-  EXPECT_EQ(accountId.getPublicKeyAlias()->toStringDer(), ed25519AliasStr);
+  EXPECT_EQ(accountId.mShardNum, getTestShardNum());
+  EXPECT_EQ(accountId.mRealmNum, getTestRealmNum());
+  EXPECT_NE(accountId.mPublicKeyAlias, nullptr);
+  EXPECT_EQ(accountId.mPublicKeyAlias->toStringDer(), ed25519AliasStr);
 
   EXPECT_THROW(accountId = AccountId::fromString(ed25519AliasStr + '.' + testRealmNumStr + '.' + testAccountNumStr),
                std::invalid_argument);
@@ -282,10 +282,10 @@ TEST_F(AccountIdTest, ConstructFromString)
 
   const std::string ecdsaAliasStr = getTestEcdsaSecp256k1Alias()->toStringDer();
   EXPECT_NO_THROW(accountId = AccountId::fromString(testShardNumStr + '.' + testRealmNumStr + '.' + ecdsaAliasStr));
-  EXPECT_EQ(accountId.getShardNum(), getTestShardNum());
-  EXPECT_EQ(accountId.getRealmNum(), getTestRealmNum());
-  EXPECT_NE(accountId.getPublicKeyAlias(), nullptr);
-  EXPECT_EQ(accountId.getPublicKeyAlias()->toStringDer(), ecdsaAliasStr);
+  EXPECT_EQ(accountId.mShardNum, getTestShardNum());
+  EXPECT_EQ(accountId.mRealmNum, getTestRealmNum());
+  EXPECT_NE(accountId.mPublicKeyAlias, nullptr);
+  EXPECT_EQ(accountId.mPublicKeyAlias->toStringDer(), ecdsaAliasStr);
 
   EXPECT_THROW(accountId = AccountId::fromString(ecdsaAliasStr + '.' + testRealmNumStr + '.' + testAccountNumStr),
                std::invalid_argument);
@@ -294,10 +294,10 @@ TEST_F(AccountIdTest, ConstructFromString)
 
   const std::string evmAddressStr = getTestEvmAddressAlias().toString();
   EXPECT_NO_THROW(accountId = AccountId::fromString(testShardNumStr + '.' + testRealmNumStr + '.' + evmAddressStr));
-  EXPECT_EQ(accountId.getShardNum(), getTestShardNum());
-  EXPECT_EQ(accountId.getRealmNum(), getTestRealmNum());
-  EXPECT_TRUE(accountId.getEvmAddressAlias());
-  EXPECT_EQ(accountId.getEvmAddressAlias()->toString(), evmAddressStr);
+  EXPECT_EQ(accountId.mShardNum, getTestShardNum());
+  EXPECT_EQ(accountId.mRealmNum, getTestRealmNum());
+  EXPECT_TRUE(accountId.mEvmAddressAlias);
+  EXPECT_EQ(accountId.mEvmAddressAlias->toString(), evmAddressStr);
 
   EXPECT_THROW(accountId = AccountId::fromString(evmAddressStr + '.' + testRealmNumStr + '.' + testAccountNumStr),
                std::invalid_argument);
@@ -306,87 +306,37 @@ TEST_F(AccountIdTest, ConstructFromString)
 }
 
 //-----
-TEST_F(AccountIdTest, SetGetShardNum)
+TEST_F(AccountIdTest, FromEvmAddress)
 {
-  AccountId accountId;
-  accountId.setShardNum(getTestShardNum());
+  // Given / When
+  const AccountId accountIdFromEvmAddress =
+    AccountId::fromEvmAddress(getTestEvmAddressAlias(), getTestShardNum(), getTestRealmNum());
+  const AccountId accountIdFromEvmAddressStr =
+    AccountId::fromEvmAddress(getTestEvmAddressAlias().toString(), getTestShardNum(), getTestRealmNum());
 
-  EXPECT_EQ(accountId.getShardNum(), getTestShardNum());
-  EXPECT_THROW(accountId.setShardNum(getTestNumTooBig()), std::invalid_argument);
-}
+  // Then
+  EXPECT_EQ(accountIdFromEvmAddress.mShardNum, getTestShardNum());
+  EXPECT_EQ(accountIdFromEvmAddress.mRealmNum, getTestRealmNum());
+  EXPECT_FALSE(accountIdFromEvmAddress.mAccountNum.has_value());
+  EXPECT_EQ(accountIdFromEvmAddress.mPublicKeyAlias, nullptr);
+  ASSERT_TRUE(accountIdFromEvmAddress.mEvmAddressAlias.has_value());
+  EXPECT_EQ(accountIdFromEvmAddress.mEvmAddressAlias->toBytes(), getTestEvmAddressAlias().toBytes());
 
-//-----
-TEST_F(AccountIdTest, SetGetRealmNum)
-{
-  AccountId accountId;
-  accountId.setRealmNum(getTestRealmNum());
-
-  EXPECT_EQ(accountId.getRealmNum(), getTestRealmNum());
-  EXPECT_THROW(accountId.setRealmNum(getTestNumTooBig()), std::invalid_argument);
-}
-
-//-----
-TEST_F(AccountIdTest, SetGetAccountNum)
-{
-  AccountId accountId;
-  accountId.setAccountNum(getTestAccountNum());
-
-  EXPECT_TRUE(accountId.getAccountNum().has_value());
-  EXPECT_EQ(*accountId.getAccountNum(), getTestAccountNum());
-  EXPECT_THROW(accountId.setAccountNum(getTestNumTooBig()), std::invalid_argument);
-}
-
-//-----
-TEST_F(AccountIdTest, SetGetPublicKeyAlias)
-{
-  AccountId accountId;
-  accountId.setPublicKeyAlias(getTestEd25519Alias());
-
-  EXPECT_NE(accountId.getPublicKeyAlias(), nullptr);
-  EXPECT_EQ(accountId.getPublicKeyAlias()->toStringDer(), getTestEd25519Alias()->toStringDer());
-
-  accountId.setPublicKeyAlias(getTestEcdsaSecp256k1Alias());
-
-  EXPECT_NE(accountId.getPublicKeyAlias(), nullptr);
-  EXPECT_EQ(accountId.getPublicKeyAlias()->toStringDer(), getTestEcdsaSecp256k1Alias()->toStringDer());
-}
-
-//-----
-TEST_F(AccountIdTest, SetGetEvmAddressAlias)
-{
-  AccountId accountId;
-  accountId.setEvmAddressAlias(getTestEvmAddressAlias());
-
-  EXPECT_TRUE(accountId.getEvmAddressAlias().has_value());
-  EXPECT_EQ(accountId.getEvmAddressAlias()->toString(), getTestEvmAddressAlias().toString());
-}
-
-//-----
-TEST_F(AccountIdTest, ResetMutuallyExclusiveAccountNumbers)
-{
-  AccountId accountId;
-
-  accountId.setEvmAddressAlias(getTestEvmAddressAlias());
-  accountId.setAccountNum(getTestAccountNum());
-  EXPECT_EQ(accountId.getPublicKeyAlias(), nullptr);
-  EXPECT_FALSE(accountId.getEvmAddressAlias().has_value());
-
-  accountId.setPublicKeyAlias(getTestEcdsaSecp256k1Alias());
-  EXPECT_FALSE(accountId.getAccountNum().has_value());
-  EXPECT_FALSE(accountId.getEvmAddressAlias().has_value());
-
-  accountId.setEvmAddressAlias(getTestEvmAddressAlias());
-  EXPECT_FALSE(accountId.getAccountNum().has_value());
-  EXPECT_EQ(accountId.getPublicKeyAlias(), nullptr);
+  EXPECT_EQ(accountIdFromEvmAddress.mShardNum, accountIdFromEvmAddressStr.mShardNum);
+  EXPECT_EQ(accountIdFromEvmAddress.mRealmNum, accountIdFromEvmAddressStr.mRealmNum);
+  EXPECT_EQ(accountIdFromEvmAddress.mAccountNum, accountIdFromEvmAddressStr.mAccountNum);
+  EXPECT_EQ(accountIdFromEvmAddress.mPublicKeyAlias, accountIdFromEvmAddressStr.mPublicKeyAlias);
+  EXPECT_EQ(accountIdFromEvmAddress.mEvmAddressAlias->toBytes(),
+            accountIdFromEvmAddressStr.mEvmAddressAlias->toBytes());
 }
 
 //-----
 TEST_F(AccountIdTest, ProtobufAccountId)
 {
   AccountId accountId;
-  accountId.setShardNum(getTestShardNum());
-  accountId.setRealmNum(getTestRealmNum());
-  accountId.setAccountNum(getTestAccountNum());
+  accountId.mShardNum = getTestShardNum();
+  accountId.mRealmNum = getTestRealmNum();
+  accountId.mAccountNum = getTestAccountNum();
 
   // Serialize shard, realm, account number
   std::unique_ptr<proto::AccountID> protoAccountId = accountId.toProtobuf();
@@ -407,13 +357,14 @@ TEST_F(AccountIdTest, ProtobufAccountId)
 
   // Deserialize shard, realm, account number
   accountId = AccountId::fromProtobuf(*protoAccountId);
-  EXPECT_EQ(accountId.getShardNum(), newShard);
-  EXPECT_EQ(accountId.getRealmNum(), newRealm);
-  EXPECT_TRUE(accountId.getAccountNum().has_value());
-  EXPECT_EQ(*accountId.getAccountNum(), newAccount);
+  EXPECT_EQ(accountId.mShardNum, newShard);
+  EXPECT_EQ(accountId.mRealmNum, newRealm);
+  EXPECT_TRUE(accountId.mAccountNum.has_value());
+  EXPECT_EQ(*accountId.mAccountNum, newAccount);
 
   // Serialize ED25519 alias
-  accountId.setPublicKeyAlias(getTestEd25519Alias());
+  accountId.mAccountNum.reset();
+  accountId.mPublicKeyAlias = getTestEd25519Alias();
   protoAccountId = accountId.toProtobuf();
   EXPECT_EQ(protoAccountId->account_case(), proto::AccountID::AccountCase::kAlias);
 
@@ -425,11 +376,11 @@ TEST_F(AccountIdTest, ProtobufAccountId)
 
   // Deserialize ED25519 alias
   accountId = AccountId::fromProtobuf(*protoAccountId);
-  EXPECT_NE(accountId.getPublicKeyAlias(), nullptr);
-  EXPECT_EQ(accountId.getPublicKeyAlias()->toBytesDer(), key->getPublicKey()->toBytesDer());
+  EXPECT_NE(accountId.mPublicKeyAlias, nullptr);
+  EXPECT_EQ(accountId.mPublicKeyAlias->toBytesDer(), key->getPublicKey()->toBytesDer());
 
   // Serialize ECDSA alias
-  accountId.setPublicKeyAlias(getTestEcdsaSecp256k1Alias());
+  accountId.mPublicKeyAlias = getTestEcdsaSecp256k1Alias();
   protoAccountId = accountId.toProtobuf();
   EXPECT_EQ(protoAccountId->account_case(), proto::AccountID::AccountCase::kAlias);
 
@@ -440,11 +391,12 @@ TEST_F(AccountIdTest, ProtobufAccountId)
 
   // Deserialize ECDSA alias
   accountId = AccountId::fromProtobuf(*protoAccountId);
-  EXPECT_NE(accountId.getPublicKeyAlias(), nullptr);
-  EXPECT_EQ(accountId.getPublicKeyAlias()->toBytesDer(), key->getPublicKey()->toBytesDer());
+  EXPECT_NE(accountId.mPublicKeyAlias, nullptr);
+  EXPECT_EQ(accountId.mPublicKeyAlias->toBytesDer(), key->getPublicKey()->toBytesDer());
 
   // Serialize EVM address
-  accountId.setEvmAddressAlias(getTestEvmAddressAlias());
+  accountId.mPublicKeyAlias = nullptr;
+  accountId.mEvmAddressAlias = getTestEvmAddressAlias();
   protoAccountId = accountId.toProtobuf();
   EXPECT_EQ(protoAccountId->account_case(), proto::AccountID::AccountCase::kAlias);
 
@@ -457,8 +409,8 @@ TEST_F(AccountIdTest, ProtobufAccountId)
 
   // Deserialize EVM address
   accountId = AccountId::fromProtobuf(*protoAccountId);
-  EXPECT_TRUE(accountId.getEvmAddressAlias().has_value());
-  EXPECT_EQ(accountId.getEvmAddressAlias()->toBytes(), testBytes);
+  EXPECT_TRUE(accountId.mEvmAddressAlias.has_value());
+  EXPECT_EQ(accountId.mEvmAddressAlias->toBytes(), testBytes);
 }
 
 //-----
@@ -467,24 +419,26 @@ TEST_F(AccountIdTest, ToString)
   AccountId accountId;
   EXPECT_EQ(accountId.toString(), "0.0.0");
 
-  accountId.setShardNum(getTestShardNum());
-  accountId.setRealmNum(getTestRealmNum());
-  accountId.setAccountNum(getTestAccountNum());
+  accountId.mShardNum = getTestShardNum();
+  accountId.mRealmNum = getTestRealmNum();
+  accountId.mAccountNum = getTestAccountNum();
   EXPECT_EQ(accountId.toString(),
             std::to_string(getTestShardNum()) + '.' + std::to_string(getTestRealmNum()) + '.' +
               std::to_string(getTestAccountNum()));
 
-  accountId.setPublicKeyAlias(getTestEd25519Alias());
+  accountId.mAccountNum.reset();
+  accountId.mPublicKeyAlias = getTestEd25519Alias();
   EXPECT_EQ(accountId.toString(),
             std::to_string(getTestShardNum()) + '.' + std::to_string(getTestRealmNum()) + '.' +
               getTestEd25519Alias()->toStringDer());
 
-  accountId.setPublicKeyAlias(getTestEcdsaSecp256k1Alias());
+  accountId.mPublicKeyAlias = getTestEcdsaSecp256k1Alias();
   EXPECT_EQ(accountId.toString(),
             std::to_string(getTestShardNum()) + '.' + std::to_string(getTestRealmNum()) + '.' +
               getTestEcdsaSecp256k1Alias()->toStringDer());
 
-  accountId.setEvmAddressAlias(getTestEvmAddressAlias());
+  accountId.mPublicKeyAlias = nullptr;
+  accountId.mEvmAddressAlias = getTestEvmAddressAlias();
   EXPECT_EQ(accountId.toString(),
             std::to_string(getTestShardNum()) + '.' + std::to_string(getTestRealmNum()) + '.' +
               getTestEvmAddressAlias().toString());

--- a/sdk/tests/unit/AssessedCustomFeesTest.cc
+++ b/sdk/tests/unit/AssessedCustomFeesTest.cc
@@ -90,12 +90,10 @@ TEST_F(AssessedCustomFeeTest, ToProtobuf)
   EXPECT_EQ(protoAssessedCustomFee->token_id().realmnum(), getTestTokenId().getRealmNum());
   EXPECT_EQ(protoAssessedCustomFee->token_id().tokennum(), getTestTokenId().getTokenNum());
   ASSERT_TRUE(protoAssessedCustomFee->has_fee_collector_account_id());
-  EXPECT_EQ(protoAssessedCustomFee->fee_collector_account_id().shardnum(),
-            getTestFeeCollectorAccountId().getShardNum());
-  EXPECT_EQ(protoAssessedCustomFee->fee_collector_account_id().realmnum(),
-            getTestFeeCollectorAccountId().getRealmNum());
+  EXPECT_EQ(protoAssessedCustomFee->fee_collector_account_id().shardnum(), getTestFeeCollectorAccountId().mShardNum);
+  EXPECT_EQ(protoAssessedCustomFee->fee_collector_account_id().realmnum(), getTestFeeCollectorAccountId().mRealmNum);
   EXPECT_EQ(protoAssessedCustomFee->fee_collector_account_id().accountnum(),
-            getTestFeeCollectorAccountId().getAccountNum());
+            getTestFeeCollectorAccountId().mAccountNum);
   EXPECT_EQ(protoAssessedCustomFee->effective_payer_account_id_size(), getTestPayerAccountIdList().size());
 }
 

--- a/sdk/tests/unit/CustomFixedFeeTest.cc
+++ b/sdk/tests/unit/CustomFixedFeeTest.cc
@@ -87,9 +87,9 @@ TEST_F(CustomFixedFeeTest, ToProtobuf)
   const std::unique_ptr<proto::CustomFee> protoCustomFee = customFixedFee.toProtobuf();
 
   // Then
-  EXPECT_EQ(protoCustomFee->fee_collector_account_id().shardnum(), getTestFeeCollectorAccountId().getShardNum());
-  EXPECT_EQ(protoCustomFee->fee_collector_account_id().realmnum(), getTestFeeCollectorAccountId().getRealmNum());
-  EXPECT_EQ(protoCustomFee->fee_collector_account_id().accountnum(), getTestFeeCollectorAccountId().getAccountNum());
+  EXPECT_EQ(protoCustomFee->fee_collector_account_id().shardnum(), getTestFeeCollectorAccountId().mShardNum);
+  EXPECT_EQ(protoCustomFee->fee_collector_account_id().realmnum(), getTestFeeCollectorAccountId().mRealmNum);
+  EXPECT_EQ(protoCustomFee->fee_collector_account_id().accountnum(), getTestFeeCollectorAccountId().mAccountNum);
   EXPECT_EQ(protoCustomFee->all_collectors_are_exempt(), getTestAllCollectorsAreExempt());
 
   ASSERT_EQ(protoCustomFee->fee_case(), proto::CustomFee::FeeCase::kFixedFee);

--- a/sdk/tests/unit/CustomFractionalFeeTest.cc
+++ b/sdk/tests/unit/CustomFractionalFeeTest.cc
@@ -103,9 +103,9 @@ TEST_F(CustomFractionalFeeTest, ToProtobuf)
   const std::unique_ptr<proto::CustomFee> protoCustomFee = customFractionalFee.toProtobuf();
 
   // Then
-  EXPECT_EQ(protoCustomFee->fee_collector_account_id().shardnum(), getTestFeeCollectorAccountId().getShardNum());
-  EXPECT_EQ(protoCustomFee->fee_collector_account_id().realmnum(), getTestFeeCollectorAccountId().getRealmNum());
-  EXPECT_EQ(protoCustomFee->fee_collector_account_id().accountnum(), getTestFeeCollectorAccountId().getAccountNum());
+  EXPECT_EQ(protoCustomFee->fee_collector_account_id().shardnum(), getTestFeeCollectorAccountId().mShardNum);
+  EXPECT_EQ(protoCustomFee->fee_collector_account_id().realmnum(), getTestFeeCollectorAccountId().mRealmNum);
+  EXPECT_EQ(protoCustomFee->fee_collector_account_id().accountnum(), getTestFeeCollectorAccountId().mAccountNum);
   EXPECT_EQ(protoCustomFee->all_collectors_are_exempt(), getTestAllCollectorsAreExempt());
 
   ASSERT_EQ(protoCustomFee->fee_case(), proto::CustomFee::FeeCase::kFractionalFee);

--- a/sdk/tests/unit/CustomRoyaltyFeeTest.cc
+++ b/sdk/tests/unit/CustomRoyaltyFeeTest.cc
@@ -93,9 +93,9 @@ TEST_F(CustomRoyaltyFeeTest, ToProtobuf)
   const std::unique_ptr<proto::CustomFee> protoCustomFee = customRoyaltyFee.toProtobuf();
 
   // Then
-  EXPECT_EQ(protoCustomFee->fee_collector_account_id().shardnum(), getTestFeeCollectorAccountId().getShardNum());
-  EXPECT_EQ(protoCustomFee->fee_collector_account_id().realmnum(), getTestFeeCollectorAccountId().getRealmNum());
-  EXPECT_EQ(protoCustomFee->fee_collector_account_id().accountnum(), getTestFeeCollectorAccountId().getAccountNum());
+  EXPECT_EQ(protoCustomFee->fee_collector_account_id().shardnum(), getTestFeeCollectorAccountId().mShardNum);
+  EXPECT_EQ(protoCustomFee->fee_collector_account_id().realmnum(), getTestFeeCollectorAccountId().mRealmNum);
+  EXPECT_EQ(protoCustomFee->fee_collector_account_id().accountnum(), getTestFeeCollectorAccountId().mAccountNum);
   EXPECT_EQ(protoCustomFee->all_collectors_are_exempt(), getTestAllCollectorsAreExempt());
 
   ASSERT_EQ(protoCustomFee->fee_case(), proto::CustomFee::FeeCase::kRoyaltyFee);

--- a/sdk/tests/unit/HbarTransferTest.cc
+++ b/sdk/tests/unit/HbarTransferTest.cc
@@ -54,7 +54,7 @@ TEST_F(HbarTransferTest, SerializeTransferToProtobuf)
   const auto protoAccountAmountPtr = std::unique_ptr<proto::AccountAmount>(testTransfer.toProtobuf());
 
   // Then
-  EXPECT_EQ(protoAccountAmountPtr->accountid().accountnum(), testAccountId.getAccountNum());
+  EXPECT_EQ(protoAccountAmountPtr->accountid().accountnum(), testAccountId.mAccountNum);
   EXPECT_EQ(protoAccountAmountPtr->amount(), testAmount);
   EXPECT_FALSE(protoAccountAmountPtr->is_approval());
 }
@@ -95,7 +95,7 @@ TEST_F(HbarTransferTest, ProtoTransfer)
   EXPECT_EQ(transfer.getAmount().toTinybars(), amount);
   EXPECT_TRUE(transfer.getApproval());
 
-  accountId.setAccountNum(15ULL);
+  accountId.mAccountNum = 15ULL;
   amount = 15LL;
 
   transfer.setAccountId(accountId);
@@ -103,7 +103,7 @@ TEST_F(HbarTransferTest, ProtoTransfer)
   transfer.setApproved(false);
 
   const auto protoAccountAmountPtr = std::unique_ptr<proto::AccountAmount>(transfer.toProtobuf());
-  EXPECT_EQ(protoAccountAmountPtr->accountid().accountnum(), accountId.getAccountNum());
+  EXPECT_EQ(protoAccountAmountPtr->accountid().accountnum(), accountId.mAccountNum);
   EXPECT_EQ(protoAccountAmountPtr->amount(), amount);
   EXPECT_FALSE(protoAccountAmountPtr->is_approval());
 }

--- a/sdk/tests/unit/NodeAddressTest.cc
+++ b/sdk/tests/unit/NodeAddressTest.cc
@@ -18,9 +18,7 @@
  *
  */
 #include "impl/NodeAddress.h"
-#include "exceptions/IllegalStateException.h"
 #include "impl/Endpoint.h"
-#include "impl/HexConverter.h"
 #include "impl/IPv4Address.h"
 #include "impl/Utilities.h"
 
@@ -75,11 +73,11 @@ TEST_F(NodeAddressTest, DefaultConstructNodeAddress)
   EXPECT_TRUE(nodeAddress.isTlsPort(testPortTLS));
   EXPECT_FALSE(nodeAddress.isNonTlsPort(testPortTLS));
   EXPECT_EQ(nodeAddress.getNodeId(), -1);
-  EXPECT_EQ(nodeAddress.getNodeAccountId().getShardNum(), 0ULL);
-  EXPECT_EQ(nodeAddress.getNodeAccountId().getRealmNum(), 0ULL);
-  EXPECT_FALSE(nodeAddress.getNodeAccountId().getAccountNum().has_value());
-  EXPECT_EQ(nodeAddress.getNodeAccountId().getPublicKeyAlias(), nullptr);
-  EXPECT_FALSE(nodeAddress.getNodeAccountId().getEvmAddressAlias().has_value());
+  EXPECT_EQ(nodeAddress.getNodeAccountId().mShardNum, 0ULL);
+  EXPECT_EQ(nodeAddress.getNodeAccountId().mRealmNum, 0ULL);
+  EXPECT_FALSE(nodeAddress.getNodeAccountId().mAccountNum.has_value());
+  EXPECT_EQ(nodeAddress.getNodeAccountId().mPublicKeyAlias, nullptr);
+  EXPECT_FALSE(nodeAddress.getNodeAccountId().mEvmAddressAlias.has_value());
   EXPECT_TRUE(nodeAddress.getNodeCertHash().empty());
   EXPECT_TRUE(nodeAddress.getDescription().empty());
   EXPECT_TRUE(nodeAddress.getEndpoints().empty());
@@ -148,11 +146,11 @@ TEST_F(NodeAddressTest, ConstructFromProtobuf)
   EXPECT_EQ(nodeAddress.getDefaultPort(), getTestPortTLS());
   EXPECT_EQ(nodeAddress.getNodeId(), testNodeId);
   EXPECT_EQ(nodeAddress.getPublicKey(), testRSAPublicKey);
-  EXPECT_EQ(nodeAddress.getNodeAccountId().getShardNum(), 0ULL);
-  EXPECT_EQ(nodeAddress.getNodeAccountId().getRealmNum(), 0ULL);
-  EXPECT_FALSE(nodeAddress.getNodeAccountId().getAccountNum().has_value());
-  EXPECT_EQ(nodeAddress.getNodeAccountId().getPublicKeyAlias(), nullptr);
-  EXPECT_FALSE(nodeAddress.getNodeAccountId().getEvmAddressAlias().has_value());
+  EXPECT_EQ(nodeAddress.getNodeAccountId().mShardNum, 0ULL);
+  EXPECT_EQ(nodeAddress.getNodeAccountId().mRealmNum, 0ULL);
+  EXPECT_FALSE(nodeAddress.getNodeAccountId().mAccountNum.has_value());
+  EXPECT_EQ(nodeAddress.getNodeAccountId().mPublicKeyAlias, nullptr);
+  EXPECT_FALSE(nodeAddress.getNodeAccountId().mEvmAddressAlias.has_value());
   EXPECT_TRUE(nodeAddress.getNodeCertHash().empty());
   EXPECT_FALSE(nodeAddress.getDescription().empty());
   EXPECT_EQ(nodeAddress.getDescription(), testDescription);
@@ -174,12 +172,12 @@ TEST_F(NodeAddressTest, ConstructFromString)
   EXPECT_EQ(nodeAddress.getDefaultIpAddress().toString(), testIpAddressV4);
   EXPECT_EQ(nodeAddress.getDefaultPort(), testPort);
   EXPECT_EQ(nodeAddress.getNodeId(), -1);
-  EXPECT_FALSE(nodeAddress.getNodeAccountId().getEvmAddressAlias().has_value());
-  EXPECT_EQ(nodeAddress.getNodeAccountId().getShardNum(), 0ULL);
-  EXPECT_EQ(nodeAddress.getNodeAccountId().getRealmNum(), 0ULL);
-  EXPECT_FALSE(nodeAddress.getNodeAccountId().getAccountNum().has_value());
-  EXPECT_EQ(nodeAddress.getNodeAccountId().getPublicKeyAlias(), nullptr);
-  EXPECT_FALSE(nodeAddress.getNodeAccountId().getEvmAddressAlias().has_value());
+  EXPECT_FALSE(nodeAddress.getNodeAccountId().mEvmAddressAlias.has_value());
+  EXPECT_EQ(nodeAddress.getNodeAccountId().mShardNum, 0ULL);
+  EXPECT_EQ(nodeAddress.getNodeAccountId().mRealmNum, 0ULL);
+  EXPECT_FALSE(nodeAddress.getNodeAccountId().mAccountNum.has_value());
+  EXPECT_EQ(nodeAddress.getNodeAccountId().mPublicKeyAlias, nullptr);
+  EXPECT_FALSE(nodeAddress.getNodeAccountId().mEvmAddressAlias.has_value());
   EXPECT_TRUE(nodeAddress.getNodeCertHash().empty());
   EXPECT_TRUE(nodeAddress.getDescription().empty());
   EXPECT_FALSE(nodeAddress.getEndpoints().empty());

--- a/sdk/tests/unit/ScheduleInfoUnitTests.cc
+++ b/sdk/tests/unit/ScheduleInfoUnitTests.cc
@@ -189,18 +189,18 @@ TEST_F(ScheduleInfoTest, ToProtobuf)
   EXPECT_EQ(protoScheduleInfo->adminkey().ed25519(),
             internal::Utilities::byteVectorToString(getTestAdminKey()->toBytesRaw()));
   EXPECT_EQ(protoScheduleInfo->signers().keys_size(), getTestSigners().size());
-  EXPECT_EQ(protoScheduleInfo->creatoraccountid().shardnum(), getTestCreatorAccountId().getShardNum());
-  EXPECT_EQ(protoScheduleInfo->creatoraccountid().realmnum(), getTestCreatorAccountId().getRealmNum());
-  EXPECT_EQ(protoScheduleInfo->creatoraccountid().accountnum(), getTestCreatorAccountId().getAccountNum());
-  EXPECT_EQ(protoScheduleInfo->payeraccountid().shardnum(), getTestPayerAccountId().getShardNum());
-  EXPECT_EQ(protoScheduleInfo->payeraccountid().realmnum(), getTestPayerAccountId().getRealmNum());
-  EXPECT_EQ(protoScheduleInfo->payeraccountid().accountnum(), getTestPayerAccountId().getAccountNum());
+  EXPECT_EQ(protoScheduleInfo->creatoraccountid().shardnum(), getTestCreatorAccountId().mShardNum);
+  EXPECT_EQ(protoScheduleInfo->creatoraccountid().realmnum(), getTestCreatorAccountId().mRealmNum);
+  EXPECT_EQ(protoScheduleInfo->creatoraccountid().accountnum(), getTestCreatorAccountId().mAccountNum);
+  EXPECT_EQ(protoScheduleInfo->payeraccountid().shardnum(), getTestPayerAccountId().mShardNum);
+  EXPECT_EQ(protoScheduleInfo->payeraccountid().realmnum(), getTestPayerAccountId().mRealmNum);
+  EXPECT_EQ(protoScheduleInfo->payeraccountid().accountnum(), getTestPayerAccountId().mAccountNum);
   EXPECT_EQ(protoScheduleInfo->scheduledtransactionid().accountid().shardnum(),
-            getTestScheduledTransactionId().getAccountId().getShardNum());
+            getTestScheduledTransactionId().getAccountId().mShardNum);
   EXPECT_EQ(protoScheduleInfo->scheduledtransactionid().accountid().realmnum(),
-            getTestScheduledTransactionId().getAccountId().getRealmNum());
+            getTestScheduledTransactionId().getAccountId().mRealmNum);
   EXPECT_EQ(protoScheduleInfo->scheduledtransactionid().accountid().accountnum(),
-            getTestScheduledTransactionId().getAccountId().getAccountNum());
+            getTestScheduledTransactionId().getAccountId().mAccountNum);
   EXPECT_EQ(
     protoScheduleInfo->scheduledtransactionid().transactionvalidstart().seconds(),
     internal::TimestampConverter::toProtobuf(getTestScheduledTransactionId().getValidTransactionTime())->seconds());

--- a/sdk/tests/unit/TokenAssociationUnitTests.cc
+++ b/sdk/tests/unit/TokenAssociationUnitTests.cc
@@ -65,9 +65,9 @@ TEST_F(TokenAssociationTest, ToProtobuf)
 
   // Then
   ASSERT_TRUE(protoTokenAssociation->has_account_id());
-  EXPECT_EQ(protoTokenAssociation->account_id().shardnum(), getTestAccountId().getShardNum());
-  EXPECT_EQ(protoTokenAssociation->account_id().realmnum(), getTestAccountId().getRealmNum());
-  EXPECT_EQ(protoTokenAssociation->account_id().accountnum(), getTestAccountId().getAccountNum());
+  EXPECT_EQ(protoTokenAssociation->account_id().shardnum(), getTestAccountId().mShardNum);
+  EXPECT_EQ(protoTokenAssociation->account_id().realmnum(), getTestAccountId().mRealmNum);
+  EXPECT_EQ(protoTokenAssociation->account_id().accountnum(), getTestAccountId().mAccountNum);
   ASSERT_TRUE(protoTokenAssociation->has_token_id());
   EXPECT_EQ(protoTokenAssociation->token_id().shardnum(), getTestTokenId().getShardNum());
   EXPECT_EQ(protoTokenAssociation->token_id().realmnum(), getTestTokenId().getRealmNum());

--- a/sdk/tests/unit/TokenInfoUnitTests.cc
+++ b/sdk/tests/unit/TokenInfoUnitTests.cc
@@ -344,9 +344,9 @@ TEST_F(TokenInfoTest, ToProtobuf)
   EXPECT_EQ(protoTokenInfo->symbol(), getTestTokenSymbol());
   EXPECT_EQ(protoTokenInfo->decimals(), getTestDecimals());
   EXPECT_EQ(protoTokenInfo->totalsupply(), getTestTotalSupply());
-  EXPECT_EQ(protoTokenInfo->treasury().shardnum(), getTestTreasuryAccountId().getShardNum());
-  EXPECT_EQ(protoTokenInfo->treasury().realmnum(), getTestTreasuryAccountId().getRealmNum());
-  EXPECT_EQ(protoTokenInfo->treasury().accountnum(), getTestTreasuryAccountId().getAccountNum());
+  EXPECT_EQ(protoTokenInfo->treasury().shardnum(), getTestTreasuryAccountId().mShardNum);
+  EXPECT_EQ(protoTokenInfo->treasury().realmnum(), getTestTreasuryAccountId().mRealmNum);
+  EXPECT_EQ(protoTokenInfo->treasury().accountnum(), getTestTreasuryAccountId().mAccountNum);
   EXPECT_EQ(protoTokenInfo->adminkey().ecdsa_secp256k1(),
             internal::Utilities::byteVectorToString(getTestAdminKey()->toBytesRaw()));
   EXPECT_EQ(protoTokenInfo->kyckey().ecdsa_secp256k1(),
@@ -368,9 +368,9 @@ TEST_F(TokenInfoTest, ToProtobuf)
        ? proto::TokenKycStatus::KycNotApplicable
        : (getTestDefaultKycStatus().value() ? proto::TokenKycStatus::Granted : proto::TokenKycStatus::Revoked)));
   EXPECT_EQ(protoTokenInfo->deleted(), getTestIsDeleted());
-  EXPECT_EQ(protoTokenInfo->autorenewaccount().shardnum(), getTestAutoRenewAccountId().getShardNum());
-  EXPECT_EQ(protoTokenInfo->autorenewaccount().realmnum(), getTestAutoRenewAccountId().getRealmNum());
-  EXPECT_EQ(protoTokenInfo->autorenewaccount().accountnum(), getTestAutoRenewAccountId().getAccountNum());
+  EXPECT_EQ(protoTokenInfo->autorenewaccount().shardnum(), getTestAutoRenewAccountId().mShardNum);
+  EXPECT_EQ(protoTokenInfo->autorenewaccount().realmnum(), getTestAutoRenewAccountId().mRealmNum);
+  EXPECT_EQ(protoTokenInfo->autorenewaccount().accountnum(), getTestAutoRenewAccountId().mAccountNum);
   EXPECT_EQ(protoTokenInfo->autorenewperiod().seconds(),
             internal::DurationConverter::toProtobuf(getTestAutoRenewPeriod())->seconds());
   EXPECT_EQ(protoTokenInfo->expiry().seconds(),

--- a/sdk/tests/unit/TokenNftTransferTest.cc
+++ b/sdk/tests/unit/TokenNftTransferTest.cc
@@ -92,8 +92,8 @@ TEST_F(TokenNftTransferTest, ProtobufTokenNftTransfer)
   tokenNftTransfer.setApproval(getTestIsApproval());
 
   std::unique_ptr<proto::NftTransfer> protoNftTransfer = tokenNftTransfer.toProtobuf();
-  EXPECT_EQ(protoNftTransfer->senderaccountid().accountnum(), getTestSenderAccountId().getAccountNum());
-  EXPECT_EQ(protoNftTransfer->receiveraccountid().accountnum(), getTestReceiverAccountId().getAccountNum());
+  EXPECT_EQ(protoNftTransfer->senderaccountid().accountnum(), getTestSenderAccountId().mAccountNum);
+  EXPECT_EQ(protoNftTransfer->receiveraccountid().accountnum(), getTestReceiverAccountId().mAccountNum);
   EXPECT_EQ(protoNftTransfer->serialnumber(), getTestNftId().getSerialNum());
   EXPECT_EQ(protoNftTransfer->is_approval(), getTestIsApproval());
 

--- a/sdk/tests/unit/TokenTransferTest.cc
+++ b/sdk/tests/unit/TokenTransferTest.cc
@@ -126,9 +126,9 @@ TEST_F(TokenTransferTest, ToProtobuf)
   const std::unique_ptr<proto::AccountAmount> proto = tokenTransfer.toProtobuf();
 
   // Then
-  EXPECT_EQ(proto->accountid().shardnum(), getTestAccountId().getShardNum());
-  EXPECT_EQ(proto->accountid().realmnum(), getTestAccountId().getRealmNum());
-  EXPECT_EQ(proto->accountid().accountnum(), getTestAccountId().getAccountNum());
+  EXPECT_EQ(proto->accountid().shardnum(), getTestAccountId().mShardNum);
+  EXPECT_EQ(proto->accountid().realmnum(), getTestAccountId().mRealmNum);
+  EXPECT_EQ(proto->accountid().accountnum(), getTestAccountId().mAccountNum);
   EXPECT_EQ(proto->amount(), getTestAmount());
   EXPECT_EQ(proto->is_approval(), getTestIsApproval());
 }

--- a/sdk/tests/unit/TopicInfoUnitTests.cc
+++ b/sdk/tests/unit/TopicInfoUnitTests.cc
@@ -171,12 +171,10 @@ TEST_F(TopicInfoTest, ToProtobuf)
             internal::Utilities::byteVectorToString(getTestSubmitKey()->toBytesRaw()));
   EXPECT_EQ(protoTopicInfo->mutable_topicinfo()->autorenewperiod().seconds(),
             internal::DurationConverter::toProtobuf(getTestAutoRenewPeriod())->seconds());
-  EXPECT_EQ(protoTopicInfo->mutable_topicinfo()->autorenewaccount().shardnum(),
-            getTestAutoRenewAccountId().getShardNum());
-  EXPECT_EQ(protoTopicInfo->mutable_topicinfo()->autorenewaccount().realmnum(),
-            getTestAutoRenewAccountId().getRealmNum());
+  EXPECT_EQ(protoTopicInfo->mutable_topicinfo()->autorenewaccount().shardnum(), getTestAutoRenewAccountId().mShardNum);
+  EXPECT_EQ(protoTopicInfo->mutable_topicinfo()->autorenewaccount().realmnum(), getTestAutoRenewAccountId().mRealmNum);
   EXPECT_EQ(protoTopicInfo->mutable_topicinfo()->autorenewaccount().accountnum(),
-            getTestAutoRenewAccountId().getAccountNum());
+            getTestAutoRenewAccountId().mAccountNum);
   EXPECT_EQ(protoTopicInfo->mutable_topicinfo()->ledger_id(),
             internal::Utilities::byteVectorToString(getTestLedgerId().toBytes()));
 }

--- a/sdk/tests/unit/TransactionIdTest.cc
+++ b/sdk/tests/unit/TransactionIdTest.cc
@@ -62,9 +62,9 @@ TEST_F(TransactionIdTest, SerializeTransactionIdToProtobuf)
   const auto protoTimestampPtr = std::unique_ptr<proto::Timestamp>(internal::TimestampConverter::toProtobuf(now));
 
   // Then
-  EXPECT_EQ(static_cast<uint64_t>(protoTransactionIdPtr->accountid().shardnum()), testAccountId.getShardNum());
-  EXPECT_EQ(static_cast<uint64_t>(protoTransactionIdPtr->accountid().realmnum()), testAccountId.getRealmNum());
-  EXPECT_EQ(static_cast<uint64_t>(protoTransactionIdPtr->accountid().accountnum()), testAccountId.getAccountNum());
+  EXPECT_EQ(static_cast<uint64_t>(protoTransactionIdPtr->accountid().shardnum()), testAccountId.mShardNum);
+  EXPECT_EQ(static_cast<uint64_t>(protoTransactionIdPtr->accountid().realmnum()), testAccountId.mRealmNum);
+  EXPECT_EQ(static_cast<uint64_t>(protoTransactionIdPtr->accountid().accountnum()), testAccountId.mAccountNum);
   EXPECT_EQ(protoTransactionIdPtr->transactionvalidstart().seconds(), protoTimestampPtr->seconds());
 }
 
@@ -83,9 +83,7 @@ TEST_F(TransactionIdTest, DeserializeTransactionIdFromProtobuf)
   const TransactionId transactionId = TransactionId::fromProtobuf(testProtoTransactionId);
 
   // Then
-  EXPECT_EQ(transactionId.getAccountId().getAccountNum(), testAccountId.getAccountNum());
-  EXPECT_EQ(transactionId.getAccountId().getRealmNum(), testAccountId.getRealmNum());
-  EXPECT_EQ(transactionId.getAccountId().getShardNum(), testAccountId.getShardNum());
+  EXPECT_EQ(transactionId.getAccountId(), testAccountId);
   EXPECT_EQ(transactionId.getValidTransactionTime(), now);
 }
 
@@ -104,9 +102,9 @@ TEST_F(TransactionIdTest, ProtobufTransactionId)
 
   const auto protoTransactionIdPtr = std::unique_ptr<proto::TransactionID>(transactionId.toProtobuf());
   const auto protoTimestampPtr = std::unique_ptr<proto::Timestamp>(internal::TimestampConverter::toProtobuf(now));
-  EXPECT_EQ(static_cast<uint64_t>(protoTransactionIdPtr->accountid().shardnum()), getTestAccountId().getShardNum());
-  EXPECT_EQ(static_cast<uint64_t>(protoTransactionIdPtr->accountid().realmnum()), getTestAccountId().getRealmNum());
-  EXPECT_EQ(static_cast<uint64_t>(protoTransactionIdPtr->accountid().accountnum()), getTestAccountId().getAccountNum());
+  EXPECT_EQ(static_cast<uint64_t>(protoTransactionIdPtr->accountid().shardnum()), getTestAccountId().mShardNum);
+  EXPECT_EQ(static_cast<uint64_t>(protoTransactionIdPtr->accountid().realmnum()), getTestAccountId().mRealmNum);
+  EXPECT_EQ(static_cast<uint64_t>(protoTransactionIdPtr->accountid().accountnum()), getTestAccountId().mAccountNum);
   EXPECT_EQ(protoTransactionIdPtr->transactionvalidstart().seconds(), protoTimestampPtr->seconds());
   EXPECT_EQ(protoTransactionIdPtr->transactionvalidstart().nanos(), protoTimestampPtr->nanos());
 }


### PR DESCRIPTION
**Description**:
This PR adds the `AccountCreationWaysExample`, which shows users the different ways accounts can be represented.

It also adds `AccountId::fromEvmAddress()` to allow for Long-Zero account ID formats to be realized correctly, as well as more aligns `AccountId`s structure with other SDKs (most notably, make private member variables public and remove setter-getter functions).

This also depends on work done in #487, so that PR should be reviewed and merged first.

**Related issue(s)**:

Fixes #492 

**Checklist**

- [x] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
