### PR TITLE
Finish APIs for `Transaction`, `Query`, and a lot of internal classes

### DIFF
--- a/sdk/examples/CMakeLists.txt
+++ b/sdk/examples/CMakeLists.txt
@@ -1,5 +1,6 @@
 set(ACCOUNT_ALLOWANCE_EXAMPLE_NAME ${PROJECT_NAME}-account-allowance-example)
 set(CONSENSUS_PUB_SUB_EXAMPLE_NAME ${PROJECT_NAME}-consensus-pub-sub-example)
+set(CONSENSUS_PUB_SUB_CHUNKED_EXAMPLE_NAME ${PROJECT_NAME}-consensus-pub-sub-chunked-example)
 set(CREATE_ACCOUNT_EXAMPLE_NAME ${PROJECT_NAME}-create-account-example)
 set(CREATE_SIMPLE_CONTRACT_EXAMPLE_NAME ${PROJECT_NAME}-create-simple-contract-example)
 set(CREATE_STATEFUL_CONTRACT_EXAMPLE_NAME ${PROJECT_NAME}-create-stateful-contract-example)
@@ -24,6 +25,7 @@ set(UPDATE_ACCOUNT_PUBLIC_KEY_EXAMPLE_NAME ${PROJECT_NAME}-update-account-public
 
 add_executable(${ACCOUNT_ALLOWANCE_EXAMPLE_NAME} AccountAllowanceExample.cc)
 add_executable(${CONSENSUS_PUB_SUB_EXAMPLE_NAME} ConsensusPubSubExample.cc)
+add_executable(${CONSENSUS_PUB_SUB_CHUNKED_EXAMPLE_NAME} ConsensusPubSubChunkedExample.cc)
 add_executable(${CREATE_ACCOUNT_EXAMPLE_NAME} CreateAccountExample.cc)
 add_executable(${CREATE_SIMPLE_CONTRACT_EXAMPLE_NAME} CreateSimpleContractExample.cc)
 add_executable(${CREATE_STATEFUL_CONTRACT_EXAMPLE_NAME} CreateStatefulContractExample.cc)
@@ -66,6 +68,7 @@ endif ()
 
 target_link_libraries(${ACCOUNT_ALLOWANCE_EXAMPLE_NAME} PUBLIC ${PROJECT_NAME})
 target_link_libraries(${CONSENSUS_PUB_SUB_EXAMPLE_NAME} PUBLIC ${PROJECT_NAME})
+target_link_libraries(${CONSENSUS_PUB_SUB_CHUNKED_EXAMPLE_NAME} PUBLIC ${PROJECT_NAME})
 target_link_libraries(${CREATE_ACCOUNT_EXAMPLE_NAME} PUBLIC ${PROJECT_NAME})
 target_link_libraries(${CREATE_SIMPLE_CONTRACT_EXAMPLE_NAME} PUBLIC ${PROJECT_NAME})
 target_link_libraries(${CREATE_STATEFUL_CONTRACT_EXAMPLE_NAME} PUBLIC ${PROJECT_NAME})
@@ -93,6 +96,7 @@ install(DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/${CMAKE_BUILD_TYPE} DESTINATION ex
 install(TARGETS
         ${ACCOUNT_ALLOWANCE_EXAMPLE_NAME}
         ${CONSENSUS_PUB_SUB_EXAMPLE_NAME}
+        ${CONSENSUS_PUB_SUB_CHUNKED_EXAMPLE_NAME}
         ${CREATE_ACCOUNT_EXAMPLE_NAME}
         ${CREATE_SIMPLE_CONTRACT_EXAMPLE_NAME}
         ${CREATE_STATEFUL_CONTRACT_EXAMPLE_NAME}

--- a/sdk/examples/ConsensusPubSubChunkedExample.cc
+++ b/sdk/examples/ConsensusPubSubChunkedExample.cc
@@ -1,0 +1,254 @@
+/*-
+ *
+ * Hedera C++ SDK
+ *
+ * Copyright (C) 2020 - 2023 Hedera Hashgraph, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+#include "Client.h"
+#include "ECDSAsecp256k1PrivateKey.h"
+#include "ED25519PrivateKey.h"
+#include "SubscriptionHandle.h"
+#include "TopicCreateTransaction.h"
+#include "TopicId.h"
+#include "TopicMessage.h"
+#include "TopicMessageQuery.h"
+#include "TopicMessageSubmitTransaction.h"
+#include "TransactionReceipt.h"
+#include "TransactionResponse.h"
+#include "impl/Utilities.h"
+
+#include <chrono>
+#include <iostream>
+#include <thread>
+
+using namespace Hedera;
+
+int main(int argc, char** argv)
+{
+  if (argc < 3)
+  {
+    std::cout << "Please input account ID and private key" << std::endl;
+    return 1;
+  }
+
+  const AccountId operatorAccountId = AccountId::fromString(argv[1]);
+  const std::shared_ptr<ED25519PrivateKey> operatorPrivateKey = ED25519PrivateKey::fromString(argv[2]);
+
+  // Get a client for the Hedera testnet, and set the operator account ID and key such that all generated transactions
+  // will be paid for by this account and be signed by this key.
+  Client client = Client::forTestnet();
+  client.setOperator(operatorAccountId, operatorPrivateKey.get());
+
+  // Generate a submit key for the topic.
+  const std::shared_ptr<PrivateKey> submitKey = ECDSAsecp256k1PrivateKey::generatePrivateKey();
+
+  // Generate a topic.
+  const TopicId topicId = TopicCreateTransaction()
+                            .setMemo("hedera-sdk-cpp/ConsensusPubSubChunkedExample")
+                            .setSubmitKey(submitKey)
+                            .execute(client)
+                            .getReceipt(client)
+                            .mTopicId.value();
+  std::cout << "Created topic " << topicId.toString() << std::endl;
+
+  // Wait for topic to propagate to the mirror nodes.
+  std::cout << "Waiting to propagate to mirror nodes";
+  for (int i = 0; i < 10; ++i)
+  {
+    std::this_thread::sleep_for(std::chrono::seconds(1));
+    std::cout << '.';
+  }
+  std::cout << std::endl;
+
+  // Set up a mirror client to print out messages as they are received.
+  SubscriptionHandle handle = TopicMessageQuery().setTopicId(topicId).subscribe(
+    client,
+    [](const TopicMessage& message)
+    {
+      std::cout << "Received message " << message.mSequenceNumber << " which reached consensus at "
+                << message.mConsensusTimestamp.time_since_epoch().count() << " and contains "
+                << message.mContents.size() << " bytes." << std::endl;
+    });
+
+  const std::string bigContents =
+    "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Curabitur aliquam augue sem, ut mattis dui laoreet a. "
+    "Curabitur consequat est euismod, scelerisque metus et, tristique dui. Nulla commodo mauris ut faucibus ultricies. "
+    "Quisque venenatis nisl nec augue tempus, at efficitur elit eleifend. Duis pharetra felis metus, sed dapibus urna "
+    "vehicula id. Duis non venenatis turpis, sit amet ornare orci. Donec non interdum quam. Sed finibus nunc et risus "
+    "finibus, non sagittis lorem cursus. Proin pellentesque tempor aliquam. Sed congue nisl in enim bibendum, "
+    "condimentum vehicula nisi feugiat.\n"
+    "\n"
+    "Suspendisse non sodales arcu. Suspendisse sodales, lorem ac mollis blandit, ipsum neque porttitor nulla, et "
+    "sodales arcu ante fermentum tellus. Integer sagittis dolor sed augue fringilla accumsan. Cras vitae finibus arcu, "
+    "sit amet varius dolor. Etiam id finibus dolor, vitae luctus velit. Proin efficitur augue nec pharetra accumsan. "
+    "Aliquam lobortis nisl diam, vel fermentum purus finibus id. Etiam at finibus orci, et tincidunt turpis. Aliquam "
+    "imperdiet congue lacus vel facilisis. Phasellus id magna vitae enim dapibus vestibulum vitae quis augue. Morbi eu "
+    "consequat enim. Maecenas neque nulla, pulvinar sit amet consequat sed, tempor sed magna. Mauris lacinia sem "
+    "feugiat faucibus aliquet. Etiam congue non turpis at commodo. Nulla facilisi.\n"
+    "\n"
+    "Nunc velit turpis, cursus ornare fringilla eu, lacinia posuere leo. Mauris rutrum ultricies dui et suscipit. "
+    "Curabitur in euismod ligula. Curabitur vitae faucibus orci. Phasellus volutpat vestibulum diam sit amet "
+    "vestibulum. In vel purus leo. Nulla condimentum lectus vestibulum lectus faucibus, id lobortis eros consequat. "
+    "Proin mollis libero elit, vel aliquet nisi imperdiet et. Morbi ornare est velit, in vehicula nunc malesuada quis. "
+    "Donec vehicula convallis interdum.\n"
+    "\n"
+    "Integer pellentesque in nibh vitae aliquet. Ut at justo id libero dignissim hendrerit. Interdum et malesuada "
+    "fames ac ante ipsum primis in faucibus. Praesent quis ornare lectus. Nam malesuada non diam quis cursus. "
+    "Phasellus a libero ligula. Suspendisse ligula elit, congue et nisi sit amet, cursus euismod dolor. Morbi aliquam, "
+    "nulla a posuere pellentesque, diam massa ornare risus, nec eleifend neque eros et elit.\n"
+    "\n"
+    "Pellentesque a sodales dui. Sed in efficitur ante. Duis eget volutpat elit, et ornare est. Nam felis dolor, "
+    "placerat mattis diam id, maximus lobortis quam. Sed pellentesque lobortis sem sed placerat. Pellentesque augue "
+    "odio, molestie sed lectus sit amet, congue volutpat massa. Quisque congue consequat nunc id fringilla. Duis "
+    "semper nulla eget enim venenatis dapibus. Class aptent taciti sociosqu ad litora torquent per conubia nostra, per "
+    "inceptos himenaeos. Pellentesque varius turpis nibh, sit amet malesuada mauris malesuada quis. Vivamus dictum "
+    "egestas placerat. Vivamus id augue elit.\n"
+    "\n"
+    "Cras fermentum volutpat eros, vitae euismod lorem viverra nec. Donec lectus augue, porta eleifend odio sit amet, "
+    "condimentum rhoncus urna. Nunc sed odio velit. Morbi non cursus odio, eget imperdiet erat. Nunc rhoncus massa non "
+    "neque volutpat, sit amet faucibus ante congue. Phasellus nec lorem vel leo accumsan lobortis. Maecenas id ligula "
+    "bibendum purus suscipit posuere ac eget diam. Nam in quam pretium, semper erat auctor, iaculis odio. Maecenas "
+    "placerat, nisi ac elementum tempor, felis nulla porttitor orci, ac rhoncus diam justo in elit. Etiam lobortis "
+    "fermentum ligula in tincidunt. Donec quis vestibulum nunc. Sed eros diam, interdum in porta lobortis, gravida eu "
+    "magna. Donec diam purus, finibus et sollicitudin quis, fringilla nec nisi. Pellentesque habitant morbi tristique "
+    "senectus et netus et malesuada fames ac turpis egestas. Curabitur ultricies sagittis dapibus. Etiam ullamcorper "
+    "aliquet libero, eu venenatis mauris suscipit id.\n"
+    "\n"
+    "Ut interdum eleifend sem, vel bibendum ipsum volutpat eget. Nunc ac dignissim augue. Aliquam ornare aliquet magna "
+    "id dignissim. Vestibulum velit sem, lacinia eu rutrum in, rhoncus vitae mauris. Pellentesque scelerisque pulvinar "
+    "mauris non cursus. Integer id dolor porta, bibendum sem vel, pretium tortor. Fusce a nisi convallis, interdum "
+    "quam condimentum, suscipit dolor. Sed magna diam, efficitur non nunc in, tincidunt varius mi. Aliquam ullamcorper "
+    "nulla eu fermentum bibendum. Vivamus a felis pretium, hendrerit enim vitae, hendrerit leo. Suspendisse lacinia "
+    "lectus a diam consectetur suscipit. Aenean hendrerit nisl sed diam venenatis pellentesque. Nullam egestas lectus "
+    "a consequat pharetra. Vivamus ornare tellus auctor, facilisis lacus id, feugiat dui. Nam id est ut est rhoncus "
+    "varius.\n"
+    "\n"
+    "Aenean vel vehicula erat. Aenean gravida risus vitae purus sodales, quis dictum enim porta. Ut elit elit, "
+    "fermentum sed posuere non, accumsan eu justo. Integer porta malesuada quam, et elementum massa suscipit nec. "
+    "Donec in elit diam. Pellentesque habitant morbi tristique senectus et netus et malesuada fames ac turpis egestas. "
+    "Duis suscipit vel ante volutpat vestibulum.\n"
+    "\n"
+    "Pellentesque ex arcu, euismod et sapien ut, vulputate suscipit enim. Donec mattis sagittis augue, et mattis "
+    "lacus. Cras placerat consequat lorem sed luctus. Nam suscipit aliquam sem ac imperdiet. Mauris a semper augue, "
+    "pulvinar fringilla magna. Integer pretium massa non risus commodo hendrerit. Sed dictum libero id erat sodales "
+    "mattis. Etiam auctor dolor lectus, ut sagittis enim lobortis vitae. Orci varius natoque penatibus et magnis dis "
+    "parturient montes, nascetur ridiculus mus. Curabitur nec orci lobortis, cursus risus eget, sollicitudin massa. "
+    "Integer vel tincidunt mi, id eleifend quam. Nullam facilisis nisl eu mauris congue, vitae euismod nisi malesuada. "
+    "Vivamus sit amet urna et libero sagittis dictum.\n"
+    "\n"
+    "In hac habitasse platea dictumst. Aliquam erat volutpat. Ut dictum, mi a viverra venenatis, mi urna pulvinar "
+    "nisi, nec gravida lectus diam eget urna. Ut dictum sit amet nisl ut dignissim. Sed sed mauris scelerisque, "
+    "efficitur augue in, vulputate turpis. Proin dolor justo, bibendum et sollicitudin feugiat, imperdiet sed mi. Sed "
+    "elementum vitae massa vel lobortis. Cras vitae massa sit amet libero dictum tempus.\n"
+    "\n"
+    "Vivamus ut mauris lectus. Curabitur placerat ornare scelerisque. Cras malesuada nunc quis tortor pretium bibendum "
+    "vel sed dui. Cras lobortis nibh eu erat blandit, sit amet consequat neque fermentum. Phasellus imperdiet molestie "
+    "tristique. Cras auctor purus erat, id mollis ligula porttitor eget. Mauris porta pharetra odio et finibus. "
+    "Suspendisse eu est a ligula bibendum cursus. Mauris ac laoreet libero. Nullam volutpat sem quis rhoncus "
+    "gravida.\n"
+    "\n"
+    "Donec malesuada lacus ac iaculis cursus. Sed sem orci, feugiat ac est ut, ultricies posuere nisi. Suspendisse "
+    "potenti. Phasellus ut ultricies purus. Etiam sem tortor, fermentum quis aliquam eget, consequat ut nulla. Aliquam "
+    "dictum metus in mi fringilla, vel gravida nulla accumsan. Cras aliquam eget leo vel posuere. Vivamus vitae "
+    "malesuada nunc. Morbi placerat magna mi, id suscipit lacus auctor quis. Nam at lorem vel odio finibus fringilla "
+    "ut ac velit. Donec laoreet at nibh quis vehicula.\n"
+    "\n"
+    "Fusce ac tristique nisi. Donec leo nisi, consectetur at tellus sit amet, consectetur ultrices dui. Quisque "
+    "gravida mollis tempor. Maecenas semper, sapien ut dignissim feugiat, massa enim viverra dolor, non varius eros "
+    "nulla nec felis. Nunc massa lacus, ornare et feugiat id, bibendum quis purus. Praesent viverra elit sit amet "
+    "purus consectetur venenatis. Maecenas nibh risus, elementum sit amet enim sagittis, ultrices malesuada lectus. "
+    "Vivamus non felis ante. Ut vulputate ex arcu. Aliquam porta gravida porta. Aliquam eros leo, malesuada quis eros "
+    "non, maximus tristique neque. Orci varius natoque penatibus et magnis dis parturient montes, nascetur ridiculus "
+    "mus. Etiam ligula orci, mollis vel luctus nec, venenatis vitae est. Fusce rutrum convallis nisi.\n"
+    "\n"
+    "Nunc laoreet eget nibh in feugiat. Pellentesque nec arcu cursus, gravida dolor a, pellentesque nisi. Praesent vel "
+    "justo blandit, placerat risus eget, consectetur orci. Sed maximus metus mi, ut euismod augue ultricies in. Nunc "
+    "id risus hendrerit, aliquet lorem nec, congue justo. Vestibulum vel nunc ac est euismod mattis ac vitae nulla. "
+    "Donec blandit luctus mauris, sit amet bibendum dui egestas et. Aenean nec lorem nec elit ornare rutrum nec eget "
+    "ligula. Fusce a ipsum vitae neque elementum pharetra. Pellentesque ullamcorper ullamcorper libero, vitae porta "
+    "sem sagittis vel. Interdum et malesuada fames ac ante ipsum primis in faucibus.\n"
+    "\n"
+    "Duis at massa sit amet risus pellentesque varius sit amet vitae eros. Cras tempor aliquet sapien, vehicula varius "
+    "neque volutpat et. Donec purus nibh, pellentesque ut lobortis nec, ultricies ultricies nisl. Sed accumsan ut dui "
+    "sit amet vulputate. Suspendisse eu facilisis massa, a hendrerit mauris. Nulla elementum molestie tincidunt. Donec "
+    "mi justo, ornare vel tempor id, gravida et orci. Nam molestie erat nec nisi bibendum accumsan. Duis vitae tempor "
+    "ante. Morbi congue mauris vel sagittis facilisis. Vivamus vehicula odio orci, a tempor nibh euismod in. Proin "
+    "mattis, nibh at feugiat porta, purus velit posuere felis, quis volutpat sapien dui vel odio. Nam fermentum sem "
+    "nec euismod aliquet. Pellentesque habitant morbi tristique senectus et netus et malesuada fames ac turpis "
+    "egestas. Aliquam erat volutpat.\n"
+    "\n"
+    "Mauris congue lacus tortor. Pellentesque arcu eros, accumsan imperdiet porttitor vitae, mattis nec justo. Nullam "
+    "ac aliquam mauris. Orci varius natoque penatibus et magnis dis parturient montes, nascetur ridiculus mus. "
+    "Suspendisse potenti. Fusce accumsan tempus felis a sagittis. Maecenas et velit odio. Vestibulum ante ipsum primis "
+    "in faucibus orci luctus et ultrices posuere cubilia curae; Aliquam eros lacus, volutpat non urna sed, tincidunt "
+    "ullamcorper elit. Sed sit amet gravida libero. In varius mi vel diam sollicitudin mollis.\n"
+    "\n"
+    "Aenean varius, diam vitae hendrerit feugiat, libero augue ultrices odio, eget consequat sem tellus eu nisi. Nam "
+    "dapibus enim et auctor sollicitudin. Nunc iaculis eros orci, ac accumsan eros malesuada ut. Ut semper augue "
+    "felis, nec sodales lorem consectetur non. Cras gravida eleifend est, et sagittis eros imperdiet congue. Fusce id "
+    "tellus dapibus nunc scelerisque tempus. Donec tempor placerat libero, in commodo nisi bibendum eu. Donec id eros "
+    "non est sollicitudin luctus. Duis bibendum bibendum tellus nec viverra. Aliquam non faucibus ex, nec luctus dui. "
+    "Curabitur efficitur varius urna non dignissim. Suspendisse elit elit, ultrices in elementum eu, tempor at "
+    "magna.\n"
+    "\n"
+    "Nunc in purus sit amet mi laoreet pulvinar placerat eget sapien. Donec vel felis at dui ultricies euismod quis "
+    "vel neque. Donec tincidunt urna non eros pretium blandit. Nullam congue tincidunt condimentum. Curabitur et "
+    "libero nibh. Proin ultricies risus id imperdiet scelerisque. Suspendisse purus mi, viverra vitae risus ut, tempus "
+    "tincidunt enim. Ut luctus lobortis nisl, eget venenatis tortor cursus non. Mauris finibus nisl quis gravida "
+    "ultricies. Fusce elementum lacus sit amet nunc congue, in porta nulla tincidunt.\n"
+    "\n"
+    "Mauris ante risus, imperdiet blandit posuere in, blandit eu ipsum. Integer et auctor arcu. Integer quis elementum "
+    "purus. Nunc in ultricies nisl, sed rutrum risus. Suspendisse venenatis eros nec lorem rhoncus, in scelerisque "
+    "velit condimentum. Etiam condimentum quam felis, in elementum odio mattis et. In ut nibh porttitor, hendrerit "
+    "tellus vel, luctus magna. Vestibulum et ligula et dolor pellentesque porta. Aenean efficitur porta massa et "
+    "bibendum. Nulla vehicula sem in risus volutpat, a eleifend elit maximus.\n"
+    "\n"
+    "Proin orci lorem, auctor a felis eu, pretium lobortis nulla. Phasellus aliquam efficitur interdum. Sed sit amet "
+    "velit rutrum est dictum facilisis. Duis cursus enim at nisl tincidunt, eu molestie elit vehicula. Cras "
+    "pellentesque nisl id enim feugiat fringilla. In quis tincidunt neque. Nam eu consectetur dolor. Ut id interdum "
+    "mauris. Mauris nunc tortor, placerat in tempor ut, vestibulum eu nisl. Integer vel dapibus ipsum. Nunc id erat "
+    "pulvinar, tincidunt magna id, condimentum massa. Pellentesque consequat est eget odio placerat vehicula. Etiam "
+    "augue neque, sagittis non leo eu, tristique scelerisque dui. Ut dui urna, blandit quis urna ac, tincidunt "
+    "tristique turpis.\n"
+    "\n"
+    "Suspendisse venenatis rhoncus ligula ultrices condimentum. In id laoreet eros. Suspendisse suscipit fringilla leo "
+    "id euismod. Sed in quam libero. Ut at ligula tellus. Sed tristique gravida dui, at egestas odio aliquam iaculis. "
+    "Praesent imperdiet velit quis nibh consequat, quis pretium sem sagittis. Donec tortor ex, congue sit amet "
+    "pulvinar ac, rutrum non est. Praesent ipsum magna, venenatis sit amet vulputate id, eleifend ac ipsum.\n"
+    "\n"
+    "In consequat, nisi iaculis laoreet elementum, massa mauris varius nisi, et porta nisi velit at urna. Maecenas sit "
+    "amet aliquet eros, a rhoncus nisl. Maecenas convallis enim nunc. Morbi purus nisl, aliquam ac tincidunt sed, "
+    "mattis in augue. Quisque et elementum quam, vitae maximus orci. Suspendisse hendrerit risus nec vehicula "
+    "placerat. Nulla et lectus nunc. Pellentesque habitant morbi tristique senectus et netus et malesuada fames ac "
+    "turpis egestas.\n"
+    "\n"
+    "Etiam ut sodales ex. Nulla luctus, magna eu scelerisque sagittis, nibh quam consectetur neque, non rutrum dolor "
+    "metus nec ex. Class aptent taciti sociosqu ad litora torquent per conubia nostra, per inceptos himenaeos. Sed "
+    "egestas augue elit, sollicitudin accumsan massa lobortis ac. Curabitur placerat, dolor a aliquam maximus, velit "
+    "ipsum laoreet ligula, id ullamcorper lacus nibh eget nisl. Donec eget lacus venenatis enim consequat auctor vel "
+    "in.\n";
+
+  // Prepare to send a large message to the topic.
+  TopicMessageSubmitTransaction topicMessageSubmitTransaction = TopicMessageSubmitTransaction()
+                                                                  .setTopicId(topicId)
+                                                                  .setMaxChunks(15U)
+                                                                  .setMessage(bigContents)
+                                                                  .sign(operatorPrivateKey.get());
+
+  // "Send" the message to be signed again "elsewhere" by the submit key.
+
+  return 0;
+}

--- a/sdk/main/CMakeLists.txt
+++ b/sdk/main/CMakeLists.txt
@@ -128,6 +128,9 @@ add_library(${PROJECT_NAME} STATIC
         src/TransferTransaction.cc
         src/WrappedTransaction.cc
 
+        src/impl/BaseNetwork.cc
+        src/impl/BaseNode.cc
+        src/impl/BaseNodeAddress.cc
         src/impl/DerivationPathUtils.cc
         src/impl/Endpoint.cc
         src/impl/DurationConverter.cc

--- a/sdk/main/include/AccountAllowanceApproveTransaction.h
+++ b/sdk/main/include/AccountAllowanceApproveTransaction.h
@@ -85,6 +85,15 @@ public:
   explicit AccountAllowanceApproveTransaction(const proto::TransactionBody& transactionBody);
 
   /**
+   * Construct from a map of TransactionIds to node account IDs and their respective Transaction protobuf objects.
+   *
+   * @param transactions The map of TransactionIds to node account IDs and their respective Transaction protobuf
+   *                     objects.
+   */
+  explicit AccountAllowanceApproveTransaction(
+    const std::map<TransactionId, std::map<AccountId, proto::Transaction>>& transactions);
+
+  /**
    * Add an Hbar allowance to this AccountAllowanceApproveTransaction.
    *
    * @param ownerAccountId   The ID of the account that is allowing the spending of its Hbar.
@@ -179,33 +188,21 @@ public:
 
 private:
   friend class WrappedTransaction;
-  
-  /**
-   * Derived from Executable. Construct a Transaction protobuf object from this AccountAllowanceApproveTransaction
-   * object.
-   *
-   * @param client The Client trying to construct this AccountAllowanceApproveTransaction.
-   * @param node   The Node to which this AccountAllowanceApproveTransaction will be sent. This is unused.
-   * @return A Transaction protobuf object filled with this AccountAllowanceApproveTransaction object's data.
-   * @throws UninitializedException If the input client has no operator with which to sign this
-   *                                AccountAllowanceApproveTransaction.
-   */
-  [[nodiscard]] proto::Transaction makeRequest(const Client& client,
-                                               const std::shared_ptr<internal::Node>& /*node*/) const override;
 
   /**
-   * Derived from Executable. Submit this AccountAllowanceApproveTransaction to a Node.
+   * Derived from Executable. Submit a Transaction protobuf object which contains this
+   * AccountAllowanceApproveTransaction's data to a Node.
    *
-   * @param client   The Client submitting this AccountAllowanceApproveTransaction.
-   * @param deadline The deadline for submitting this AccountAllowanceApproveTransaction.
-   * @param node     Pointer to the Node to which this AccountAllowanceApproveTransaction should be submitted.
-   * @param response Pointer to the TransactionResponse protobuf object that gRPC should populate with the response
-   *                 information from the gRPC server.
+   * @param request  The Transaction protobuf object to submit.
+   * @param node     The Node to which to submit the request.
+   * @param deadline The deadline for submitting the request.
+   * @param response Pointer to the ProtoResponseType object that gRPC should populate with the response information
+   *                 from the gRPC server.
    * @return The gRPC status of the submission.
    */
-  [[nodiscard]] grpc::Status submitRequest(const Client& client,
-                                           const std::chrono::system_clock::time_point& deadline,
+  [[nodiscard]] grpc::Status submitRequest(const proto::Transaction& request,
                                            const std::shared_ptr<internal::Node>& node,
+                                           const std::chrono::system_clock::time_point& deadline,
                                            proto::TransactionResponse* response) const override;
   /**
    * Derived from Transaction. Build and add the AccountAllowanceApproveTransaction protobuf representation to the
@@ -214,6 +211,11 @@ private:
    * @param body The TransactionBody protobuf object being built.
    */
   void addToBody(proto::TransactionBody& body) const override;
+
+  /**
+   * Initialize this AccountAllowanceApproveTransaction from its source TransactionBody protobuf object.
+   */
+  void initFromSourceTransactionBody();
 
   /**
    * Build a CryptoApproveAllowanceTransactionBody protobuf object from this AccountAllowanceApproveTransaction object.

--- a/sdk/main/include/AccountAllowanceDeleteTransaction.h
+++ b/sdk/main/include/AccountAllowanceDeleteTransaction.h
@@ -23,6 +23,8 @@
 #include "TokenNftAllowance.h"
 #include "Transaction.h"
 
+#include <vector>
+
 namespace proto
 {
 class CryptoDeleteAllowanceTransactionBody;
@@ -31,6 +33,7 @@ class TransactionBody;
 
 namespace Hedera
 {
+class AccountId;
 class NftId;
 }
 
@@ -56,6 +59,15 @@ public:
   explicit AccountAllowanceDeleteTransaction(const proto::TransactionBody& transactionBody);
 
   /**
+   * Construct from a map of TransactionIds to node account IDs and their respective Transaction protobuf objects.
+   *
+   * @param transactions The map of TransactionIds to node account IDs and their respective Transaction protobuf
+   *                     objects.
+   */
+  explicit AccountAllowanceDeleteTransaction(
+    const std::map<TransactionId, std::map<AccountId, proto::Transaction>>& transactions);
+
+  /**
    * Remove all NFT allowances from an account.
    *
    * @param nftId The ID of the NFT to remove as an allowance.
@@ -77,33 +89,21 @@ public:
 
 private:
   friend class WrappedTransaction;
-  
-  /**
-   * Derived from Executable. Construct a Transaction protobuf object from this AccountAllowanceDeleteTransaction
-   * object.
-   *
-   * @param client The Client trying to construct this AccountAllowanceDeleteTransaction.
-   * @param node   The Node to which this AccountAllowanceDeleteTransaction will be sent. This is unused.
-   * @return A Transaction protobuf object filled with this AccountAllowanceDeleteTransaction object's data.
-   * @throws UninitializedException If the input client has no operator with which to sign this
-   *                                AccountAllowanceApproveTransaction.
-   */
-  [[nodiscard]] proto::Transaction makeRequest(const Client& client,
-                                               const std::shared_ptr<internal::Node>& /*node*/) const override;
 
   /**
-   * Derived from Executable. Submit this AccountAllowanceDeleteTransaction to a Node.
+   * Derived from Executable. Submit a Transaction protobuf object which contains this
+   * AccountAllowanceDeleteTransaction's data to a Node.
    *
-   * @param client   The Client submitting this AccountAllowanceDeleteTransaction.
-   * @param deadline The deadline for submitting this AccountAllowanceDeleteTransaction.
-   * @param node     Pointer to the Node to which this AccountAllowanceDeleteTransaction should be submitted.
-   * @param response Pointer to the TransactionResponse protobuf object that gRPC should populate with the response
-   *                 information from the gRPC server.
+   * @param request  The Transaction protobuf object to submit.
+   * @param node     The Node to which to submit the request.
+   * @param deadline The deadline for submitting the request.
+   * @param response Pointer to the ProtoResponseType object that gRPC should populate with the response information
+   *                 from the gRPC server.
    * @return The gRPC status of the submission.
    */
-  [[nodiscard]] grpc::Status submitRequest(const Client& client,
-                                           const std::chrono::system_clock::time_point& deadline,
+  [[nodiscard]] grpc::Status submitRequest(const proto::Transaction& request,
                                            const std::shared_ptr<internal::Node>& node,
+                                           const std::chrono::system_clock::time_point& deadline,
                                            proto::TransactionResponse* response) const override;
   /**
    * Derived from Transaction. Build and add the AccountAllowanceDeleteTransaction protobuf representation to the
@@ -112,6 +112,11 @@ private:
    * @param body The TransactionBody protobuf object being built.
    */
   void addToBody(proto::TransactionBody& body) const override;
+
+  /**
+   * Initialize this AccountAllowanceDeleteTransaction from its source TransactionBody protobuf object.
+   */
+  void initFromSourceTransactionBody();
 
   /**
    * Build a CryptoDeleteAllowanceTransactionBody protobuf object from this AccountAllowanceDeleteTransaction object.

--- a/sdk/main/include/AccountBalanceQuery.h
+++ b/sdk/main/include/AccountBalanceQuery.h
@@ -117,6 +117,13 @@ private:
   [[nodiscard]] proto::ResponseHeader mapResponseHeader(const proto::Response& response) const override;
 
   /**
+   * Derived from Query. Does this AccountBalanceQuery require payment?
+   *
+   * @return \c FALSE, AccountBalanceQuery is free.
+   */
+  [[nodiscard]] inline bool isPaymentRequired() const override { return false; }
+
+  /**
    * The ID of the account of which this query should get the balance.
    */
   std::optional<AccountId> mAccountId;

--- a/sdk/main/include/AccountBalanceQuery.h
+++ b/sdk/main/include/AccountBalanceQuery.h
@@ -78,16 +78,6 @@ public:
 
 private:
   /**
-   * Derived from Executable. Construct a Query protobuf object from this AccountBalanceQuery object.
-   *
-   * @param client The Client trying to construct this AccountBalanceQuery. This is unused.
-   * @param node   The Node to which this AccountBalanceQuery will be sent. This is unused.
-   * @return A Query protobuf object filled with this AccountBalanceQuery object's data.
-   */
-  [[nodiscard]] proto::Query makeRequest(const Client& /*client*/,
-                                         const std::shared_ptr<internal::Node>& /*node*/) const override;
-
-  /**
    * Derived from Executable. Construct an AccountBalance object from a Response protobuf object.
    *
    * @param response The Response protobuf object from which to construct an AccountBalance object.
@@ -96,28 +86,35 @@ private:
   [[nodiscard]] AccountBalance mapResponse(const proto::Response& response) const override;
 
   /**
-   * Derived from Executable. Get the status response code for a submitted AccountBalanceQuery from a Response protobuf
-   * object.
+   * Derived from Executable. Submit a Query protobuf object which contains this AccountBalanceQuery's data to a Node.
    *
-   * @param response The Response protobuf object from which to grab the AccountBalanceQuery status response code.
-   * @return The AccountBalanceQuery status response code of the input Response protobuf object.
-   */
-  [[nodiscard]] Status mapResponseStatus(const proto::Response& response) const override;
-
-  /**
-   * Derived from Executable. Submit this AccountBalanceQuery to a Node.
-   *
-   * @param client   The Client submitting this AccountBalanceQuery.
-   * @param deadline The deadline for submitting this AccountBalanceQuery.
-   * @param node     Pointer to the Node to which this AccountBalanceQuery should be submitted.
-   * @param response Pointer to the Response protobuf object that gRPC should populate with the response information
+   * @param request  The Query protobuf object to submit.
+   * @param node     The Node to which to submit the request.
+   * @param deadline The deadline for submitting the request.
+   * @param response Pointer to the ProtoResponseType object that gRPC should populate with the response information
    *                 from the gRPC server.
    * @return The gRPC status of the submission.
    */
-  [[nodiscard]] grpc::Status submitRequest(const Client& client,
-                                           const std::chrono::system_clock::time_point& deadline,
+  [[nodiscard]] grpc::Status submitRequest(const proto::Query& request,
                                            const std::shared_ptr<internal::Node>& node,
+                                           const std::chrono::system_clock::time_point& deadline,
                                            proto::Response* response) const override;
+  /**
+   * Derived from Query. Build a Query protobuf object with this AccountBalanceQuery's data, with the input QueryHeader
+   * protobuf object.
+   *
+   * @param header A pointer to the QueryHeader protobuf object to add to the Query protobuf object.
+   * @return The constructed Query protobuf object.
+   */
+  [[nodiscard]] proto::Query buildRequest(proto::QueryHeader* header) const override;
+
+  /**
+   * Derived from Query. Get the ResponseHeader protobuf object from the input Response protobuf object.
+   *
+   * @param response The Response protobuf object from which to get the ResponseHeader protobuf object.
+   * @return The ResponseHeader protobuf object of the input Response protobuf object for this derived Query.
+   */
+  [[nodiscard]] proto::ResponseHeader mapResponseHeader(const proto::Response& response) const override;
 
   /**
    * The ID of the account of which this query should get the balance.

--- a/sdk/main/include/AccountCreateTransaction.h
+++ b/sdk/main/include/AccountCreateTransaction.h
@@ -84,6 +84,15 @@ public:
   explicit AccountCreateTransaction(const proto::TransactionBody& transactionBody);
 
   /**
+   * Construct from a map of TransactionIds to node account IDs and their respective Transaction protobuf objects.
+   *
+   * @param transactions The map of TransactionIds to node account IDs and their respective Transaction protobuf
+   *                     objects.
+   */
+  explicit AccountCreateTransaction(
+    const std::map<TransactionId, std::map<AccountId, proto::Transaction>>& transactions);
+
+  /**
    * Set the key for the new account. The key that must sign each transfer out of the account. If
    * mReceiverSignatureRequired is true, then it must also sign any transfer into the account.
    *
@@ -259,30 +268,19 @@ private:
   friend class WrappedTransaction;
 
   /**
-   * Derived from Executable. Construct a Transaction protobuf object from this AccountCreateTransaction object.
+   * Derived from Executable. Submit a Transaction protobuf object which contains this AccountCreateTransaction's data
+   * to a Node.
    *
-   * @param client The Client trying to construct this AccountCreateTransaction.
-   * @param node   The Node to which this AccountCreateTransaction will be sent. This is unused.
-   * @return A Transaction protobuf object filled with this AccountCreateTransaction object's data.
-   * @throws UninitializedException If the input client has no operator with which to sign this
-   *                                AccountAllowanceApproveTransaction.
-   */
-  [[nodiscard]] proto::Transaction makeRequest(const Client& client,
-                                               const std::shared_ptr<internal::Node>& /*node*/) const override;
-
-  /**
-   * Derived from Executable. Submit this AccountCreateTransaction to a Node.
-   *
-   * @param client   The Client submitting this AccountCreateTransaction.
-   * @param deadline The deadline for submitting this AccountCreateTransaction.
-   * @param node     Pointer to the Node to which this AccountCreateTransaction should be submitted.
-   * @param response Pointer to the TransactionResponse protobuf object that gRPC should populate with the response
-   *                 information from the gRPC server.
+   * @param request  The Transaction protobuf object to submit.
+   * @param node     The Node to which to submit the request.
+   * @param deadline The deadline for submitting the request.
+   * @param response Pointer to the ProtoResponseType object that gRPC should populate with the response information
+   *                 from the gRPC server.
    * @return The gRPC status of the submission.
    */
-  [[nodiscard]] grpc::Status submitRequest(const Client& client,
-                                           const std::chrono::system_clock::time_point& deadline,
+  [[nodiscard]] grpc::Status submitRequest(const proto::Transaction& request,
                                            const std::shared_ptr<internal::Node>& node,
+                                           const std::chrono::system_clock::time_point& deadline,
                                            proto::TransactionResponse* response) const override;
   /**
    * Derived from Transaction. Build and add the AccountCreateTransaction protobuf representation to the Transaction
@@ -291,6 +289,11 @@ private:
    * @param body The TransactionBody protobuf object being built.
    */
   void addToBody(proto::TransactionBody& body) const override;
+
+  /**
+   * Initialize this AccountCreateTransaction from its source TransactionBody protobuf object.
+   */
+  void initFromSourceTransactionBody();
 
   /**
    * Build a CryptoCreateTransactionBody protobuf object from this AccountCreateTransaction object.

--- a/sdk/main/include/AccountDeleteTransaction.h
+++ b/sdk/main/include/AccountDeleteTransaction.h
@@ -52,6 +52,15 @@ public:
   explicit AccountDeleteTransaction(const proto::TransactionBody& transactionBody);
 
   /**
+   * Construct from a map of TransactionIds to node account IDs and their respective Transaction protobuf objects.
+   *
+   * @param transactions The map of TransactionIds to node account IDs and their respective Transaction protobuf
+   *                     objects.
+   */
+  explicit AccountDeleteTransaction(
+    const std::map<TransactionId, std::map<AccountId, proto::Transaction>>& transactions);
+
+  /**
    * Sets the ID of the account to delete.
    *
    * @param accountId The ID of the account to delete.
@@ -90,38 +99,32 @@ private:
   friend class WrappedTransaction;
 
   /**
-   * Derived from Executable. Construct a Transaction protobuf object from this AccountDeleteTransaction object.
+   * Derived from Executable. Submit a Transaction protobuf object which contains this AccountDeleteTransaction's data
+   * to a Node.
    *
-   * @param client The Client trying to construct this AccountDeleteTransaction.
-   * @param node   The Node to which this AccountDeleteTransaction will be sent. This is unused.
-   * @return A Transaction protobuf object filled with this AccountDeleteTransaction object's data.
-   * @throws UninitializedException If the input client has no operator with which to sign this
-   *                                AccountDeleteTransaction.
-   */
-  [[nodiscard]] proto::Transaction makeRequest(const Client& client,
-                                               const std::shared_ptr<internal::Node>& /*node*/) const override;
-
-  /**
-   * Derived from Executable. Submit this AccountDeleteTransaction to a Node.
-   *
-   * @param client   The Client submitting this AccountDeleteTransaction.
-   * @param deadline The deadline for submitting this AccountDeleteTransaction.
-   * @param node     Pointer to the Node to which this AccountDeleteTransaction should be submitted.
-   * @param response Pointer to the TransactionResponse protobuf object that gRPC should populate with the response
-   *                 information from the gRPC server.
+   * @param request  The Transaction protobuf object to submit.
+   * @param node     The Node to which to submit the request.
+   * @param deadline The deadline for submitting the request.
+   * @param response Pointer to the ProtoResponseType object that gRPC should populate with the response information
+   *                 from the gRPC server.
    * @return The gRPC status of the submission.
    */
-  [[nodiscard]] grpc::Status submitRequest(const Client& client,
-                                           const std::chrono::system_clock::time_point& deadline,
+  [[nodiscard]] grpc::Status submitRequest(const proto::Transaction& request,
                                            const std::shared_ptr<internal::Node>& node,
+                                           const std::chrono::system_clock::time_point& deadline,
                                            proto::TransactionResponse* response) const override;
   /**
-   * Derived from Transaction. Build and add the AccountCreateTransaction protobuf representation to the Transaction
+   * Derived from Transaction. Build and add the AccountDeleteTransaction protobuf representation to the Transaction
    * protobuf object.
    *
    * @param body The TransactionBody protobuf object being built.
    */
   void addToBody(proto::TransactionBody& body) const override;
+
+  /**
+   * Initialize this AccountDeleteTransaction from its source TransactionBody protobuf object.
+   */
+  void initFromSourceTransactionBody();
 
   /**
    * Build a CryptoDeleteTransactionBody protobuf object from this AccountDeleteTransaction object.

--- a/sdk/main/include/AccountId.h
+++ b/sdk/main/include/AccountId.h
@@ -274,9 +274,21 @@ template<>
 struct hash<Hedera::AccountId>
 {
   /**
-   * Operator override to enable use of AccountId as map key
+   * Operator override to enable use of AccountId as map key.
    */
   size_t operator()(const Hedera::AccountId& id) const { return hash<string>()(id.toString()); }
+};
+
+template<>
+struct less<Hedera::AccountId>
+{
+  /**
+   * Operator override to enable use of AccountId in a std::map, which requires fair ordering.
+   */
+  bool operator()(const Hedera::AccountId& lhs, const Hedera::AccountId& rhs) const
+  {
+    return lhs.toString() < rhs.toString();
+  }
 };
 
 } // namespace std

--- a/sdk/main/include/AccountInfoQuery.h
+++ b/sdk/main/include/AccountInfoQuery.h
@@ -56,46 +56,43 @@ public:
 
 private:
   /**
-   * Derived from Executable. Construct a Query protobuf object from this AccountInfoQuery object.
-   *
-   * @param client The Client trying to construct this AccountInfoQuery.
-   * @param node   The Node to which this AccountInfoQuery will be sent.
-   * @return A Query protobuf object filled with this AccountInfoQuery object's data.
-   */
-  [[nodiscard]] proto::Query makeRequest(const Client& client,
-                                         const std::shared_ptr<internal::Node>& node) const override;
-
-  /**
    * Derived from Executable. Construct an AccountInfo object from a Response protobuf object.
    *
    * @param response The Response protobuf object from which to construct an AccountInfo object.
-   * @return An AccountInfo object filled with the Response protobuf object's data.
+   * @return An AccountInfo object filled with the Response protobuf object's data
    */
   [[nodiscard]] AccountInfo mapResponse(const proto::Response& response) const override;
 
   /**
-   * Derived from Executable. Get the status response code for a submitted AccountInfoQuery from a Response protobuf
-   * object.
+   * Derived from Executable. Submit a Query protobuf object which contains this AccountInfoQuery's data to a Node.
    *
-   * @param response The Response protobuf object from which to grab the AccountInfoQuery status response code.
-   * @return The AccountInfoQuery status response code of the input Response protobuf object.
-   */
-  [[nodiscard]] Status mapResponseStatus(const proto::Response& response) const override;
-
-  /**
-   * Derived from Executable. Submit this AccountInfoQuery to a Node.
-   *
-   * @param client   The Client submitting this AccountInfoQuery.
-   * @param deadline The deadline for submitting this AccountInfoQuery.
-   * @param node     Pointer to the Node to which this AccountInfoQuery should be submitted.
-   * @param response Pointer to the Response protobuf object that gRPC should populate with the response information
+   * @param request  The Query protobuf object to submit.
+   * @param node     The Node to which to submit the request.
+   * @param deadline The deadline for submitting the request.
+   * @param response Pointer to the ProtoResponseType object that gRPC should populate with the response information
    *                 from the gRPC server.
    * @return The gRPC status of the submission.
    */
-  [[nodiscard]] grpc::Status submitRequest(const Client& client,
-                                           const std::chrono::system_clock::time_point& deadline,
+  [[nodiscard]] grpc::Status submitRequest(const proto::Query& request,
                                            const std::shared_ptr<internal::Node>& node,
+                                           const std::chrono::system_clock::time_point& deadline,
                                            proto::Response* response) const override;
+  /**
+   * Derived from Query. Build a Query protobuf object with this AccountInfoQuery's data, with the input QueryHeader
+   * protobuf object.
+   *
+   * @param header A pointer to the QueryHeader protobuf object to add to the Query protobuf object.
+   * @return The constructed Query protobuf object.
+   */
+  [[nodiscard]] proto::Query buildRequest(proto::QueryHeader* header) const override;
+
+  /**
+   * Derived from Query. Get the ResponseHeader protobuf object from the input Response protobuf object.
+   *
+   * @param response The Response protobuf object from which to get the ResponseHeader protobuf object.
+   * @return The ResponseHeader protobuf object of the input Response protobuf object for this derived Query.
+   */
+  [[nodiscard]] proto::ResponseHeader mapResponseHeader(const proto::Response& response) const override;
 
   /**
    * The ID of the account of which this query should get the info.

--- a/sdk/main/include/AccountRecordsQuery.h
+++ b/sdk/main/include/AccountRecordsQuery.h
@@ -57,46 +57,43 @@ public:
 
 private:
   /**
-   * Derived from Executable. Construct a Query protobuf object from this AccountRecordsQuery object.
-   *
-   * @param client The Client trying to construct this AccountRecordsQuery.
-   * @param node   The Node to which this AccountRecordsQuery will be sent.
-   * @return A Query protobuf object filled with this AccountRecordsQuery object's data.
-   */
-  [[nodiscard]] proto::Query makeRequest(const Client& client,
-                                         const std::shared_ptr<internal::Node>& node) const override;
-
-  /**
    * Derived from Executable. Construct an AccountRecords object from a Response protobuf object.
    *
    * @param response The Response protobuf object from which to construct an AccountRecords object.
-   * @return An AccountRecords object filled with the Response protobuf object's data.
+   * @return An AccountRecords object filled with the Response protobuf object's data
    */
   [[nodiscard]] AccountRecords mapResponse(const proto::Response& response) const override;
 
   /**
-   * Derived from Executable. Get the status response code for a submitted AccountRecordsQuery from a Response protobuf
-   * object.
+   * Derived from Executable. Submit a Query protobuf object which contains this AccountRecordsQuery's data to a Node.
    *
-   * @param response The Response protobuf object from which to grab the AccountRecordsQuery status response code.
-   * @return The AccountRecordsQuery status response code of the input Response protobuf object.
-   */
-  [[nodiscard]] Status mapResponseStatus(const proto::Response& response) const override;
-
-  /**
-   * Derived from Executable. Submit this AccountRecordsQuery to a Node.
-   *
-   * @param client   The Client submitting this AccountRecordsQuery.
-   * @param deadline The deadline for submitting this AccountRecordsQuery.
-   * @param node     Pointer to the Node to which this AccountRecordsQuery should be submitted.
-   * @param response Pointer to the Response protobuf object that gRPC should populate with the response information
+   * @param request  The Query protobuf object to submit.
+   * @param node     The Node to which to submit the request.
+   * @param deadline The deadline for submitting the request.
+   * @param response Pointer to the ProtoResponseType object that gRPC should populate with the response information
    *                 from the gRPC server.
    * @return The gRPC status of the submission.
    */
-  [[nodiscard]] grpc::Status submitRequest(const Client& client,
-                                           const std::chrono::system_clock::time_point& deadline,
+  [[nodiscard]] grpc::Status submitRequest(const proto::Query& request,
                                            const std::shared_ptr<internal::Node>& node,
+                                           const std::chrono::system_clock::time_point& deadline,
                                            proto::Response* response) const override;
+  /**
+   * Derived from Query. Build a Query protobuf object with this AccountRecordsQuery's data, with the input QueryHeader
+   * protobuf object.
+   *
+   * @param header A pointer to the QueryHeader protobuf object to add to the Query protobuf object.
+   * @return The constructed Query protobuf object.
+   */
+  [[nodiscard]] proto::Query buildRequest(proto::QueryHeader* header) const override;
+
+  /**
+   * Derived from Query. Get the ResponseHeader protobuf object from the input Response protobuf object.
+   *
+   * @param response The Response protobuf object from which to get the ResponseHeader protobuf object.
+   * @return The ResponseHeader protobuf object of the input Response protobuf object for this derived Query.
+   */
+  [[nodiscard]] proto::ResponseHeader mapResponseHeader(const proto::Response& response) const override;
 
   /**
    * The ID of the account of which this query should get the records.

--- a/sdk/main/include/AccountStakersQuery.h
+++ b/sdk/main/include/AccountStakersQuery.h
@@ -53,46 +53,43 @@ public:
 
 private:
   /**
-   * Derived from Executable. Construct a Query protobuf object from this AccountStakersQuery object.
-   *
-   * @param client The Client trying to construct this AccountStakersQuery.
-   * @param node   The Node to which this AccountStakersQuery will be sent.
-   * @return A Query protobuf object filled with this AccountStakersQuery object's data.
-   */
-  [[nodiscard]] proto::Query makeRequest(const Client& client,
-                                         const std::shared_ptr<internal::Node>& node) const override;
-
-  /**
    * Derived from Executable. Construct an AccountStakers object from a Response protobuf object.
    *
    * @param response The Response protobuf object from which to construct an AccountStakers object.
-   * @return An AccountStakers object filled with the Response protobuf object's data.
+   * @return An AccountStakers object filled with the Response protobuf object's data
    */
   [[nodiscard]] AccountStakers mapResponse(const proto::Response& response) const override;
 
   /**
-   * Derived from Executable. Get the status response code for a submitted AccountStakersQuery from a Response protobuf
-   * object.
+   * Derived from Executable. Submit a Query protobuf object which contains this AccountStakersQuery's data to a Node.
    *
-   * @param response The Response protobuf object from which to grab the AccountStakersQuery status response code.
-   * @return The AccountStakersQuery status response code of the input Response protobuf object.
-   */
-  [[nodiscard]] Status mapResponseStatus(const proto::Response& response) const override;
-
-  /**
-   * Derived from Executable. Submit this AccountStakersQuery to a Node.
-   *
-   * @param client   The Client submitting this AccountStakersQuery.
-   * @param deadline The deadline for submitting this AccountStakersQuery.
-   * @param node     Pointer to the Node to which this AccountStakersQuery should be submitted.
-   * @param response Pointer to the Response protobuf object that gRPC should populate with the response information
+   * @param request  The Query protobuf object to submit.
+   * @param node     The Node to which to submit the request.
+   * @param deadline The deadline for submitting the request.
+   * @param response Pointer to the ProtoResponseType object that gRPC should populate with the response information
    *                 from the gRPC server.
    * @return The gRPC status of the submission.
    */
-  [[nodiscard]] grpc::Status submitRequest(const Client& client,
-                                           const std::chrono::system_clock::time_point& deadline,
+  [[nodiscard]] grpc::Status submitRequest(const proto::Query& request,
                                            const std::shared_ptr<internal::Node>& node,
+                                           const std::chrono::system_clock::time_point& deadline,
                                            proto::Response* response) const override;
+  /**
+   * Derived from Query. Build a Query protobuf object with this AccountStakersQuery's data, with the input QueryHeader
+   * protobuf object.
+   *
+   * @param header A pointer to the QueryHeader protobuf object to add to the Query protobuf object.
+   * @return The constructed Query protobuf object.
+   */
+  [[nodiscard]] proto::Query buildRequest(proto::QueryHeader* header) const override;
+
+  /**
+   * Derived from Query. Get the ResponseHeader protobuf object from the input Response protobuf object.
+   *
+   * @param response The Response protobuf object from which to get the ResponseHeader protobuf object.
+   * @return The ResponseHeader protobuf object of the input Response protobuf object for this derived Query.
+   */
+  [[nodiscard]] proto::ResponseHeader mapResponseHeader(const proto::Response& response) const override;
 
   /**
    * The ID of the account of which this query should get the stakers.

--- a/sdk/main/include/AccountUpdateTransaction.h
+++ b/sdk/main/include/AccountUpdateTransaction.h
@@ -59,6 +59,15 @@ public:
   explicit AccountUpdateTransaction(const proto::TransactionBody& transactionBody);
 
   /**
+   * Construct from a map of TransactionIds to node account IDs and their respective Transaction protobuf objects.
+   *
+   * @param transactions The map of TransactionIds to node account IDs and their respective Transaction protobuf
+   *                     objects.
+   */
+  explicit AccountUpdateTransaction(
+    const std::map<TransactionId, std::map<AccountId, proto::Transaction>>& transactions);
+
+  /**
    * Set the ID of the account to update.
    *
    * @param accountId The ID of the account this transaction should update.
@@ -242,30 +251,19 @@ private:
   friend class WrappedTransaction;
 
   /**
-   * Derived from Executable. Construct a Transaction protobuf object from this AccountUpdateTransaction object.
+   * Derived from Executable. Submit a Transaction protobuf object which contains this AccountUpdateTransaction's data
+   * to a Node.
    *
-   * @param client The Client trying to construct this AccountUpdateTransaction.
-   * @param node   The Node to which this AccountUpdateTransaction will be sent. This is unused.
-   * @return A Transaction protobuf object filled with this AccountUpdateTransaction object's data.
-   * @throws UninitializedException If the input client has no operator with which to sign this
-   *                                AccountUpdateTransaction.
-   */
-  [[nodiscard]] proto::Transaction makeRequest(const Client& client,
-                                               const std::shared_ptr<internal::Node>& /*node*/) const override;
-
-  /**
-   * Derived from Executable. Submit this AccountUpdateTransaction to a Node.
-   *
-   * @param client   The Client submitting this AccountUpdateTransaction.
-   * @param deadline The deadline for submitting this AccountUpdateTransaction.
-   * @param node     Pointer to the Node to which this AccountUpdateTransaction should be submitted.
-   * @param response Pointer to the TransactionResponse protobuf object that gRPC should populate with the response
-   *                 information from the gRPC server.
+   * @param request  The Transaction protobuf object to submit.
+   * @param node     The Node to which to submit the request.
+   * @param deadline The deadline for submitting the request.
+   * @param response Pointer to the ProtoResponseType object that gRPC should populate with the response information
+   *                 from the gRPC server.
    * @return The gRPC status of the submission.
    */
-  [[nodiscard]] grpc::Status submitRequest(const Client& client,
-                                           const std::chrono::system_clock::time_point& deadline,
+  [[nodiscard]] grpc::Status submitRequest(const proto::Transaction& request,
                                            const std::shared_ptr<internal::Node>& node,
+                                           const std::chrono::system_clock::time_point& deadline,
                                            proto::TransactionResponse* response) const override;
   /**
    * Derived from Transaction. Build and add the AccountUpdateTransaction protobuf representation to the Transaction
@@ -274,6 +272,11 @@ private:
    * @param body The TransactionBody protobuf object being built.
    */
   void addToBody(proto::TransactionBody& body) const override;
+
+  /**
+   * Initialize this AccountUpdateTransaction from its source TransactionBody protobuf object.
+   */
+  void initFromSourceTransactionBody();
 
   /**
    * Build a CryptoUpdateTransactionBody protobuf object from this AccountUpdateTransaction object.

--- a/sdk/main/include/ChunkedTransaction.h
+++ b/sdk/main/include/ChunkedTransaction.h
@@ -189,7 +189,7 @@ public:
 
 protected:
   ChunkedTransaction();
-  virtual ~ChunkedTransaction();
+  ~ChunkedTransaction();
   ChunkedTransaction(const ChunkedTransaction&);
   ChunkedTransaction& operator=(const ChunkedTransaction&);
   ChunkedTransaction(ChunkedTransaction&&) noexcept;

--- a/sdk/main/include/ChunkedTransaction.h
+++ b/sdk/main/include/ChunkedTransaction.h
@@ -287,6 +287,13 @@ private:
   void clearTransactions() override;
 
   /**
+   * Derived from Transaction. Get the ID of the previously-executed ChunkedTransaction.
+   *
+   * @return The ID of the previously-executed ChunkedTransaction.
+   */
+  [[nodiscard]] TransactionId getCurrentTransactionId() const override;
+
+  /**
    * Get the number of chunks that will be required to send this full ChunkedTransaction.
    *
    * @return The number of chunks that will be required to send this full ChunkedTransaction.

--- a/sdk/main/include/ChunkedTransaction.h
+++ b/sdk/main/include/ChunkedTransaction.h
@@ -28,6 +28,7 @@
 #include <cstddef>
 #include <cstdint>
 #include <string_view>
+#include <unordered_map>
 #include <vector>
 
 namespace Hedera
@@ -100,6 +101,63 @@ public:
   std::vector<TransactionResponse> executeAll(const Client& client, const std::chrono::duration<double>& timeout);
 
   /**
+   * Derived from Transaction. Add a signature to this ChunkedTransaction.
+   *
+   * @param publicKey The associated PublicKey of the PrivateKey that generated the signature.
+   * @param signature The signature to add.
+   * @return A reference to this derived ChunkedTransaction object with the newly-added signature.
+   * @throws IllegalStateException If there are multiple chunks in this ChunkedTransaction,there is not exactly one node
+   *                               account ID set, or if this ChunkedTransaction is not frozen.
+   */
+  SdkRequestType& addSignature(const std::shared_ptr<PublicKey>& publicKey,
+                               const std::vector<std::byte>& signature) override;
+
+  /**
+   * Derived from Transaction. Get the signatures of each potential Transaction protobuf object this ChunkedTransaction
+   * may send.
+   *
+   * @return The map of node account IDs to their PublicKeys and signatures.
+   */
+  [[nodiscard]] std::map<AccountId, std::map<std::shared_ptr<PublicKey>, std::vector<std::byte>>> getSignatures()
+    const override;
+
+  /**
+   * Get the signatures of all chunks of this ChunkedTransaction, for each potential node to which it may be sent.
+   *
+   * @return The list of signatures for each node account ID for each chunk.
+   */
+  [[nodiscard]] std::vector<std::map<AccountId, std::map<std::shared_ptr<PublicKey>, std::vector<std::byte>>>>
+  getAllSignatures() const;
+
+  /**
+   * Derived from Transaction. Get the SHA384 hash of this ChunkedTransaction.
+   *
+   * @return The SHA384 hash of this Transaction.
+   * @throws IllegalStateException If this ChunkedTransaction contains multiple chunks or this ChunkedTransaction is
+   * not frozen.
+   */
+  [[nodiscard]] std::vector<std::byte> getTransactionHash() const override;
+
+  /**
+   * Derived from Transaction. Get the SHA384 hash of each potential Transaction protobuf object this ChunkedTransaction
+   * may send.
+   *
+   * @return The map of node account IDs to the SHA384 hash of their Transaction.
+   * @throws IllegalStateException If this ChunkedTransaction contains multiple chunks or this ChunkedTransaction is not
+   *                               frozen.
+   */
+  [[nodiscard]] std::map<AccountId, std::vector<std::byte>> getTransactionHashPerNode() const override;
+
+  /**
+   * Get the SHA384 hashes of all Transaction protobuf objects for each chunk of this ChunkedTransaction, for each node
+   * account ID.
+   *
+   * @return The list of Transaction protobuf object hashes for each node account ID for each chunk.
+   * @throws IllegalStateException If this ChunkedTransaction isn't frozen.
+   */
+  [[nodiscard]] std::vector<std::map<AccountId, std::vector<std::byte>>> getAllTransactionHashesPerNode() const;
+
+  /**
    * Set the maximum number of chunks for this ChunkedTransaction.
    *
    * @param chunks The maximum number of chunks for this ChunkedTransaction.
@@ -120,16 +178,41 @@ public:
    *
    * @return The maximum number of chunks for this ChunkedTransaction.
    */
-  [[nodiscard]] inline unsigned int getMaxChunks() const { return mMaxChunks; }
+  [[nodiscard]] unsigned int getMaxChunks() const;
 
   /**
    * Get the size of each chunk, in bytes, for this ChunkedTransaction.
    *
    * @return The size of each chunk, in bytes, for this ChunkedTransaction.
    */
-  [[nodiscard]] inline unsigned int getChunkSize() const { return mChunkSize; }
+  [[nodiscard]] unsigned int getChunkSize() const;
 
 protected:
+  ChunkedTransaction();
+  virtual ~ChunkedTransaction();
+  ChunkedTransaction(const ChunkedTransaction&);
+  ChunkedTransaction& operator=(const ChunkedTransaction&);
+  ChunkedTransaction(ChunkedTransaction&&) noexcept;
+  ChunkedTransaction& operator=(ChunkedTransaction&&) noexcept;
+
+  /**
+   * Construct from a TransactionBody protobuf object.
+   *
+   * @param txBody The TransactionBody protobuf object from which to construct.
+   */
+  explicit ChunkedTransaction(const proto::TransactionBody& txBody);
+
+  /**
+   * Construct from a map of TransactionIds to node account IDs and their respective Transaction protobuf objects. This
+   * will ignore the first TransactionId entry (as its information will be stored in the base Transaction
+   * implementation) and construct additional Transaction protobuf objects for each additional chunk of the Transaction
+   * that must be sent.
+   *
+   * @param transactions The map of TransactionIds to node account IDs and their respective Transaction protobuf
+   *                     objects.
+   */
+  explicit ChunkedTransaction(const std::map<TransactionId, std::map<AccountId, proto::Transaction>>& transactions);
+
   /**
    * Set the data for this ChunkedTransaction.
    *
@@ -144,7 +227,15 @@ protected:
    *
    * @return The data for this ChunkedTransaction.
    */
-  [[nodiscard]] inline std::vector<std::byte> getData() const { return mData; }
+  [[nodiscard]] std::vector<std::byte> getData() const;
+
+  /**
+   * Get the data contained in the input chunk of this ChunkedTransaction.
+   *
+   * @param chunk The chunk number of which to get the data.
+   * @return The data contained in the input chunk number.
+   */
+  [[nodiscard]] std::vector<std::byte> getDataForChunk(unsigned int chunk) const;
 
   /**
    * Set the receipt retrieval policy for this ChunkedTransaction.
@@ -160,53 +251,53 @@ protected:
    * @retrun retrieveReceipt \c TRUE if this ChunkedTransaction should retrieve a receipt after each submitted chunk,
    *                         otherwise \c FALSE.
    */
-  [[nodiscard]] inline bool getShouldGetReceipt() const { return mShouldGetReceipt; }
+  [[nodiscard]] bool getShouldGetReceipt() const;
 
 private:
   /**
-   * Perform any needed actions for this ChunkedTransaction after it has been chunked.
+   * Build and add the derived ChunkedTransaction's chunked protobuf representation to the TransactionBody protobuf
+   * object.
    *
-   * @param firstTransactionId The transaction ID of the first chunk.
-   * @param chunk              The chunk number of this chunk.
-   * @param total              The total number of chunks being created.
-   * @throws UninitializedException If the client doesn't have an AccountId from which to generate a TransactionId.
+   * @param chunk The chunk number.
+   * @param total The total number of chunks being created.
+   * @param body  The TransactionBody protobuf object to which to add the chunked data.
    */
-  virtual void onChunk([[maybe_unused]] const TransactionId& firstTransactionId,
-                       [[maybe_unused]] int32_t chunk,
-                       [[maybe_unused]] int32_t total)
-  { // Intentionally unimplemented, no processing needs to occur by default.
-  }
+  virtual void addToChunk(uint32_t chunk, [[maybe_unused]] uint32_t total, proto::TransactionBody& body) const = 0;
 
   /**
-   * Wrapper function needed to execute the Executable<SdkRequestType, proto::Transaction, proto::TransactionResponse,
-   * TransactionResponse> version of execute().
+   * Derived from Executable. Construct a Transaction protobuf object from this ChunkedTransaction, based on the attempt
+   * number. This will take into account the current chunk of this ChunkedTransaction trying to be sent.
    *
-   * @param client  The Client to use to submit the ChunkedTransaction.
-   * @param timeout The desired timeout for the execution of the ChunkedTransaction.
-   * @param tx      The ChunkedTransaction to execute.
-   * @return The TransactionResponse object sent from the Hedera network that contains the result of the request.
+   * @param attempt The attempt number of trying to execute this ChunkedTransaction.
+   * @return A Transaction protobuf object filled with this ChunkedTransaction's data, based on the attempt number.
    */
-  TransactionResponse wrappedExecute(const Client& client, const std::chrono::duration<double>& timeout);
+  [[nodiscard]] proto::Transaction makeRequest(unsigned int attempt) const override;
 
   /**
-   * This ChunkedTransaction's data.
+   * Derived from Transaction. Generate the SignedTransaction protobuf objects for this ChunkedTransaction.
+   *
+   * @param client A pointer to the Client to use to generate the SignedTransaction protobuf objects.
    */
-  std::vector<std::byte> mData;
+  void generateSignedTransactions(const Client* client) override;
 
   /**
-   * The size of this ChunkedTransaction's chunks, in bytes.
+   * Derived from Transaction. Clear the SignedTransaction and Transaction protobuf objects held by this
+   * ChunkedTransaction.
    */
-  unsigned int mChunkSize = 1024U;
+  void clearTransactions() override;
 
   /**
-   * The maximum number of chunks into which this ChunkedTransaction will get broken up.
+   * Get the number of chunks that will be required to send this full ChunkedTransaction.
+   *
+   * @return The number of chunks that will be required to send this full ChunkedTransaction.
    */
-  unsigned int mMaxChunks = DEFAULT_MAX_CHUNKS;
+  [[nodiscard]] unsigned int getNumberOfChunksRequired() const;
 
   /**
-   * Should this ChunkedTransaction get a receipt for each submitted chunk?
+   * Implementation object used to hide implementation details and internal headers.
    */
-  bool mShouldGetReceipt = false;
+  struct ChunkedTransactionImpl;
+  std::unique_ptr<ChunkedTransactionImpl> mImpl;
 };
 
 } // namespace Hedera

--- a/sdk/main/include/Client.h
+++ b/sdk/main/include/Client.h
@@ -32,7 +32,7 @@ namespace Hedera
 namespace internal
 {
 class MirrorNetwork;
-class Node;
+class Network;
 }
 class AccountId;
 class Hbar;
@@ -114,27 +114,7 @@ public:
   Client& setOperator(const AccountId& accountId, const PrivateKey* privateKey);
 
   /**
-   * Sign an arbitrary array of bytes with this Client's operator.
-   *
-   * @param bytes The bytes for this Client's operator to sign.
-   * @return The generated signature of this Client's operator.
-   * @throws UninitializedException If this Client's operator has not yet been set.
-   */
-  [[nodiscard]] std::vector<std::byte> sign(const std::vector<std::byte>& bytes) const;
-
-  /**
-   * Get a list of pointers to Nodes on this Client's network that are associated with the input account IDs. If no
-   * account IDs are specified, this returns the list a list of pointers to all nodes in this Client's network.
-   *
-   * @param accountIds The account IDs of the requested nodes. This can be empty to get all Nodes.
-   * @return A list of pointers to Nodes that are associated with the requested account IDs.
-   * @throws UninitializedException If this Client's network has not yet been initialized.
-   */
-  [[nodiscard]] std::vector<std::shared_ptr<internal::Node>> getNodesWithAccountIds(
-    const std::vector<AccountId>& accountIds) const;
-
-  /**
-   * Initiate an orderly shutdown of communications with the network with which this Client was configured to
+   * Initiate an orderly close of communications with the network with which this Client was configured to
    * communicate. Preexisting transactions or queries continue but subsequent calls would be immediately cancelled.
    *
    * After this method returns, this Client can be re-used. All network communication can be re-established as needed.
@@ -159,6 +139,17 @@ public:
    * @throws std::invalid_argument If the transaction fee is negative.
    */
   Client& setMaxTransactionFee(const Hbar& fee);
+
+  /**
+   * Set the maximum query payment willing to be paid for transactions executed by this Client. Every request submitted
+   * with this Client will have its maximum query payment overwritten by this Client's maximum query payment if and only
+   * if it has not been set manually in the request itself.
+   *
+   * @param payment The desired maximum query payment willing to be paid for queries submitted by this Client.
+   * @return A reference to this Client object with the newly-set maximum query payment.
+   * @throws std::invalid_argument If the query payment is negative.
+   */
+  Client& setMaxQueryPayment(const Hbar& payment);
 
   /**
    * Set the transaction ID regeneration policy for transactions executed by this Client. Every transaction submitted
@@ -208,6 +199,13 @@ public:
   Client& setMaxBackoff(const std::chrono::duration<double>& backoff);
 
   /**
+   * Get a pointer to the Network this Client is using to communicate with consensus nodes.
+   *
+   * @return A pointer to the Network this Client is using to communicate with consensus nodes.
+   */
+  [[nodiscard]] std::shared_ptr<internal::Network> getNetwork() const;
+
+  /**
    * Get the account ID of this Client's operator.
    *
    * @return The account ID of this Client's operator. Uninitialized if the operator has not yet been set.
@@ -243,6 +241,13 @@ public:
    *         set.
    */
   [[nodiscard]] std::optional<Hbar> getMaxTransactionFee() const;
+
+  /**
+   * Get the maximum payment willing to be paid for queries submitted by this Client.
+   *
+   * @return The maximum query payment willing to be paid by this Client. Uninitialized if the fee has not yet been set.
+   */
+  [[nodiscard]] std::optional<Hbar> getMaxQueryPayment() const;
 
   /**
    * Get the transaction ID regeneration policy for transactions submitted by this Client.

--- a/sdk/main/include/ContractByteCodeQuery.h
+++ b/sdk/main/include/ContractByteCodeQuery.h
@@ -54,46 +54,43 @@ public:
 
 private:
   /**
-   * Derived from Executable. Construct a Query protobuf object from this ContractByteCodeQuery object.
+   * Derived from Executable. Construct a ContractByteCode object from a Response protobuf object.
    *
-   * @param client The Client trying to construct this ContractByteCodeQuery.
-   * @param node   The Node to which this ContractByteCodeQuery will be sent.
-   * @return A Query protobuf object filled with this ContractByteCodeQuery object's data.
-   */
-  [[nodiscard]] proto::Query makeRequest(const Client& client,
-                                         const std::shared_ptr<internal::Node>& node) const override;
-
-  /**
-   * Derived from Executable. Construct an ContractByteCode object from a Response protobuf object.
-   *
-   * @param response The Response protobuf object from which to construct an ContractByteCode object.
-   * @return An ContractByteCode object filled with the Response protobuf object's data
+   * @param response The Response protobuf object from which to construct a ContractByteCode object.
+   * @return A ContractByteCode object filled with the Response protobuf object's data
    */
   [[nodiscard]] ContractByteCode mapResponse(const proto::Response& response) const override;
 
   /**
-   * Derived from Executable. Get the status response code for a submitted ContractByteCodeQuery from a Response
-   * protobuf object.
+   * Derived from Executable. Submit a Query protobuf object which contains this ContractByteCodeQuery's data to a Node.
    *
-   * @param response The Response protobuf object from which to grab the ContractByteCodeQuery status response code.
-   * @return The ContractByteCodeQuery status response code of the input Response protobuf object.
-   */
-  [[nodiscard]] Status mapResponseStatus(const proto::Response& response) const override;
-
-  /**
-   * Derived from Executable. Submit this ContractByteCodeQuery to a Node.
-   *
-   * @param client   The Client submitting this ContractByteCodeQuery.
-   * @param deadline The deadline for submitting this ContractByteCodeQuery.
-   * @param node     Pointer to the Node to which this ContractByteCodeQuery should be submitted.
-   * @param response Pointer to the Response protobuf object that gRPC should populate with the response information
+   * @param request  The Query protobuf object to submit.
+   * @param node     The Node to which to submit the request.
+   * @param deadline The deadline for submitting the request.
+   * @param response Pointer to the ProtoResponseType object that gRPC should populate with the response information
    *                 from the gRPC server.
    * @return The gRPC status of the submission.
    */
-  [[nodiscard]] grpc::Status submitRequest(const Client& client,
-                                           const std::chrono::system_clock::time_point& deadline,
+  [[nodiscard]] grpc::Status submitRequest(const proto::Query& request,
                                            const std::shared_ptr<internal::Node>& node,
+                                           const std::chrono::system_clock::time_point& deadline,
                                            proto::Response* response) const override;
+  /**
+   * Derived from Query. Build a Query protobuf object with this ContractByteCodeQuery's data, with the input
+   * QueryHeader protobuf object.
+   *
+   * @param header A pointer to the QueryHeader protobuf object to add to the Query protobuf object.
+   * @return The constructed Query protobuf object.
+   */
+  [[nodiscard]] proto::Query buildRequest(proto::QueryHeader* header) const override;
+
+  /**
+   * Derived from Query. Get the ResponseHeader protobuf object from the input Response protobuf object.
+   *
+   * @param response The Response protobuf object from which to get the ResponseHeader protobuf object.
+   * @return The ResponseHeader protobuf object of the input Response protobuf object for this derived Query.
+   */
+  [[nodiscard]] proto::ResponseHeader mapResponseHeader(const proto::Response& response) const override;
 
   /**
    * The ID of the contract of which this query should get the byte code.

--- a/sdk/main/include/ContractCallQuery.h
+++ b/sdk/main/include/ContractCallQuery.h
@@ -125,46 +125,43 @@ public:
 
 private:
   /**
-   * Derived from Executable. Construct a Query protobuf object from this ContractCallQuery object.
+   * Derived from Executable. Construct a ContractFunctionResult object from a Response protobuf object.
    *
-   * @param client The Client trying to construct this ContractCallQuery.
-   * @param node   The Node to which this ContractCallQuery will be sent.
-   * @return A Query protobuf object filled with this ContractCallQuery object's data.
-   */
-  [[nodiscard]] proto::Query makeRequest(const Client& client,
-                                         const std::shared_ptr<internal::Node>& node) const override;
-
-  /**
-   * Derived from Executable. Construct an ContractCallQuery object from a Response protobuf object.
-   *
-   * @param response The Response protobuf object from which to construct an ContractCallQuery object.
-   * @return An ContractCallQuery object filled with the Response protobuf object's data
+   * @param response The Response protobuf object from which to construct a ContractFunctionResult object.
+   * @return A ContractFunctionResult object filled with the Response protobuf object's data
    */
   [[nodiscard]] ContractFunctionResult mapResponse(const proto::Response& response) const override;
 
   /**
-   * Derived from Executable. Get the status response code for a submitted ContractCallQuery from a Response
-   * protobuf object.
+   * Derived from Executable. Submit a Query protobuf object which contains this ContractCallQuery's data to a Node.
    *
-   * @param response The Response protobuf object from which to grab the ContractCallQuery status response code.
-   * @return The ContractCallQuery status response code of the input Response protobuf object.
-   */
-  [[nodiscard]] Status mapResponseStatus(const proto::Response& response) const override;
-
-  /**
-   * Derived from Executable. Submit this ContractCallQuery to a Node.
-   *
-   * @param client   The Client submitting this ContractCallQuery.
-   * @param deadline The deadline for submitting this ContractCallQuery.
-   * @param node     Pointer to the Node to which this ContractCallQuery should be submitted.
-   * @param response Pointer to the Response protobuf object that gRPC should populate with the response information
+   * @param request  The Query protobuf object to submit.
+   * @param node     The Node to which to submit the request.
+   * @param deadline The deadline for submitting the request.
+   * @param response Pointer to the ProtoResponseType object that gRPC should populate with the response information
    *                 from the gRPC server.
    * @return The gRPC status of the submission.
    */
-  [[nodiscard]] grpc::Status submitRequest(const Client& client,
-                                           const std::chrono::system_clock::time_point& deadline,
+  [[nodiscard]] grpc::Status submitRequest(const proto::Query& request,
                                            const std::shared_ptr<internal::Node>& node,
+                                           const std::chrono::system_clock::time_point& deadline,
                                            proto::Response* response) const override;
+  /**
+   * Derived from Query. Build a Query protobuf object with this ContractCallQuery's data, with the input QueryHeader
+   * protobuf object.
+   *
+   * @param header A pointer to the QueryHeader protobuf object to add to the Query protobuf object.
+   * @return The constructed Query protobuf object.
+   */
+  [[nodiscard]] proto::Query buildRequest(proto::QueryHeader* header) const override;
+
+  /**
+   * Derived from Query. Get the ResponseHeader protobuf object from the input Response protobuf object.
+   *
+   * @param response The Response protobuf object from which to get the ResponseHeader protobuf object.
+   * @return The ResponseHeader protobuf object of the input Response protobuf object for this derived Query.
+   */
+  [[nodiscard]] proto::ResponseHeader mapResponseHeader(const proto::Response& response) const override;
 
   /**
    * The ID of the contract from which this query should call a function.

--- a/sdk/main/include/ContractCreateTransaction.h
+++ b/sdk/main/include/ContractCreateTransaction.h
@@ -107,6 +107,15 @@ public:
   explicit ContractCreateTransaction(const proto::TransactionBody& transactionBody);
 
   /**
+   * Construct from a map of TransactionIds to node account IDs and their respective Transaction protobuf objects.
+   *
+   * @param transactions The map of TransactionIds to node account IDs and their respective Transaction protobuf
+   *                     objects.
+   */
+  explicit ContractCreateTransaction(
+    const std::map<TransactionId, std::map<AccountId, proto::Transaction>>& transactions);
+
+  /**
    * Set the ID of the file that contains the smart contract bytecode. A copy will be made and held by the contract
    * instance, and have the same expiration time as the instance. If the bytecode is large (>5K), then it must be stored
    * in a file. This is mutually exclusive with mBytecode, and will reset the value of the mBytecode if it is set.
@@ -343,30 +352,19 @@ private:
   friend class WrappedTransaction;
 
   /**
-   * Derived from Executable. Construct a Transaction protobuf object from this ContractCreateTransaction object.
+   * Derived from Executable. Submit a Transaction protobuf object which contains this ContractCreateTransaction's data
+   * to a Node.
    *
-   * @param client The Client trying to construct this ContractCreateTransaction.
-   * @param node   The Node to which this ContractCreateTransaction will be sent. This is unused.
-   * @return A Transaction protobuf object filled with this ContractCreateTransaction object's data.
-   * @throws UninitializedException If the input client has no operator with which to sign this
-   *                                ContractCreateTransaction.
-   */
-  [[nodiscard]] proto::Transaction makeRequest(const Client& client,
-                                               const std::shared_ptr<internal::Node>& /*node*/) const override;
-
-  /**
-   * Derived from Executable. Submit this ContractCreateTransaction to a Node.
-   *
-   * @param client   The Client submitting this ContractCreateTransaction.
-   * @param deadline The deadline for submitting this ContractCreateTransaction.
-   * @param node     Pointer to the Node to which this ContractCreateTransaction should be submitted.
-   * @param response Pointer to the TransactionResponse protobuf object that gRPC should populate with the response
-   *                 information from the gRPC server.
+   * @param request  The Transaction protobuf object to submit.
+   * @param node     The Node to which to submit the request.
+   * @param deadline The deadline for submitting the request.
+   * @param response Pointer to the ProtoResponseType object that gRPC should populate with the response information
+   *                 from the gRPC server.
    * @return The gRPC status of the submission.
    */
-  [[nodiscard]] grpc::Status submitRequest(const Client& client,
-                                           const std::chrono::system_clock::time_point& deadline,
+  [[nodiscard]] grpc::Status submitRequest(const proto::Transaction& request,
                                            const std::shared_ptr<internal::Node>& node,
+                                           const std::chrono::system_clock::time_point& deadline,
                                            proto::TransactionResponse* response) const override;
   /**
    * Derived from Transaction. Build and add the ContractCreateTransaction protobuf representation to the Transaction
@@ -375,6 +373,11 @@ private:
    * @param body The TransactionBody protobuf object being built.
    */
   void addToBody(proto::TransactionBody& body) const override;
+
+  /**
+   * Initialize this ContractCreateTransaction from its source TransactionBody protobuf object.
+   */
+  void initFromSourceTransactionBody();
 
   /**
    * Build a ContractCreateTransactionBody protobuf object from this ContractCreateTransaction object.

--- a/sdk/main/include/ContractDeleteTransaction.h
+++ b/sdk/main/include/ContractDeleteTransaction.h
@@ -60,6 +60,15 @@ public:
   explicit ContractDeleteTransaction(const proto::TransactionBody& transactionBody);
 
   /**
+   * Construct from a map of TransactionIds to node account IDs and their respective Transaction protobuf objects.
+   *
+   * @param transactions The map of TransactionIds to node account IDs and their respective Transaction protobuf
+   *                     objects.
+   */
+  explicit ContractDeleteTransaction(
+    const std::map<TransactionId, std::map<AccountId, proto::Transaction>>& transactions);
+
+  /**
    * Set the ID of the contract to delete.
    *
    * @param contractId The ID of the contract to delete.
@@ -115,30 +124,19 @@ private:
   friend class WrappedTransaction;
 
   /**
-   * Derived from Executable. Construct a Transaction protobuf object from this ContractDeleteTransaction object.
+   * Derived from Executable. Submit a Transaction protobuf object which contains this ContractDeleteTransaction's data
+   * to a Node.
    *
-   * @param client The Client trying to construct this ContractDeleteTransaction.
-   * @param node   The Node to which this ContractDeleteTransaction will be sent. This is unused.
-   * @return A Transaction protobuf object filled with this ContractDeleteTransaction object's data.
-   * @throws UninitializedException If the input client has no operator with which to sign this
-   *                                ContractDeleteTransaction.
-   */
-  [[nodiscard]] proto::Transaction makeRequest(const Client& client,
-                                               const std::shared_ptr<internal::Node>& /*node*/) const override;
-
-  /**
-   * Derived from Executable. Submit this ContractDeleteTransaction to a Node.
-   *
-   * @param client   The Client submitting this ContractDeleteTransaction.
-   * @param deadline The deadline for submitting this ContractDeleteTransaction.
-   * @param node     Pointer to the Node to which this ContractDeleteTransaction should be submitted.
-   * @param response Pointer to the TransactionResponse protobuf object that gRPC should populate with the response
-   *                 information from the gRPC server.
+   * @param request  The Transaction protobuf object to submit.
+   * @param node     The Node to which to submit the request.
+   * @param deadline The deadline for submitting the request.
+   * @param response Pointer to the ProtoResponseType object that gRPC should populate with the response information
+   *                 from the gRPC server.
    * @return The gRPC status of the submission.
    */
-  [[nodiscard]] grpc::Status submitRequest(const Client& client,
-                                           const std::chrono::system_clock::time_point& deadline,
+  [[nodiscard]] grpc::Status submitRequest(const proto::Transaction& request,
                                            const std::shared_ptr<internal::Node>& node,
+                                           const std::chrono::system_clock::time_point& deadline,
                                            proto::TransactionResponse* response) const override;
   /**
    * Derived from Transaction. Build and add the ContractDeleteTransaction protobuf representation to the Transaction
@@ -147,6 +145,11 @@ private:
    * @param body The TransactionBody protobuf object being built.
    */
   void addToBody(proto::TransactionBody& body) const override;
+
+  /**
+   * Initialize this ContractDeleteTransaction from its source TransactionBody protobuf object.
+   */
+  void initFromSourceTransactionBody();
 
   /**
    * Build a ContractDeleteTransactionBody protobuf object from this ContractDeleteTransaction object.

--- a/sdk/main/include/ContractExecuteTransaction.h
+++ b/sdk/main/include/ContractExecuteTransaction.h
@@ -61,6 +61,15 @@ public:
   explicit ContractExecuteTransaction(const proto::TransactionBody& transactionBody);
 
   /**
+   * Construct from a map of TransactionIds to node account IDs and their respective Transaction protobuf objects.
+   *
+   * @param transactions The map of TransactionIds to node account IDs and their respective Transaction protobuf
+   *                     objects.
+   */
+  explicit ContractExecuteTransaction(
+    const std::map<TransactionId, std::map<AccountId, proto::Transaction>>& transactions);
+
+  /**
    * Set the ID of the contract to call.
    *
    * @param fileId The ID of the contract to call.
@@ -139,30 +148,19 @@ private:
   friend class WrappedTransaction;
 
   /**
-   * Derived from Executable. Construct a Transaction protobuf object from this ContractExecuteTransaction object.
+   * Derived from Executable. Submit a Transaction protobuf object which contains this ContractExecuteTransaction's data
+   * to a Node.
    *
-   * @param client The Client trying to construct this ContractExecuteTransaction.
-   * @param node   The Node to which this ContractExecuteTransaction will be sent. This is unused.
-   * @return A Transaction protobuf object filled with this ContractExecuteTransaction object's data.
-   * @throws UninitializedException If the input client has no operator with which to sign this
-   *                                ContractExecuteTransaction.
-   */
-  [[nodiscard]] proto::Transaction makeRequest(const Client& client,
-                                               const std::shared_ptr<internal::Node>& /*node*/) const override;
-
-  /**
-   * Derived from Executable. Submit this ContractExecuteTransaction to a Node.
-   *
-   * @param client   The Client submitting this ContractExecuteTransaction.
-   * @param deadline The deadline for submitting this ContractExecuteTransaction.
-   * @param node     Pointer to the Node to which this ContractExecuteTransaction should be submitted.
-   * @param response Pointer to the TransactionResponse protobuf object that gRPC should populate with the response
-   *                 information from the gRPC server.
+   * @param request  The Transaction protobuf object to submit.
+   * @param node     The Node to which to submit the request.
+   * @param deadline The deadline for submitting the request.
+   * @param response Pointer to the ProtoResponseType object that gRPC should populate with the response information
+   *                 from the gRPC server.
    * @return The gRPC status of the submission.
    */
-  [[nodiscard]] grpc::Status submitRequest(const Client& client,
-                                           const std::chrono::system_clock::time_point& deadline,
+  [[nodiscard]] grpc::Status submitRequest(const proto::Transaction& request,
                                            const std::shared_ptr<internal::Node>& node,
+                                           const std::chrono::system_clock::time_point& deadline,
                                            proto::TransactionResponse* response) const override;
   /**
    * Derived from Transaction. Build and add the ContractExecuteTransaction protobuf representation to the Transaction
@@ -171,6 +169,11 @@ private:
    * @param body The TransactionBody protobuf object being built.
    */
   void addToBody(proto::TransactionBody& body) const override;
+
+  /**
+   * Initialize this ContractExecuteTransaction from its source TransactionBody protobuf object.
+   */
+  void initFromSourceTransactionBody();
 
   /**
    * Build a ContractCallTransactionBody protobuf object from this ContractExecuteTransaction object.

--- a/sdk/main/include/ContractInfoQuery.h
+++ b/sdk/main/include/ContractInfoQuery.h
@@ -58,16 +58,6 @@ public:
 
 private:
   /**
-   * Derived from Executable. Construct a Query protobuf object from this ContractInfoQuery object.
-   *
-   * @param client The Client trying to construct this ContractInfoQuery.
-   * @param node   The Node to which this ContractInfoQuery will be sent.
-   * @return A Query protobuf object filled with this ContractInfoQuery object's data.
-   */
-  [[nodiscard]] proto::Query makeRequest(const Client& client,
-                                         const std::shared_ptr<internal::Node>& node) const override;
-
-  /**
    * Derived from Executable. Construct a ContractInfo object from a Response protobuf object.
    *
    * @param response The Response protobuf object from which to construct a ContractInfo object.
@@ -76,28 +66,35 @@ private:
   [[nodiscard]] ContractInfo mapResponse(const proto::Response& response) const override;
 
   /**
-   * Derived from Executable. Get the status response code for a submitted ContractInfoQuery from a Response protobuf
-   * object.
+   * Derived from Executable. Submit a Query protobuf object which contains this ContractInfoQuery's data to a Node.
    *
-   * @param response The Response protobuf object from which to grab the ContractInfoQuery status response code.
-   * @return The ContractInfoQuery status response code of the input Response protobuf object.
-   */
-  [[nodiscard]] Status mapResponseStatus(const proto::Response& response) const override;
-
-  /**
-   * Derived from Executable. Submit this ContractInfoQuery to a Node.
-   *
-   * @param client   The Client submitting this ContractInfoQuery.
-   * @param deadline The deadline for submitting this ContractInfoQuery.
-   * @param node     Pointer to the Node to which this ContractInfoQuery should be submitted.
-   * @param response Pointer to the Response protobuf object that gRPC should populate with the response information
+   * @param request  The Query protobuf object to submit.
+   * @param node     The Node to which to submit the request.
+   * @param deadline The deadline for submitting the request.
+   * @param response Pointer to the ProtoResponseType object that gRPC should populate with the response information
    *                 from the gRPC server.
    * @return The gRPC status of the submission.
    */
-  [[nodiscard]] grpc::Status submitRequest(const Client& client,
-                                           const std::chrono::system_clock::time_point& deadline,
+  [[nodiscard]] grpc::Status submitRequest(const proto::Query& request,
                                            const std::shared_ptr<internal::Node>& node,
+                                           const std::chrono::system_clock::time_point& deadline,
                                            proto::Response* response) const override;
+  /**
+   * Derived from Query. Build a Query protobuf object with this ContractInfoQuery's data, with the input QueryHeader
+   * protobuf object.
+   *
+   * @param header A pointer to the QueryHeader protobuf object to add to the Query protobuf object.
+   * @return The constructed Query protobuf object.
+   */
+  [[nodiscard]] proto::Query buildRequest(proto::QueryHeader* header) const override;
+
+  /**
+   * Derived from Query. Get the ResponseHeader protobuf object from the input Response protobuf object.
+   *
+   * @param response The Response protobuf object from which to get the ResponseHeader protobuf object.
+   * @return The ResponseHeader protobuf object of the input Response protobuf object for this derived Query.
+   */
+  [[nodiscard]] proto::ResponseHeader mapResponseHeader(const proto::Response& response) const override;
 
   /**
    * The ID of the contract of which this query should get the info.

--- a/sdk/main/include/ContractUpdateTransaction.h
+++ b/sdk/main/include/ContractUpdateTransaction.h
@@ -68,6 +68,15 @@ public:
   explicit ContractUpdateTransaction(const proto::TransactionBody& transactionBody);
 
   /**
+   * Construct from a map of TransactionIds to node account IDs and their respective Transaction protobuf objects.
+   *
+   * @param transactions The map of TransactionIds to node account IDs and their respective Transaction protobuf
+   *                     objects.
+   */
+  explicit ContractUpdateTransaction(
+    const std::map<TransactionId, std::map<AccountId, proto::Transaction>>& transactions);
+
+  /**
    * Set the ID of the contract to update.
    *
    * @param contractId The ID of the contract to update.
@@ -253,30 +262,19 @@ private:
   friend class WrappedTransaction;
 
   /**
-   * Derived from Executable. Construct a Transaction protobuf object from this ContractUpdateTransaction object.
+   * Derived from Executable. Submit a Transaction protobuf object which contains this ContractUpdateTransaction's data
+   * to a Node.
    *
-   * @param client The Client trying to construct this ContractUpdateTransaction.
-   * @param node   The Node to which this ContractUpdateTransaction will be sent. This is unused.
-   * @return A Transaction protobuf object filled with this ContractUpdateTransaction object's data.
-   * @throws UninitializedException If the input client has no operator with which to sign this
-   *                                ContractUpdateTransaction.
-   */
-  [[nodiscard]] proto::Transaction makeRequest(const Client& client,
-                                               const std::shared_ptr<internal::Node>& /*node*/) const override;
-
-  /**
-   * Derived from Executable. Submit this ContractUpdateTransaction to a Node.
-   *
-   * @param client   The Client submitting this ContractUpdateTransaction.
-   * @param deadline The deadline for submitting this ContractUpdateTransaction.
-   * @param node     Pointer to the Node to which this ContractUpdateTransaction should be submitted.
-   * @param response Pointer to the TransactionResponse protobuf object that gRPC should populate with the response
-   *                 information from the gRPC server.
+   * @param request  The Transaction protobuf object to submit.
+   * @param node     The Node to which to submit the request.
+   * @param deadline The deadline for submitting the request.
+   * @param response Pointer to the ProtoResponseType object that gRPC should populate with the response information
+   *                 from the gRPC server.
    * @return The gRPC status of the submission.
    */
-  [[nodiscard]] grpc::Status submitRequest(const Client& client,
-                                           const std::chrono::system_clock::time_point& deadline,
+  [[nodiscard]] grpc::Status submitRequest(const proto::Transaction& request,
                                            const std::shared_ptr<internal::Node>& node,
+                                           const std::chrono::system_clock::time_point& deadline,
                                            proto::TransactionResponse* response) const override;
   /**
    * Derived from Transaction. Build and add the ContractUpdateTransaction protobuf representation to the Transaction
@@ -285,6 +283,11 @@ private:
    * @param body The TransactionBody protobuf object being built.
    */
   void addToBody(proto::TransactionBody& body) const override;
+
+  /**
+   * Initialize this ContractUpdateTransaction from its source TransactionBody protobuf object.
+   */
+  void initFromSourceTransactionBody();
 
   /**
    * Build a ContractUpdateTransactionBody protobuf object from this ContractUpdateTransaction object.

--- a/sdk/main/include/Defaults.h
+++ b/sdk/main/include/Defaults.h
@@ -76,6 +76,10 @@ constexpr auto DEFAULT_TRANSACTION_VALID_DURATION = std::chrono::minutes(2);
  */
 constexpr auto DEFAULT_REGENERATE_TRANSACTION_ID = true;
 /**
+ * The default size of a chunk for a ChunkedTransaction.
+ */
+constexpr auto DEFAULT_CHUNK_SIZE = 1024U;
+/**
  * The default number of chunks for a ChunkedTransaction.
  */
 constexpr auto DEFAULT_MAX_CHUNKS = 20U;

--- a/sdk/main/include/Defaults.h
+++ b/sdk/main/include/Defaults.h
@@ -31,21 +31,50 @@ namespace Hedera
  */
 constexpr auto DEFAULT_MAX_ATTEMPTS = 10U;
 /**
- * The default minimum duration of time to wait before retrying to submit a previously-failed request to the same node.
+ * The default minimum duration of time to wait before retrying to submit a previously-failed request.
  */
 constexpr auto DEFAULT_MIN_BACKOFF = std::chrono::milliseconds(250);
 /**
- * The default maximum duration of time to wait before retrying to submit a previously-failed request to the same node.
+ * The default maximum duration of time to wait before retrying to submit a previously-failed request.
  */
 constexpr auto DEFAULT_MAX_BACKOFF = std::chrono::seconds(8);
+/**
+ * The default maximum number of times a node is allowed to return a bad gRPC status before it is permanently removed
+ * from a network. 0 indicates there's no maximum.
+ */
+constexpr auto DEFAULT_MAX_NODE_ATTEMPTS = 0U;
+/**
+ * The default minimum duration of time to wait before retrying to submit a previously-failed request to the same node.
+ */
+constexpr auto DEFAULT_MIN_NODE_BACKOFF = std::chrono::seconds(8);
+/**
+ * The default maximum duration of time to wait before retrying to submit a previously-failed request to the same node.
+ */
+constexpr auto DEFAULT_MAX_NODE_BACKOFF = std::chrono::hours(1);
+/**
+ * The default amount of time to allow a node to gracefully close a gRPC connection before forcibly terminating it.
+ */
+constexpr auto DEFAULT_CLOSE_TIMEOUT = std::chrono::seconds(30);
 /**
  * The default maximum transaction fee.
  */
 constexpr auto DEFAULT_MAX_TRANSACTION_FEE = Hbar(2LL);
 /**
+ * The default maximum query payment
+ */
+constexpr auto DEFAULT_MAX_QUERY_PAYMENT = Hbar(1LL);
+/**
  * The default auto-renew period.
  */
 constexpr auto DEFAULT_AUTO_RENEW_PERIOD = std::chrono::hours(2160);
+/**
+ * The default duration of time a Transaction will remain valid.
+ */
+constexpr auto DEFAULT_TRANSACTION_VALID_DURATION = std::chrono::minutes(2);
+/**
+ * The default transaction ID regeneration policy.
+ */
+constexpr auto DEFAULT_REGENERATE_TRANSACTION_ID = true;
 /**
  * The default number of chunks for a ChunkedTransaction.
  */

--- a/sdk/main/include/ECDSAsecp256k1PublicKey.h
+++ b/sdk/main/include/ECDSAsecp256k1PublicKey.h
@@ -189,6 +189,15 @@ public:
   [[nodiscard]] std::vector<std::byte> toBytesRaw() const override;
 
   /**
+   * Derived from PublicKey. Serialize this ECDSAsecp256k1PublicKey to a SignaturePair protobuf object with the given
+   * signature.
+   *
+   * @param signature The signature created by this ECDSAsecp256k1PublicKey.
+   */
+  [[nodiscard]] std::unique_ptr<proto::SignaturePair> toSignaturePairProtobuf(
+    const std::vector<std::byte>& signature) const override;
+
+  /**
    * Construct an EvmAddress from this ECDSAsecp256k1PublicKey. The constructed EvmAddress will be the last 20 bytes of
    * the keccak-256 hash of this ECDSAsecp256k1PublicKey.
    *

--- a/sdk/main/include/ED25519PublicKey.h
+++ b/sdk/main/include/ED25519PublicKey.h
@@ -139,6 +139,15 @@ public:
    */
   [[nodiscard]] std::vector<std::byte> toBytesRaw() const override;
 
+  /**
+   * Derived from PublicKey. Serialize this ED25519PublicKey to a SignaturePair protobuf object with the given
+   * signature.
+   *
+   * @param signature The signature created by this ED25519PublicKey.
+   */
+  [[nodiscard]] std::unique_ptr<proto::SignaturePair> toSignaturePairProtobuf(
+    const std::vector<std::byte>& signature) const override;
+
 private:
   /**
    * Construct from a wrapped OpenSSL key object.

--- a/sdk/main/include/EthereumTransaction.h
+++ b/sdk/main/include/EthereumTransaction.h
@@ -57,6 +57,14 @@ public:
   explicit EthereumTransaction(const proto::TransactionBody& transactionBody);
 
   /**
+   * Construct from a map of TransactionIds to node account IDs and their respective Transaction protobuf objects.
+   *
+   * @param transactions The map of TransactionIds to node account IDs and their respective Transaction protobuf
+   *                     objects.
+   */
+  explicit EthereumTransaction(const std::map<TransactionId, std::map<AccountId, proto::Transaction>>& transactions);
+
+  /**
    * Set the raw Ethereum transaction (RLP encoded type 0, 1, and 2).
    *
    * @param ethereumData The raw Ethereum transaction.
@@ -112,30 +120,19 @@ private:
   friend class WrappedTransaction;
 
   /**
-   * Derived from Executable. Construct a Transaction protobuf object from this EthereumTransaction object.
+   * Derived from Executable. Submit a Transaction protobuf object which contains this EthereumTransaction's data to a
+   * Node.
    *
-   * @param client The Client trying to construct this EthereumTransaction.
-   * @param node   The Node to which this EthereumTransaction will be sent. This is unused.
-   * @return A Transaction protobuf object filled with this EthereumTransaction object's data.
-   * @throws UninitializedException If the input client has no operator with which to sign this
-   *                                ContractUpdateTransaction.
-   */
-  [[nodiscard]] proto::Transaction makeRequest(const Client& client,
-                                               const std::shared_ptr<internal::Node>& /*node*/) const override;
-
-  /**
-   * Derived from Executable. Submit this EthereumTransaction to a Node.
-   *
-   * @param client   The Client submitting this EthereumTransaction.
-   * @param deadline The deadline for submitting this EthereumTransaction.
-   * @param node     Pointer to the Node to which this EthereumTransaction should be submitted.
-   * @param response Pointer to the TransactionResponse protobuf object that gRPC should populate with the response
-   *                 information from the gRPC server.
+   * @param request  The Transaction protobuf object to submit.
+   * @param node     The Node to which to submit the request.
+   * @param deadline The deadline for submitting the request.
+   * @param response Pointer to the ProtoResponseType object that gRPC should populate with the response information
+   *                 from the gRPC server.
    * @return The gRPC status of the submission.
    */
-  [[nodiscard]] grpc::Status submitRequest(const Client& client,
-                                           const std::chrono::system_clock::time_point& deadline,
+  [[nodiscard]] grpc::Status submitRequest(const proto::Transaction& request,
                                            const std::shared_ptr<internal::Node>& node,
+                                           const std::chrono::system_clock::time_point& deadline,
                                            proto::TransactionResponse* response) const override;
   /**
    * Derived from Transaction. Build and add the EthereumTransaction protobuf representation to the Transaction protobuf
@@ -144,6 +141,11 @@ private:
    * @param body The TransactionBody protobuf object being built.
    */
   void addToBody(proto::TransactionBody& body) const override;
+
+  /**
+   * Initialize this EthereumTransaction from its source TransactionBody protobuf object.
+   */
+  void initFromSourceTransactionBody();
 
   /**
    * Build a EthereumTransactionBody protobuf object from this EthereumTransaction object.

--- a/sdk/main/include/Executable.h
+++ b/sdk/main/include/Executable.h
@@ -58,8 +58,6 @@ template<typename SdkRequestType, typename ProtoRequestType, typename ProtoRespo
 class Executable
 {
 public:
-  virtual ~Executable() = default;
-
   /**
    * Submit this Executable to a Hedera network.
    *
@@ -84,12 +82,12 @@ public:
   virtual SdkResponseType execute(const Client& client, const std::chrono::duration<double>& timeout);
 
   /**
-   * Set the desired account IDs of nodes to which this transaction will be submitted.
+   * Set the desired account IDs of nodes to which this request will be submitted.
    *
    * @param nodeAccountIds The desired list of account IDs of nodes to submit this request.
    * @return A reference to this Executable derived class with the newly-set node account IDs.
    */
-  SdkRequestType& setNodeAccountIds(const std::vector<AccountId>& nodeAccountIds);
+  virtual SdkRequestType& setNodeAccountIds(const std::vector<AccountId>& nodeAccountIds);
 
   /**
    * Set the maximum number of times this Executable should try to resubmit itself after a failed attempt before it
@@ -183,13 +181,6 @@ protected:
   };
 
   /**
-   * Perform any needed actions for this Executable when a Node has been selected to which to submit this Executable.
-   *
-   * @param node The Node to which this Executable is being submitted.
-   */
-  virtual void onSelectNode([[maybe_unused]] const std::shared_ptr<internal::Node>& node);
-
-  /**
    * Determine the ExecutionStatus of this Executable after being submitted.
    *
    * @param status   The response status from the network.
@@ -203,15 +194,14 @@ protected:
 
 private:
   /**
-   * Construct a ProtoRequestType object from this Executable object.
+   * Construct a ProtoRequestType object from this Executable, based on the node account ID at the given index.
    *
-   * @param client The Client being used to submit this Executable.
-   * @param node   The Node to which this Executable will be sent.
-   * @return A ProtoRequestType object filled with this Executable object's data.
+   * @param index The index of the node account ID that's associated with the Node being used to execute this
+   *              Executable.
+   * @return A ProtoRequestType object filled with this Executable's data, based on the node account ID at the given
+   *         index.
    */
-  [[nodiscard]] virtual ProtoRequestType makeRequest(
-    [[maybe_unused]] const Client& client,
-    [[maybe_unused]] const std::shared_ptr<internal::Node>& node) const = 0;
+  [[nodiscard]] virtual ProtoRequestType makeRequest(unsigned int index) const = 0;
 
   /**
    * Construct an SdkResponseType from a ProtoResponseType object.
@@ -230,18 +220,18 @@ private:
   [[nodiscard]] virtual Status mapResponseStatus(const ProtoResponseType& response) const = 0;
 
   /**
-   * Submit this Executable to a Node.
+   * Submit a ProtoRequestType object which contains this Executable's data to a Node.
    *
-   * @param client   The Client submitting this Executable.
-   * @param deadline The deadline for submitting this Executable.
-   * @param node     Pointer to the Node to which this Executable should be submitted.
+   * @param request  The ProtoRequestType object to submit.
+   * @param node     The Node to which to submit the request.
+   * @param deadline The deadline for submitting the request.
    * @param response Pointer to the ProtoResponseType object that gRPC should populate with the response information
    *                 from the gRPC server.
    * @return The gRPC status of the submission.
    */
-  [[nodiscard]] virtual grpc::Status submitRequest(const Client& client,
-                                                   const std::chrono::system_clock::time_point& deadline,
+  [[nodiscard]] virtual grpc::Status submitRequest(const ProtoRequestType& request,
                                                    const std::shared_ptr<internal::Node>& node,
+                                                   const std::chrono::system_clock::time_point& deadline,
                                                    ProtoResponseType* response) const = 0;
 
   /**
@@ -263,14 +253,24 @@ private:
   void setExecutionParameters(const Client& client);
 
   /**
-   * Get a Node from a list of Nodes to which to try and send this Executable. This will prioritize getting "healthy"
-   * Nodes first in order to ensure as little wait time to submit as possible.
+   * Get a list of Nodes that are on the input Client's Network that are being run by this Executable's node account
+   * IDs.
    *
-   * @param nodes The list of Nodes from which to select a Node.
+   * @param client The Client from which to get the list of Nodes.
+   * @return A list of Nodes that are being run by this Executable's node account IDs.
+   */
+  [[nodiscard]] std::vector<std::shared_ptr<internal::Node>> getNodesFromNodeAccountIds(const Client& client) const;
+
+  /**
+   * Get the index of a Node from a list of Nodes to which to try and send this Executable. This will prioritize getting
+   * "healthy" Nodes first in order to ensure as little wait time to submit as possible.
+   *
+   * @param nodes   The list of Nodes from which to select a Node.
+   * @param attempt The attempt number of trying to submit this Executable.
    * @return A pointer to a Node to which to try and send this Executable.
    */
-  [[nodiscard]] std::shared_ptr<internal::Node> getNodeForExecute(
-    const std::vector<std::shared_ptr<internal::Node>>& nodes) const;
+  [[nodiscard]] unsigned int getNodeIndexForExecute(const std::vector<std::shared_ptr<internal::Node>>& nodes,
+                                                    unsigned int attempt) const;
 
   /**
    * The list of account IDs of the nodes with which execution should be attempted.
@@ -299,26 +299,26 @@ private:
    * The maximum number of attempts to be used for an execution. This may be this Executable's mMaxAttempts, the
    * Client's max attempts, or DEFAULT_MAX_ATTEMPTS.
    */
-  uint32_t mCurrentMaxAttempts;
+  uint32_t mCurrentMaxAttempts = 0;
 
   /**
    * The minimum backoff to be used for an execution. This may be this Executable's mMinBackoff, the Client's set
    * minimum backoff, or DEFAULT_MIN_BACKOFF.
    */
-  std::chrono::duration<double> mCurrentMinBackoff;
+  std::chrono::duration<double> mCurrentMinBackoff = DEFAULT_MIN_BACKOFF;
 
   /**
    * The maximum backoff to be used for an execution. This may be this Executable's mMaxBackoff, the Client's set
    * maximum backoff, or DEFAULT_MAX_BACKOFF.
    */
-  std::chrono::duration<double> mCurrentMaxBackoff;
+  std::chrono::duration<double> mCurrentMaxBackoff = DEFAULT_MAX_BACKOFF;
 
   /**
    * The current backoff time being used during the current execution. Every failed submission attempt waits a certain
    * amount of time that is double the previous amount of time this Executable waited for its previous submission
    * attempt, up to the specified maximum backoff time, at which point the execution is considered a failure.
    */
-  std::chrono::duration<double> mCurrentBackoff;
+  std::chrono::duration<double> mCurrentBackoff = DEFAULT_MIN_BACKOFF;
 };
 
 } // namespace Hedera

--- a/sdk/main/include/Executable.h
+++ b/sdk/main/include/Executable.h
@@ -87,7 +87,7 @@ public:
    * @param nodeAccountIds The desired list of account IDs of nodes to submit this request.
    * @return A reference to this Executable derived class with the newly-set node account IDs.
    */
-  virtual SdkRequestType& setNodeAccountIds(const std::vector<AccountId>& nodeAccountIds);
+  virtual SdkRequestType& setNodeAccountIds(std::vector<AccountId> nodeAccountIds);
 
   /**
    * Set the maximum number of times this Executable should try to resubmit itself after a failed attempt before it
@@ -157,6 +157,13 @@ public:
   [[nodiscard]] inline std::optional<std::chrono::duration<double>> getMaxBackoff() const { return mMaxBackoff; }
 
 protected:
+  Executable() = default;
+  ~Executable() = default;
+  Executable(const Executable&) = default;
+  Executable& operator=(const Executable&) = default;
+  Executable(Executable&&) noexcept = default;
+  Executable& operator=(Executable&&) noexcept = default;
+
   /**
    * Enumeration describing the status of a submitted Executable.
    */

--- a/sdk/main/include/FileContentsQuery.h
+++ b/sdk/main/include/FileContentsQuery.h
@@ -57,46 +57,43 @@ public:
 
 private:
   /**
-   * Derived from Executable. Construct a Query protobuf object from this FileContentsQuery object.
-   *
-   * @param client The Client trying to construct this FileContentsQuery.
-   * @param node   The Node to which this FileContentsQuery will be sent.
-   * @return A Query protobuf object filled with this FileContentsQuery object's data.
-   */
-  [[nodiscard]] proto::Query makeRequest(const Client& client,
-                                         const std::shared_ptr<internal::Node>& node) const override;
-
-  /**
    * Derived from Executable. Construct a FileContents object from a Response protobuf object.
    *
    * @param response The Response protobuf object from which to construct a FileContents object.
-   * @return A FileContents object filled with the Response protobuf object's data.
+   * @return A FileContents object filled with the Response protobuf object's data
    */
   [[nodiscard]] FileContents mapResponse(const proto::Response& response) const override;
 
   /**
-   * Derived from Executable. Get the status response code for a submitted FileContentsQuery from a Response
-   * protobuf object.
+   * Derived from Executable. Submit a Query protobuf object which contains this FileContentsQuery's data to a Node.
    *
-   * @param response The Response protobuf object from which to grab the FileContentsQuery status response code.
-   * @return The FileContentsQuery status response code of the input Response protobuf object.
-   */
-  [[nodiscard]] Status mapResponseStatus(const proto::Response& response) const override;
-
-  /**
-   * Derived from Executable. Submit this FileContentsQuery to a Node.
-   *
-   * @param client   The Client submitting this FileContentsQuery.
-   * @param deadline The deadline for submitting this FileContentsQuery.
-   * @param node     Pointer to the Node to which this FileContentsQuery should be submitted.
-   * @param response Pointer to the Response protobuf object that gRPC should populate with the response information
+   * @param request  The Query protobuf object to submit.
+   * @param node     The Node to which to submit the request.
+   * @param deadline The deadline for submitting the request.
+   * @param response Pointer to the ProtoResponseType object that gRPC should populate with the response information
    *                 from the gRPC server.
    * @return The gRPC status of the submission.
    */
-  [[nodiscard]] grpc::Status submitRequest(const Client& client,
-                                           const std::chrono::system_clock::time_point& deadline,
+  [[nodiscard]] grpc::Status submitRequest(const proto::Query& request,
                                            const std::shared_ptr<internal::Node>& node,
+                                           const std::chrono::system_clock::time_point& deadline,
                                            proto::Response* response) const override;
+  /**
+   * Derived from Query. Build a Query protobuf object with this FileContentsQuery's data, with the input QueryHeader
+   * protobuf object.
+   *
+   * @param header A pointer to the QueryHeader protobuf object to add to the Query protobuf object.
+   * @return The constructed Query protobuf object.
+   */
+  [[nodiscard]] proto::Query buildRequest(proto::QueryHeader* header) const override;
+
+  /**
+   * Derived from Query. Get the ResponseHeader protobuf object from the input Response protobuf object.
+   *
+   * @param response The Response protobuf object from which to get the ResponseHeader protobuf object.
+   * @return The ResponseHeader protobuf object of the input Response protobuf object for this derived Query.
+   */
+  [[nodiscard]] proto::ResponseHeader mapResponseHeader(const proto::Response& response) const override;
 
   /**
    * The ID of the file of which this query should get the contents.

--- a/sdk/main/include/FileCreateTransaction.h
+++ b/sdk/main/include/FileCreateTransaction.h
@@ -66,6 +66,14 @@ public:
   explicit FileCreateTransaction(const proto::TransactionBody& transactionBody);
 
   /**
+   * Construct from a map of TransactionIds to node account IDs and their respective Transaction protobuf objects.
+   *
+   * @param transactions The map of TransactionIds to node account IDs and their respective Transaction protobuf
+   *                     objects.
+   */
+  explicit FileCreateTransaction(const std::map<TransactionId, std::map<AccountId, proto::Transaction>>& transactions);
+
+  /**
    * Set the time at which the new file will expire. When the file expires, it will be deleted. To prevent the file from
    * being deleted, use a FileUpdateTransaction to update with the new expiration time.
    *
@@ -139,30 +147,19 @@ private:
   friend class WrappedTransaction;
 
   /**
-   * Derived from Executable. Construct a Transaction protobuf object from this FileCreateTransaction object.
+   * Derived from Executable. Submit a Transaction protobuf object which contains this FileCreateTransaction's data to a
+   * Node.
    *
-   * @param client The Client trying to construct this FileCreateTransaction.
-   * @param node   The Node to which this FileCreateTransaction will be sent. This is unused.
-   * @return A Transaction protobuf object filled with this FileCreateTransaction object's data.
-   * @throws UninitializedException If the input client has no operator with which to sign this
-   *                                FileCreateTransaction.
-   */
-  [[nodiscard]] proto::Transaction makeRequest(const Client& client,
-                                               const std::shared_ptr<internal::Node>& /*node*/) const override;
-
-  /**
-   * Derived from Executable. Submit this FileCreateTransaction to a Node.
-   *
-   * @param client   The Client submitting this FileCreateTransaction.
-   * @param deadline The deadline for submitting this FileCreateTransaction.
-   * @param node     Pointer to the Node to which this FileCreateTransaction should be submitted.
-   * @param response Pointer to the TransactionResponse protobuf object that gRPC should populate with the response
-   *                 information from the gRPC server.
+   * @param request  The Transaction protobuf object to submit.
+   * @param node     The Node to which to submit the request.
+   * @param deadline The deadline for submitting the request.
+   * @param response Pointer to the ProtoResponseType object that gRPC should populate with the response information
+   *                 from the gRPC server.
    * @return The gRPC status of the submission.
    */
-  [[nodiscard]] grpc::Status submitRequest(const Client& client,
-                                           const std::chrono::system_clock::time_point& deadline,
+  [[nodiscard]] grpc::Status submitRequest(const proto::Transaction& request,
                                            const std::shared_ptr<internal::Node>& node,
+                                           const std::chrono::system_clock::time_point& deadline,
                                            proto::TransactionResponse* response) const override;
   /**
    * Derived from Transaction. Build and add the FileCreateTransaction protobuf representation to the Transaction
@@ -171,6 +168,11 @@ private:
    * @param body The TransactionBody protobuf object being built.
    */
   void addToBody(proto::TransactionBody& body) const override;
+
+  /**
+   * Initialize this FileCreateTransaction from its source TransactionBody protobuf object.
+   */
+  void initFromSourceTransactionBody();
 
   /**
    * Build a FileCreateTransactionBody protobuf object from this FileCreateTransaction object.

--- a/sdk/main/include/FileDeleteTransaction.h
+++ b/sdk/main/include/FileDeleteTransaction.h
@@ -54,6 +54,14 @@ public:
   explicit FileDeleteTransaction(const proto::TransactionBody& transactionBody);
 
   /**
+   * Construct from a map of TransactionIds to node account IDs and their respective Transaction protobuf objects.
+   *
+   * @param transactions The map of TransactionIds to node account IDs and their respective Transaction protobuf
+   *                     objects.
+   */
+  explicit FileDeleteTransaction(const std::map<TransactionId, std::map<AccountId, proto::Transaction>>& transactions);
+
+  /**
    * Set the ID of the file to delete.
    *
    * @param fileId The ID of the file to delete.
@@ -73,30 +81,19 @@ private:
   friend class WrappedTransaction;
 
   /**
-   * Derived from Executable. Construct a Transaction protobuf object from this FileDeleteTransaction object.
+   * Derived from Executable. Submit a Transaction protobuf object which contains this FileDeleteTransaction's data to a
+   * Node.
    *
-   * @param client The Client trying to construct this FileDeleteTransaction.
-   * @param node   The Node to which this FileDeleteTransaction will be sent. This is unused.
-   * @return A Transaction protobuf object filled with this FileCreateTransaction object's data.
-   * @throws UninitializedException If the input client has no operator with which to sign this
-   *                                FileDeleteTransaction.
-   */
-  [[nodiscard]] proto::Transaction makeRequest(const Client& client,
-                                               const std::shared_ptr<internal::Node>& /*node*/) const override;
-
-  /**
-   * Derived from Executable. Submit this FileDeleteTransaction to a Node.
-   *
-   * @param client   The Client submitting this FileDeleteTransaction.
-   * @param deadline The deadline for submitting this FileDeleteTransaction.
-   * @param node     Pointer to the Node to which this FileDeleteTransaction should be submitted.
-   * @param response Pointer to the TransactionResponse protobuf object that gRPC should populate with the response
-   *                 information from the gRPC server.
+   * @param request  The Transaction protobuf object to submit.
+   * @param node     The Node to which to submit the request.
+   * @param deadline The deadline for submitting the request.
+   * @param response Pointer to the ProtoResponseType object that gRPC should populate with the response information
+   *                 from the gRPC server.
    * @return The gRPC status of the submission.
    */
-  [[nodiscard]] grpc::Status submitRequest(const Client& client,
-                                           const std::chrono::system_clock::time_point& deadline,
+  [[nodiscard]] grpc::Status submitRequest(const proto::Transaction& request,
                                            const std::shared_ptr<internal::Node>& node,
+                                           const std::chrono::system_clock::time_point& deadline,
                                            proto::TransactionResponse* response) const override;
   /**
    * Derived from Transaction. Build and add the FileDeleteTransaction protobuf representation to the Transaction
@@ -105,6 +102,11 @@ private:
    * @param body The TransactionBody protobuf object being built.
    */
   void addToBody(proto::TransactionBody& body) const override;
+
+  /**
+   * Initialize this FileDeleteTransaction from its source TransactionBody protobuf object.
+   */
+  void initFromSourceTransactionBody();
 
   /**
    * Build a FileDeleteTransactionBody protobuf object from this FileDeleteTransaction object.

--- a/sdk/main/include/FileInfoQuery.h
+++ b/sdk/main/include/FileInfoQuery.h
@@ -55,46 +55,43 @@ public:
 
 private:
   /**
-   * Derived from Executable. Construct a Query protobuf object from this FileInfoQuery object.
-   *
-   * @param client The Client trying to construct this FileInfoQuery.
-   * @param node   The Node to which this FileInfoQuery will be sent.
-   * @return A Query protobuf object filled with this FileInfoQuery object's data.
-   */
-  [[nodiscard]] proto::Query makeRequest(const Client& client,
-                                         const std::shared_ptr<internal::Node>& node) const override;
-
-  /**
    * Derived from Executable. Construct a FileInfo object from a Response protobuf object.
    *
    * @param response The Response protobuf object from which to construct a FileInfo object.
-   * @return A FileInfo object filled with the Response protobuf object's data.
+   * @return A FileInfo object filled with the Response protobuf object's data
    */
   [[nodiscard]] FileInfo mapResponse(const proto::Response& response) const override;
 
   /**
-   * Derived from Executable. Get the status response code for a submitted FileInfoQuery from a Response protobuf
-   * object.
+   * Derived from Executable. Submit a Query protobuf object which contains this FileInfoQuery's data to a Node.
    *
-   * @param response The Response protobuf object from which to grab the FileInfoQuery status response code.
-   * @return The FileInfoQuery status response code of the input Response protobuf object.
-   */
-  [[nodiscard]] Status mapResponseStatus(const proto::Response& response) const override;
-
-  /**
-   * Derived from Executable. Submit this FileInfoQuery to a Node.
-   *
-   * @param client   The Client submitting this FileInfoQuery.
-   * @param deadline The deadline for submitting this FileInfoQuery.
-   * @param node     Pointer to the Node to which this FileInfoQuery should be submitted.
-   * @param response Pointer to the Response protobuf object that gRPC should populate with the response information
+   * @param request  The Query protobuf object to submit.
+   * @param node     The Node to which to submit the request.
+   * @param deadline The deadline for submitting the request.
+   * @param response Pointer to the ProtoResponseType object that gRPC should populate with the response information
    *                 from the gRPC server.
    * @return The gRPC status of the submission.
    */
-  [[nodiscard]] grpc::Status submitRequest(const Client& client,
-                                           const std::chrono::system_clock::time_point& deadline,
+  [[nodiscard]] grpc::Status submitRequest(const proto::Query& request,
                                            const std::shared_ptr<internal::Node>& node,
+                                           const std::chrono::system_clock::time_point& deadline,
                                            proto::Response* response) const override;
+  /**
+   * Derived from Query. Build a Query protobuf object with this FileInfoQuery's data, with the input QueryHeader
+   * protobuf object.
+   *
+   * @param header A pointer to the QueryHeader protobuf object to add to the Query protobuf object.
+   * @return The constructed Query protobuf object.
+   */
+  [[nodiscard]] proto::Query buildRequest(proto::QueryHeader* header) const override;
+
+  /**
+   * Derived from Query. Get the ResponseHeader protobuf object from the input Response protobuf object.
+   *
+   * @param response The Response protobuf object from which to get the ResponseHeader protobuf object.
+   * @return The ResponseHeader protobuf object of the input Response protobuf object for this derived Query.
+   */
+  [[nodiscard]] proto::ResponseHeader mapResponseHeader(const proto::Response& response) const override;
 
   /**
    * The ID of the file of which this query should get the info.

--- a/sdk/main/include/FileUpdateTransaction.h
+++ b/sdk/main/include/FileUpdateTransaction.h
@@ -64,6 +64,14 @@ public:
   explicit FileUpdateTransaction(const proto::TransactionBody& transactionBody);
 
   /**
+   * Construct from a map of TransactionIds to node account IDs and their respective Transaction protobuf objects.
+   *
+   * @param transactions The map of TransactionIds to node account IDs and their respective Transaction protobuf
+   *                     objects.
+   */
+  explicit FileUpdateTransaction(const std::map<TransactionId, std::map<AccountId, proto::Transaction>>& transactions);
+
+  /**
    * Set the ID of the file to update.
    *
    * @param fileId The ID of the file to update.
@@ -154,30 +162,19 @@ private:
   friend class WrappedTransaction;
 
   /**
-   * Derived from Executable. Construct a Transaction protobuf object from this FileUpdateTransaction object.
+   * Derived from Executable. Submit a Transaction protobuf object which contains this FileUpdateTransaction's data to a
+   * Node.
    *
-   * @param client The Client trying to construct this FileUpdateTransaction.
-   * @param node   The Node to which this FileUpdateTransaction will be sent. This is unused.
-   * @return A Transaction protobuf object filled with this FileUpdateTransaction object's data.
-   * @throws UninitializedException If the input client has no operator with which to sign this
-   *                                FileUpdateTransaction.
-   */
-  [[nodiscard]] proto::Transaction makeRequest(const Client& client,
-                                               const std::shared_ptr<internal::Node>& /*node*/) const override;
-
-  /**
-   * Derived from Executable. Submit this FileUpdateTransaction to a Node.
-   *
-   * @param client   The Client submitting this FileUpdateTransaction.
-   * @param deadline The deadline for submitting this FileUpdateTransaction.
-   * @param node     Pointer to the Node to which this FileUpdateTransaction should be submitted.
-   * @param response Pointer to the TransactionResponse protobuf object that gRPC should populate with the response
-   *                 information from the gRPC server.
+   * @param request  The Transaction protobuf object to submit.
+   * @param node     The Node to which to submit the request.
+   * @param deadline The deadline for submitting the request.
+   * @param response Pointer to the ProtoResponseType object that gRPC should populate with the response information
+   *                 from the gRPC server.
    * @return The gRPC status of the submission.
    */
-  [[nodiscard]] grpc::Status submitRequest(const Client& client,
-                                           const std::chrono::system_clock::time_point& deadline,
+  [[nodiscard]] grpc::Status submitRequest(const proto::Transaction& request,
                                            const std::shared_ptr<internal::Node>& node,
+                                           const std::chrono::system_clock::time_point& deadline,
                                            proto::TransactionResponse* response) const override;
   /**
    * Derived from Transaction. Build and add the FileUpdateTransaction protobuf representation to the Transaction
@@ -186,6 +183,11 @@ private:
    * @param body The TransactionBody protobuf object being built.
    */
   void addToBody(proto::TransactionBody& body) const override;
+
+  /**
+   * Initialize this FileUpdateTransaction from its source TransactionBody protobuf object.
+   */
+  void initFromSourceTransactionBody();
 
   /**
    * Build a FileUpdateTransactionBody protobuf object from this FileUpdateTransaction object.

--- a/sdk/main/include/FreezeTransaction.h
+++ b/sdk/main/include/FreezeTransaction.h
@@ -59,6 +59,14 @@ public:
   explicit FreezeTransaction(const proto::TransactionBody& transactionBody);
 
   /**
+   * Construct from a map of TransactionIds to node account IDs and their respective Transaction protobuf objects.
+   *
+   * @param transactions The map of TransactionIds to node account IDs and their respective Transaction protobuf
+   *                     objects.
+   */
+  explicit FreezeTransaction(const std::map<TransactionId, std::map<AccountId, proto::Transaction>>& transactions);
+
+  /**
    * Set the ID of the file to use for the network software upgrade.
    *
    * @param fileId The ID of the file to use for the network software upgrade.
@@ -128,30 +136,19 @@ private:
   friend class WrappedTransaction;
 
   /**
-   * Derived from Executable. Construct a Transaction protobuf object from this FreezeTransaction object.
+   * Derived from Executable. Submit a Transaction protobuf object which contains this FreezeTransaction's data to a
+   * Node.
    *
-   * @param client The Client trying to construct this FreezeTransaction.
-   * @param node   The Node to which this FreezeTransaction will be sent. This is unused.
-   * @return A Transaction protobuf object filled with this FreezeTransaction object's data.
-   * @throws UninitializedException If the input client has no operator with which to sign this
-   *                                FreezeTransaction.
-   */
-  [[nodiscard]] proto::Transaction makeRequest(const Client& client,
-                                               const std::shared_ptr<internal::Node>& /*node*/) const override;
-
-  /**
-   * Derived from Executable. Submit this FreezeTransaction to a Node.
-   *
-   * @param client   The Client submitting this FreezeTransaction.
-   * @param deadline The deadline for submitting this FreezeTransaction.
-   * @param node     Pointer to the Node to which this FreezeTransaction should be submitted.
-   * @param response Pointer to the TransactionResponse protobuf object that gRPC should populate with the response
-   *                 information from the gRPC server.
+   * @param request  The Transaction protobuf object to submit.
+   * @param node     The Node to which to submit the request.
+   * @param deadline The deadline for submitting the request.
+   * @param response Pointer to the ProtoResponseType object that gRPC should populate with the response information
+   *                 from the gRPC server.
    * @return The gRPC status of the submission.
    */
-  [[nodiscard]] grpc::Status submitRequest(const Client& client,
-                                           const std::chrono::system_clock::time_point& deadline,
+  [[nodiscard]] grpc::Status submitRequest(const proto::Transaction& request,
                                            const std::shared_ptr<internal::Node>& node,
+                                           const std::chrono::system_clock::time_point& deadline,
                                            proto::TransactionResponse* response) const override;
   /**
    * Derived from Transaction. Build and add the FreezeTransaction protobuf representation to the Transaction
@@ -160,6 +157,11 @@ private:
    * @param body The TransactionBody protobuf object being built.
    */
   void addToBody(proto::TransactionBody& body) const override;
+
+  /**
+   * Initialize this FreezeTransaction from its source TransactionBody protobuf object.
+   */
+  void initFromSourceTransactionBody();
 
   /**
    * Build a FreezeTransactionBody protobuf object from this FreezeTransaction object.

--- a/sdk/main/include/LedgerId.h
+++ b/sdk/main/include/LedgerId.h
@@ -103,6 +103,13 @@ public:
   [[nodiscard]] inline bool isPreviewnet() const { return *this == PREVIEWNET; }
 
   /**
+   * Does this LedgerId represent the LedgerId of any Hedera network?
+   *
+   * @return \c TRUE if this LedgerId represents the LedgerId of any Hedera network, otherwise \c FALSE.
+   */
+  [[nodiscard]] inline bool isKnownNetwork() const { return isMainnet() || isTestnet() || isPreviewnet(); }
+
+  /**
    * Get the bytes of this LedgerId.
    *
    * @return The bytes of this LedgerId.

--- a/sdk/main/include/NetworkVersionInfoQuery.h
+++ b/sdk/main/include/NetworkVersionInfoQuery.h
@@ -36,46 +36,44 @@ class NetworkVersionInfoQuery : public Query<NetworkVersionInfoQuery, NetworkVer
 {
 private:
   /**
-   * Derived from Executable. Construct a Query protobuf object from this NetworkVersionInfoQuery object.
-   *
-   * @param client The Client trying to construct this NetworkVersionInfoQuery.
-   * @param node   The Node to which this NetworkVersionInfoQuery will be sent.
-   * @return A Query protobuf object filled with this NetworkVersionInfoQuery object's data.
-   */
-  [[nodiscard]] proto::Query makeRequest(const Client& client,
-                                         const std::shared_ptr<internal::Node>& node) const override;
-
-  /**
    * Derived from Executable. Construct a NetworkVersionInfo object from a Response protobuf object.
    *
    * @param response The Response protobuf object from which to construct a NetworkVersionInfo object.
-   * @return A NetworkVersionInfo object filled with the Response protobuf object's data.
+   * @return A NetworkVersionInfo object filled with the Response protobuf object's data
    */
   [[nodiscard]] NetworkVersionInfo mapResponse(const proto::Response& response) const override;
 
   /**
-   * Derived from Executable. Get the status response code for a submitted NetworkVersionInfoQuery from a Response
-   * protobuf object.
+   * Derived from Executable. Submit a Query protobuf object which contains this NetworkVersionInfoQuery's data to a
+   * Node.
    *
-   * @param response The Response protobuf object from which to grab the NetworkVersionInfoQuery status response code.
-   * @return The NetworkVersionInfoQuery status response code of the input Response protobuf object.
-   */
-  [[nodiscard]] Status mapResponseStatus(const proto::Response& response) const override;
-
-  /**
-   * Derived from Executable. Submit this NetworkVersionInfoQuery to a Node.
-   *
-   * @param client   The Client submitting this NetworkVersionInfoQuery.
-   * @param deadline The deadline for submitting this NetworkVersionInfoQuery.
-   * @param node     Pointer to the Node to which this NetworkVersionInfoQuery should be submitted.
-   * @param response Pointer to the Response protobuf object that gRPC should populate with the response information
+   * @param request  The Query protobuf object to submit.
+   * @param node     The Node to which to submit the request.
+   * @param deadline The deadline for submitting the request.
+   * @param response Pointer to the ProtoResponseType object that gRPC should populate with the response information
    *                 from the gRPC server.
    * @return The gRPC status of the submission.
    */
-  [[nodiscard]] grpc::Status submitRequest(const Client& client,
-                                           const std::chrono::system_clock::time_point& deadline,
+  [[nodiscard]] grpc::Status submitRequest(const proto::Query& request,
                                            const std::shared_ptr<internal::Node>& node,
+                                           const std::chrono::system_clock::time_point& deadline,
                                            proto::Response* response) const override;
+  /**
+   * Derived from Query. Build a Query protobuf object with this NetworkVersionInfoQuery's data, with the input
+   * QueryHeader protobuf object.
+   *
+   * @param header A pointer to the QueryHeader protobuf object to add to the Query protobuf object.
+   * @return The constructed Query protobuf object.
+   */
+  [[nodiscard]] proto::Query buildRequest(proto::QueryHeader* header) const override;
+
+  /**
+   * Derived from Query. Get the ResponseHeader protobuf object from the input Response protobuf object.
+   *
+   * @param response The Response protobuf object from which to get the ResponseHeader protobuf object.
+   * @return The ResponseHeader protobuf object of the input Response protobuf object for this derived Query.
+   */
+  [[nodiscard]] proto::ResponseHeader mapResponseHeader(const proto::Response& response) const override;
 };
 
 } // namespace Hedera

--- a/sdk/main/include/PublicKey.h
+++ b/sdk/main/include/PublicKey.h
@@ -31,6 +31,7 @@
 namespace proto
 {
 class Key;
+class SignaturePair;
 }
 
 namespace Hedera::internal::OpenSSLUtils
@@ -108,6 +109,14 @@ public:
    * @return The raw bytes of this PublicKey.
    */
   [[nodiscard]] virtual std::vector<std::byte> toBytesRaw() const = 0;
+
+  /**
+   * Serialize this PublicKey to a SignaturePair protobuf object with the given signature.
+   *
+   * @param signature The signature created by this PublicKey.
+   */
+  [[nodiscard]] virtual std::unique_ptr<proto::SignaturePair> toSignaturePairProtobuf(
+    const std::vector<std::byte>& signature) const = 0;
 
 protected:
   /**

--- a/sdk/main/include/PublicKey.h
+++ b/sdk/main/include/PublicKey.h
@@ -70,6 +70,17 @@ public:
   [[nodiscard]] static std::unique_ptr<PublicKey> fromStringDer(std::string_view key);
 
   /**
+   * Construct a PublicKey object from a raw byte vector. This will attempt to determine the type of key based on the
+   * input byte vector length.
+   *
+   * @param bytes The vector of raw bytes from which to construct a PublicKey.
+   * @return A pointer to a PublicKey representing the input DER-encoded bytes.
+   * @throws BadKeyException If the public key type (ED25519 or ECDSAsecp256k1) is unable to be determined or realized
+   *                         from the input byte array.
+   */
+  [[nodiscard]] static std::unique_ptr<PublicKey> fromBytes(const std::vector<std::byte>& bytes);
+
+  /**
    * Construct a PublicKey object from a DER-encoded byte vector.
    *
    * @param bytes The vector of DER-encoded bytes from which to construct a PublicKey.

--- a/sdk/main/include/Query.h
+++ b/sdk/main/include/Query.h
@@ -157,20 +157,6 @@ private:
   void onExecute(const Client& client) override;
 
   /**
-   * Create a Transaction protobuf object that contains the payment for this Query.
-   *
-   * @param transactionId The TransactionId of the payment transaction.
-   * @param nodeAccountId The AccountId of the node to which the payment transaction is being sent.
-   * @param client        The Client paying for the payment transaction.
-   * @param amount        The amount of Hbar being paid.
-   * @return The created Transaction protobuf object.
-   */
-  [[nodiscard]] proto::Transaction makePaymentTransaction(const TransactionId& transactionId,
-                                                          const AccountId& nodeAccountId,
-                                                          const Client& client,
-                                                          const Hbar& amount) const;
-
-  /**
    * Does this Query require payment? Default to \c TRUE, as most Queries do.
    *
    * @return \c TRUE if this Query requires payment, otherwise \c FALSE.

--- a/sdk/main/include/Query.h
+++ b/sdk/main/include/Query.h
@@ -106,7 +106,14 @@ protected:
    *
    * @param header The ResponseHeader protobuf object from which to get the cost.
    */
-  void saveCostFromHeader(const proto::ResponseHeader& header);
+  void saveCostFromHeader(const proto::ResponseHeader& header) const;
+
+  /**
+   * Is this Query meant a cost query?
+   *
+   * @return \c TRUE if this Query is meant to get the cost, otherwise \c FALSE.
+   */
+  [[nodiscard]] bool isCostQuery() const;
 
 private:
   /**
@@ -162,13 +169,6 @@ private:
                                                           const AccountId& nodeAccountId,
                                                           const Client& client,
                                                           const Hbar& amount) const;
-
-  /**
-   * Set the node account IDs for this Query from the input Client's network.
-   *
-   * @param client The Client whose network should be used to set the node account IDs.
-   */
-  void setNodeAccountIds(const Client& client);
 
   /**
    * Does this Query require payment? Default to \c TRUE, as most Queries do.

--- a/sdk/main/include/Query.h
+++ b/sdk/main/include/Query.h
@@ -22,10 +22,24 @@
 
 #include "Executable.h"
 
+#include <chrono>
+#include <memory>
+
 namespace proto
 {
 class Query;
+class QueryHeader;
 class Response;
+class ResponseHeader;
+class Transaction;
+}
+
+namespace Hedera
+{
+class AccountId;
+class Client;
+class Hbar;
+class TransactionId;
 }
 
 namespace Hedera
@@ -40,24 +54,134 @@ template<typename SdkRequestType, typename SdkResponseType>
 class Query : public Executable<SdkRequestType, proto::Query, proto::Response, SdkResponseType>
 {
 public:
-  ~Query() override = default;
+  /**
+   * Set an amount to pay for this Query. The Client will submit exactly this amount and no remainder will be returned.
+   *
+   * @param amount The amount to pay for this Query.
+   * @return A reference to this derived Query with the newly-set payment.
+   */
+  SdkRequestType& setQueryPayment(const Hbar& amount);
+
+  /**
+   * Set a maximum amount to pay for this Query. A Query without an explicit payment amount set will first query for the
+   * cost of the Query and attach a payment for that amount from the operator account on the client to the node account
+   * ID. Set to 0 to disable automatic implicit payments.
+   *
+   * @param maxAmount The maximum amount to pay for this Query.
+   * @return A reference to this derived Query with the newly-set payment.
+   */
+  SdkRequestType& setMaxQueryPayment(const Hbar& maxAmount);
+
+  /**
+   * Get the expected cost of this Query.
+   *
+   * @param client The Client to use to fetch the cost.
+   * @return The expected cost of this Query.
+   */
+  [[nodiscard]] Hbar getCost(const Client& client);
+
+  /**
+   * Get the expected cost of this Query with a specific timeout.
+   *
+   * @param client  The Client to use to fetch the cost.
+   * @param timeout The timeout to use to get the cost.
+   * @return The expected cost of this Query.
+   */
+  [[nodiscard]] Hbar getCost(const Client& client, const std::chrono::duration<double>& timeout);
 
 protected:
   /**
    * Prevent public copying and moving to prevent slicing. Use the 'clone()' virtual method instead.
    */
-  Query() = default;
-  Query(const Query&) = default;
-  Query& operator=(const Query&) = default;
-  Query(Query&&) noexcept = default;
-  Query& operator=(Query&&) noexcept = default;
+  Query();
+  ~Query();
+  Query(const Query&);
+  Query& operator=(const Query&);
+  Query(Query&&) noexcept;
+  Query& operator=(Query&&) noexcept;
 
   /**
-   * Derived from Executable. Perform any operations needed when this Query is being executed.
+   * Get the cost of the Query from the ResponseHeader protobuf object and set it in this Query, if this Query was
+   * configured to get the cost.
+   *
+   * @param header The ResponseHeader protobuf object from which to get the cost.
    */
-  void onExecute(const Client&) override
-  { // Intentionally unimplemented
-  }
+  void saveCostFromHeader(const proto::ResponseHeader& header);
+
+private:
+  /**
+   * Build a Query protobuf object with this Query's data, with the input QueryHeader protobuf object.
+   *
+   * @param header A pointer to the QueryHeader protobuf object to add to the Query protobuf object.
+   * @return The constructed Query protobuf object.
+   */
+  [[nodiscard]] virtual proto::Query buildRequest(proto::QueryHeader* header) const = 0;
+
+  /**
+   * Get the ResponseHeader protobuf object from the input Response protobuf object.
+   *
+   * @param response The Response protobuf object from which to get the ResponseHeader protobuf object.
+   * @return The ResponseHeader protobuf object of the input Response protobuf object for this derived Query.
+   */
+  [[nodiscard]] virtual proto::ResponseHeader mapResponseHeader(const proto::Response& response) const = 0;
+
+  /**
+   * Derived from Executable. Construct a Query protobuf object from this Query, based on the node account ID at the
+   * given index.
+   *
+   * @param index The index of the node account ID that's associated with the Node being used to execute this Query.
+   * @return A Query protobuf object filled with this Query's data, based on the node account ID at the given index.
+   */
+  [[nodiscard]] proto::Query makeRequest(unsigned int index) const override;
+
+  /**
+   * Derived from Executable. Get the status response code from a Response protobuf object.
+   *
+   * @param response The Response protobuf object from which to grab the status response code.
+   * @return The status response code of the input Response protobuf object.
+   */
+  [[nodiscard]] Status mapResponseStatus(const proto::Response& response) const override;
+
+  /**
+   * Derived from Executable. Perform any needed actions for this Query when it is being submitted.
+   *
+   * @param client The Client being used to submit this Query.
+   */
+  void onExecute(const Client& client) override;
+
+  /**
+   * Create a Transaction protobuf object that contains the payment for this Query.
+   *
+   * @param transactionId The TransactionId of the payment transaction.
+   * @param nodeAccountId The AccountId of the node to which the payment transaction is being sent.
+   * @param client        The Client paying for the payment transaction.
+   * @param amount        The amount of Hbar being paid.
+   * @return The created Transaction protobuf object.
+   */
+  [[nodiscard]] proto::Transaction makePaymentTransaction(const TransactionId& transactionId,
+                                                          const AccountId& nodeAccountId,
+                                                          const Client& client,
+                                                          const Hbar& amount) const;
+
+  /**
+   * Set the node account IDs for this Query from the input Client's network.
+   *
+   * @param client The Client whose network should be used to set the node account IDs.
+   */
+  void setNodeAccountIds(const Client& client);
+
+  /**
+   * Does this Query require payment? Default to \c TRUE, as most Queries do.
+   *
+   * @return \c TRUE if this Query requires payment, otherwise \c FALSE.
+   */
+  [[nodiscard]] inline virtual bool isPaymentRequired() const { return true; }
+
+  /**
+   * Implementation object used to hide implementation details and internal headers.
+   */
+  struct QueryImpl;
+  std::unique_ptr<QueryImpl> mImpl;
 };
 
 } // namespace Hedera

--- a/sdk/main/include/ScheduleCreateTransaction.h
+++ b/sdk/main/include/ScheduleCreateTransaction.h
@@ -70,7 +70,7 @@ class ScheduleCreateTransaction : public Transaction<ScheduleCreateTransaction>
 {
 public:
   ScheduleCreateTransaction();
-  ~ScheduleCreateTransaction() override;
+  ~ScheduleCreateTransaction();
   ScheduleCreateTransaction(const ScheduleCreateTransaction&);
   ScheduleCreateTransaction& operator=(const ScheduleCreateTransaction&);
   ScheduleCreateTransaction(ScheduleCreateTransaction&&) noexcept;
@@ -83,6 +83,15 @@ public:
    * @throws std::invalid_argument If the input TransactionBody does not represent a ScheduleCreate transaction.
    */
   explicit ScheduleCreateTransaction(const proto::TransactionBody& transactionBody);
+
+  /**
+   * Construct from a map of TransactionIds to node account IDs and their respective Transaction protobuf objects.
+   *
+   * @param transactions The map of TransactionIds to node account IDs and their respective Transaction protobuf
+   *                     objects.
+   */
+  explicit ScheduleCreateTransaction(
+    const std::map<TransactionId, std::map<AccountId, proto::Transaction>>& transactions);
 
   /**
    * Set the Transaction to schedule.
@@ -184,30 +193,19 @@ private:
   friend class WrappedTransaction;
 
   /**
-   * Derived from Executable. Construct a Transaction protobuf object from this ScheduleCreateTransaction object.
+   * Derived from Executable. Submit a Transaction protobuf object which contains this ScheduleCreateTransaction's data
+   * to a Node.
    *
-   * @param client The Client trying to construct this ScheduleCreateTransaction.
-   * @param node   The Node to which this ScheduleCreateTransaction will be sent. This is unused.
-   * @return A Transaction protobuf object filled with this ScheduleCreateTransaction object's data.
-   * @throws UninitializedException If the input client has no operator with which to sign this
-   *                                ScheduleCreateTransaction.
-   */
-  [[nodiscard]] proto::Transaction makeRequest(const Client& client,
-                                               const std::shared_ptr<internal::Node>& /*node*/) const override;
-
-  /**
-   * Derived from Executable. Submit this ScheduleCreateTransaction to a Node.
-   *
-   * @param client   The Client submitting this ScheduleCreateTransaction.
-   * @param deadline The deadline for submitting this ScheduleCreateTransaction.
-   * @param node     Pointer to the Node to which this ScheduleCreateTransaction should be submitted.
-   * @param response Pointer to the TransactionResponse protobuf object that gRPC should populate with the response
-   *                 information from the gRPC server.
+   * @param request  The Transaction protobuf object to submit.
+   * @param node     The Node to which to submit the request.
+   * @param deadline The deadline for submitting the request.
+   * @param response Pointer to the ProtoResponseType object that gRPC should populate with the response information
+   *                 from the gRPC server.
    * @return The gRPC status of the submission.
    */
-  [[nodiscard]] grpc::Status submitRequest(const Client& client,
-                                           const std::chrono::system_clock::time_point& deadline,
+  [[nodiscard]] grpc::Status submitRequest(const proto::Transaction& request,
                                            const std::shared_ptr<internal::Node>& node,
+                                           const std::chrono::system_clock::time_point& deadline,
                                            proto::TransactionResponse* response) const override;
   /**
    * Derived from Transaction. Build and add the ScheduleCreateTransaction protobuf representation to the Transaction
@@ -218,17 +216,17 @@ private:
   void addToBody(proto::TransactionBody& body) const override;
 
   /**
+   * Initialize this ScheduleCreateTransaction from its source TransactionBody protobuf object.
+   */
+  void initFromSourceTransactionBody();
+
+  /**
    * Build a ScheduleCreateTransactionBody protobuf object from this ScheduleCreateTransaction object.
    *
    * @return A pointer to a ScheduleCreateTransactionBody protobuf object filled with this ScheduleCreateTransaction
    *         object's data.
    */
   [[nodiscard]] proto::ScheduleCreateTransactionBody* build() const;
-
-  /**
-   * Initialize this ScheduleCreateTransaction's implementation object.
-   */
-  void initImpl();
 
   /**
    * Implementation object used to hide implementation details and internal headers.

--- a/sdk/main/include/ScheduleDeleteTransaction.h
+++ b/sdk/main/include/ScheduleDeleteTransaction.h
@@ -57,6 +57,15 @@ public:
   explicit ScheduleDeleteTransaction(const proto::TransactionBody& transactionBody);
 
   /**
+   * Construct from a map of TransactionIds to node account IDs and their respective Transaction protobuf objects.
+   *
+   * @param transactions The map of TransactionIds to node account IDs and their respective Transaction protobuf
+   *                     objects.
+   */
+  explicit ScheduleDeleteTransaction(
+    const std::map<TransactionId, std::map<AccountId, proto::Transaction>>& transactions);
+
+  /**
    * Set the ID of the schedule to delete.
    *
    * @param scheduleId The ID of the schedule to delete.
@@ -77,30 +86,19 @@ private:
   friend class WrappedTransaction;
 
   /**
-   * Derived from Executable. Construct a Transaction protobuf object from this ScheduleDeleteTransaction object.
+   * Derived from Executable. Submit a Transaction protobuf object which contains this ScheduleDeleteTransaction's data
+   * to a Node.
    *
-   * @param client The Client trying to construct this ScheduleDeleteTransaction.
-   * @param node   The Node to which this ScheduleDeleteTransaction will be sent. This is unused.
-   * @return A Transaction protobuf object filled with this ScheduleDeleteTransaction object's data.
-   * @throws UninitializedException If the input client has no operator with which to sign this
-   *                                ScheduleDeleteTransaction.
-   */
-  [[nodiscard]] proto::Transaction makeRequest(const Client& client,
-                                               const std::shared_ptr<internal::Node>& /*node*/) const override;
-
-  /**
-   * Derived from Executable. Submit this ScheduleDeleteTransaction to a Node.
-   *
-   * @param client   The Client submitting this ScheduleDeleteTransaction.
-   * @param deadline The deadline for submitting this ScheduleDeleteTransaction.
-   * @param node     Pointer to the Node to which this ScheduleDeleteTransaction should be submitted.
-   * @param response Pointer to the TransactionResponse protobuf object that gRPC should populate with the response
-   *                 information from the gRPC server.
+   * @param request  The Transaction protobuf object to submit.
+   * @param node     The Node to which to submit the request.
+   * @param deadline The deadline for submitting the request.
+   * @param response Pointer to the ProtoResponseType object that gRPC should populate with the response information
+   *                 from the gRPC server.
    * @return The gRPC status of the submission.
    */
-  [[nodiscard]] grpc::Status submitRequest(const Client& client,
-                                           const std::chrono::system_clock::time_point& deadline,
+  [[nodiscard]] grpc::Status submitRequest(const proto::Transaction& request,
                                            const std::shared_ptr<internal::Node>& node,
+                                           const std::chrono::system_clock::time_point& deadline,
                                            proto::TransactionResponse* response) const override;
   /**
    * Derived from Transaction. Build and add the ScheduleDeleteTransaction protobuf representation to the Transaction
@@ -109,6 +107,11 @@ private:
    * @param body The TransactionBody protobuf object being built.
    */
   void addToBody(proto::TransactionBody& body) const override;
+
+  /**
+   * Initialize this ScheduleDeleteTransaction from its source TransactionBody protobuf object.
+   */
+  void initFromSourceTransactionBody();
 
   /**
    * Build a ScheduleDeleteTransactionBody protobuf object from this ScheduleDeleteTransaction object.

--- a/sdk/main/include/ScheduleInfoQuery.h
+++ b/sdk/main/include/ScheduleInfoQuery.h
@@ -54,46 +54,43 @@ public:
 
 private:
   /**
-   * Derived from Executable. Construct a Query protobuf object from this ScheduleInfoQuery object.
-   *
-   * @param client The Client trying to construct this ScheduleInfoQuery.
-   * @param node   The Node to which this ScheduleInfoQuery will be sent.
-   * @return A Query protobuf object filled with this ScheduleInfoQuery object's data.
-   */
-  [[nodiscard]] proto::Query makeRequest(const Client& client,
-                                         const std::shared_ptr<internal::Node>& node) const override;
-
-  /**
    * Derived from Executable. Construct a ScheduleInfo object from a Response protobuf object.
    *
    * @param response The Response protobuf object from which to construct a ScheduleInfo object.
-   * @return A ScheduleInfo object filled with the Response protobuf object's data.
+   * @return A ScheduleInfo object filled with the Response protobuf object's data
    */
   [[nodiscard]] ScheduleInfo mapResponse(const proto::Response& response) const override;
 
   /**
-   * Derived from Executable. Get the status response code for a submitted ScheduleInfoQuery from a Response protobuf
-   * object.
+   * Derived from Executable. Submit a Query protobuf object which contains this ScheduleInfoQuery's data to a Node.
    *
-   * @param response The Response protobuf object from which to grab the ScheduleInfoQuery status response code.
-   * @return The ScheduleInfoQuery status response code of the input Response protobuf object.
-   */
-  [[nodiscard]] Status mapResponseStatus(const proto::Response& response) const override;
-
-  /**
-   * Derived from Executable. Submit this ScheduleInfoQuery to a Node.
-   *
-   * @param client   The Client submitting this ScheduleInfoQuery.
-   * @param deadline The deadline for submitting this ScheduleInfoQuery.
-   * @param node     Pointer to the Node to which this ScheduleInfoQuery should be submitted.
-   * @param response Pointer to the Response protobuf object that gRPC should populate with the response information
+   * @param request  The Query protobuf object to submit.
+   * @param node     The Node to which to submit the request.
+   * @param deadline The deadline for submitting the request.
+   * @param response Pointer to the ProtoResponseType object that gRPC should populate with the response information
    *                 from the gRPC server.
    * @return The gRPC status of the submission.
    */
-  [[nodiscard]] grpc::Status submitRequest(const Client& client,
-                                           const std::chrono::system_clock::time_point& deadline,
+  [[nodiscard]] grpc::Status submitRequest(const proto::Query& request,
                                            const std::shared_ptr<internal::Node>& node,
+                                           const std::chrono::system_clock::time_point& deadline,
                                            proto::Response* response) const override;
+  /**
+   * Derived from Query. Build a Query protobuf object with this ScheduleInfoQuery's data, with the input QueryHeader
+   * protobuf object.
+   *
+   * @param header A pointer to the QueryHeader protobuf object to add to the Query protobuf object.
+   * @return The constructed Query protobuf object.
+   */
+  [[nodiscard]] proto::Query buildRequest(proto::QueryHeader* header) const override;
+
+  /**
+   * Derived from Query. Get the ResponseHeader protobuf object from the input Response protobuf object.
+   *
+   * @param response The Response protobuf object from which to get the ResponseHeader protobuf object.
+   * @return The ResponseHeader protobuf object of the input Response protobuf object for this derived Query.
+   */
+  [[nodiscard]] proto::ResponseHeader mapResponseHeader(const proto::Response& response) const override;
 
   /**
    * The ID of the schedule of which this query should get the info.

--- a/sdk/main/include/ScheduleSignTransaction.h
+++ b/sdk/main/include/ScheduleSignTransaction.h
@@ -57,6 +57,15 @@ public:
   explicit ScheduleSignTransaction(const proto::TransactionBody& transactionBody);
 
   /**
+   * Construct from a map of TransactionIds to node account IDs and their respective Transaction protobuf objects.
+   *
+   * @param transactions The map of TransactionIds to node account IDs and their respective Transaction protobuf
+   *                     objects.
+   */
+  explicit ScheduleSignTransaction(
+    const std::map<TransactionId, std::map<AccountId, proto::Transaction>>& transactions);
+
+  /**
    * Set the ID of the schedule to sign.
    *
    * @param scheduleId The ID of the schedule to sign.
@@ -85,30 +94,19 @@ private:
   friend class WrappedTransaction;
 
   /**
-   * Derived from Executable. Construct a Transaction protobuf object from this ScheduleSignTransaction object.
+   * Derived from Executable. Submit a Transaction protobuf object which contains this ScheduleSignTransaction's data to
+   * a Node.
    *
-   * @param client The Client trying to construct this ScheduleSignTransaction.
-   * @param node   The Node to which this ScheduleSignTransaction will be sent. This is unused.
-   * @return A Transaction protobuf object filled with this ScheduleSignTransaction object's data.
-   * @throws UninitializedException If the input client has no operator with which to sign this
-   *                                ScheduleSignTransaction.
-   */
-  [[nodiscard]] proto::Transaction makeRequest(const Client& client,
-                                               const std::shared_ptr<internal::Node>& /*node*/) const override;
-
-  /**
-   * Derived from Executable. Submit this ScheduleSignTransaction to a Node.
-   *
-   * @param client   The Client submitting this ScheduleSignTransaction.
-   * @param deadline The deadline for submitting this ScheduleSignTransaction.
-   * @param node     Pointer to the Node to which this ScheduleSignTransaction should be submitted.
-   * @param response Pointer to the TransactionResponse protobuf object that gRPC should populate with the response
-   *                 information from the gRPC server.
+   * @param request  The Transaction protobuf object to submit.
+   * @param node     The Node to which to submit the request.
+   * @param deadline The deadline for submitting the request.
+   * @param response Pointer to the ProtoResponseType object that gRPC should populate with the response information
+   *                 from the gRPC server.
    * @return The gRPC status of the submission.
    */
-  [[nodiscard]] grpc::Status submitRequest(const Client& client,
-                                           const std::chrono::system_clock::time_point& deadline,
+  [[nodiscard]] grpc::Status submitRequest(const proto::Transaction& request,
                                            const std::shared_ptr<internal::Node>& node,
+                                           const std::chrono::system_clock::time_point& deadline,
                                            proto::TransactionResponse* response) const override;
   /**
    * Derived from Transaction. Build and add the ScheduleSignTransaction protobuf representation to the Transaction
@@ -117,6 +115,11 @@ private:
    * @param body The TransactionBody protobuf object being built.
    */
   void addToBody(proto::TransactionBody& body) const override;
+
+  /**
+   * Initialize this ScheduleSignTransaction from its source TransactionBody protobuf object.
+   */
+  void initFromSourceTransactionBody();
 
   /**
    * Build a ScheduleSignTransactionBody protobuf object from this ScheduleSignTransaction object.

--- a/sdk/main/include/SystemDeleteTransaction.h
+++ b/sdk/main/include/SystemDeleteTransaction.h
@@ -58,6 +58,15 @@ public:
   explicit SystemDeleteTransaction(const proto::TransactionBody& transactionBody);
 
   /**
+   * Construct from a map of TransactionIds to node account IDs and their respective Transaction protobuf objects.
+   *
+   * @param transactions The map of TransactionIds to node account IDs and their respective Transaction protobuf
+   *                     objects.
+   */
+  explicit SystemDeleteTransaction(
+    const std::map<TransactionId, std::map<AccountId, proto::Transaction>>& transactions);
+
+  /**
    * Set the ID of the file to delete. This is mutually exclusive with mContractId, and will reset the value of
    * mContractId if it is set.
    *
@@ -113,30 +122,19 @@ private:
   friend class WrappedTransaction;
 
   /**
-   * Derived from Executable. Construct a Transaction protobuf object from this SystemDeleteTransaction object.
+   * Derived from Executable. Submit a Transaction protobuf object which contains this SystemDeleteTransaction's data to
+   * a Node.
    *
-   * @param client The Client trying to construct this SystemDeleteTransaction.
-   * @param node   The Node to which this SystemDeleteTransaction will be sent. This is unused.
-   * @return A Transaction protobuf object filled with this SystemDeleteTransaction object's data.
-   * @throws UninitializedException If the input client has no operator with which to sign this
-   *                                SystemDeleteTransaction.
-   */
-  [[nodiscard]] proto::Transaction makeRequest(const Client& client,
-                                               const std::shared_ptr<internal::Node>& /*node*/) const override;
-
-  /**
-   * Derived from Executable. Submit this SystemDeleteTransaction to a Node.
-   *
-   * @param client   The Client submitting this SystemDeleteTransaction.
-   * @param deadline The deadline for submitting this SystemDeleteTransaction.
-   * @param node     Pointer to the Node to which this SystemDeleteTransaction should be submitted.
-   * @param response Pointer to the TransactionResponse protobuf object that gRPC should populate with the response
-   *                 information from the gRPC server.
+   * @param request  The Transaction protobuf object to submit.
+   * @param node     The Node to which to submit the request.
+   * @param deadline The deadline for submitting the request.
+   * @param response Pointer to the ProtoResponseType object that gRPC should populate with the response information
+   *                 from the gRPC server.
    * @return The gRPC status of the submission.
    */
-  [[nodiscard]] grpc::Status submitRequest(const Client& client,
-                                           const std::chrono::system_clock::time_point& deadline,
+  [[nodiscard]] grpc::Status submitRequest(const proto::Transaction& request,
                                            const std::shared_ptr<internal::Node>& node,
+                                           const std::chrono::system_clock::time_point& deadline,
                                            proto::TransactionResponse* response) const override;
   /**
    * Derived from Transaction. Build and add the SystemDeleteTransaction protobuf representation to the Transaction
@@ -145,6 +143,11 @@ private:
    * @param body The TransactionBody protobuf object being built.
    */
   void addToBody(proto::TransactionBody& body) const override;
+
+  /**
+   * Initialize this SystemDeleteTransaction from its source TransactionBody protobuf object.
+   */
+  void initFromSourceTransactionBody();
 
   /**
    * Build a SystemDeleteTransactionBody protobuf object from this SystemDeleteTransaction object.

--- a/sdk/main/include/SystemUndeleteTransaction.h
+++ b/sdk/main/include/SystemUndeleteTransaction.h
@@ -54,6 +54,15 @@ public:
   explicit SystemUndeleteTransaction(const proto::TransactionBody& transactionBody);
 
   /**
+   * Construct from a map of TransactionIds to node account IDs and their respective Transaction protobuf objects.
+   *
+   * @param transactions The map of TransactionIds to node account IDs and their respective Transaction protobuf
+   *                     objects.
+   */
+  explicit SystemUndeleteTransaction(
+    const std::map<TransactionId, std::map<AccountId, proto::Transaction>>& transactions);
+
+  /**
    * Set the ID of the file to undelete. This is mutually exclusive with mContractId, and will reset the value of
    * mContractId if it is set.
    *
@@ -93,30 +102,19 @@ private:
   friend class WrappedTransaction;
 
   /**
-   * Derived from Executable. Construct a Transaction protobuf object from this SystemUndeleteTransaction object.
+   * Derived from Executable. Submit a Transaction protobuf object which contains this SystemUndeleteTransaction's data
+   * to a Node.
    *
-   * @param client The Client trying to construct this SystemUndeleteTransaction.
-   * @param node   The Node to which this SystemUndeleteTransaction will be sent. This is unused.
-   * @return A Transaction protobuf object filled with this SystemUndeleteTransaction object's data.
-   * @throws UninitializedException If the input client has no operator with which to sign this
-   *                                SystemUndeleteTransaction.
-   */
-  [[nodiscard]] proto::Transaction makeRequest(const Client& client,
-                                               const std::shared_ptr<internal::Node>& /*node*/) const override;
-
-  /**
-   * Derived from Executable. Submit this SystemUndeleteTransaction to a Node.
-   *
-   * @param client   The Client submitting this SystemUndeleteTransaction.
-   * @param deadline The deadline for submitting this SystemUndeleteTransaction.
-   * @param node     Pointer to the Node to which this SystemUndeleteTransaction should be submitted.
-   * @param response Pointer to the TransactionResponse protobuf object that gRPC should populate with the response
-   *                 information from the gRPC server.
+   * @param request  The Transaction protobuf object to submit.
+   * @param node     The Node to which to submit the request.
+   * @param deadline The deadline for submitting the request.
+   * @param response Pointer to the ProtoResponseType object that gRPC should populate with the response information
+   *                 from the gRPC server.
    * @return The gRPC status of the submission.
    */
-  [[nodiscard]] grpc::Status submitRequest(const Client& client,
-                                           const std::chrono::system_clock::time_point& deadline,
+  [[nodiscard]] grpc::Status submitRequest(const proto::Transaction& request,
                                            const std::shared_ptr<internal::Node>& node,
+                                           const std::chrono::system_clock::time_point& deadline,
                                            proto::TransactionResponse* response) const override;
   /**
    * Derived from Transaction. Build and add the SystemUndeleteTransaction protobuf representation to the Transaction
@@ -125,6 +123,11 @@ private:
    * @param body The TransactionBody protobuf object being built.
    */
   void addToBody(proto::TransactionBody& body) const override;
+
+  /**
+   * Initialize this SystemUndeleteTransaction from its source TransactionBody protobuf object.
+   */
+  void initFromSourceTransactionBody();
 
   /**
    * Build a SystemUndeleteTransactionBody protobuf object from this SystemUndeleteTransaction object.

--- a/sdk/main/include/TokenAssociateTransaction.h
+++ b/sdk/main/include/TokenAssociateTransaction.h
@@ -75,6 +75,15 @@ public:
   explicit TokenAssociateTransaction(const proto::TransactionBody& transactionBody);
 
   /**
+   * Construct from a map of TransactionIds to node account IDs and their respective Transaction protobuf objects.
+   *
+   * @param transactions The map of TransactionIds to node account IDs and their respective Transaction protobuf
+   *                     objects.
+   */
+  explicit TokenAssociateTransaction(
+    const std::map<TransactionId, std::map<AccountId, proto::Transaction>>& transactions);
+
+  /**
    * Set the ID of the account to be associated with the provided tokens.
    *
    * @param accountId The ID of the account to be associated.
@@ -111,30 +120,19 @@ private:
   friend class WrappedTransaction;
 
   /**
-   * Derived from Executable. Construct a Transaction protobuf object from this TokenAssociateTransaction object.
+   * Derived from Executable. Submit a Transaction protobuf object which contains this TokenAssociateTransaction's data
+   * to a Node.
    *
-   * @param client The Client trying to construct this TokenAssociateTransaction.
-   * @param node   The Node to which this TokenAssociateTransaction will be sent. This is unused.
-   * @return A Transaction protobuf object filled with this TokenAssociateTransaction object's data.
-   * @throws UninitializedException If the input client has no operator with which to sign this
-   *                                TokenAssociateTransaction.
-   */
-  [[nodiscard]] proto::Transaction makeRequest(const Client& client,
-                                               const std::shared_ptr<internal::Node>& /*node*/) const override;
-
-  /**
-   * Derived from Executable. Submit this TokenAssociateTransaction to a Node.
-   *
-   * @param client   The Client submitting this TokenAssociateTransaction.
-   * @param deadline The deadline for submitting this TokenAssociateTransaction.
-   * @param node     Pointer to the Node to which this TokenAssociateTransaction should be submitted.
-   * @param response Pointer to the TransactionResponse protobuf object that gRPC should populate with the response
-   *                 information from the gRPC server.
+   * @param request  The Transaction protobuf object to submit.
+   * @param node     The Node to which to submit the request.
+   * @param deadline The deadline for submitting the request.
+   * @param response Pointer to the ProtoResponseType object that gRPC should populate with the response information
+   *                 from the gRPC server.
    * @return The gRPC status of the submission.
    */
-  [[nodiscard]] grpc::Status submitRequest(const Client& client,
-                                           const std::chrono::system_clock::time_point& deadline,
+  [[nodiscard]] grpc::Status submitRequest(const proto::Transaction& request,
                                            const std::shared_ptr<internal::Node>& node,
+                                           const std::chrono::system_clock::time_point& deadline,
                                            proto::TransactionResponse* response) const override;
   /**
    * Derived from Transaction. Build and add the TokenAssociateTransaction protobuf representation to the Transaction
@@ -143,6 +141,11 @@ private:
    * @param body The TransactionBody protobuf object being built.
    */
   void addToBody(proto::TransactionBody& body) const override;
+
+  /**
+   * Initialize this TokenAssociateTransaction from its source TransactionBody protobuf object.
+   */
+  void initFromSourceTransactionBody();
 
   /**
    * Build a TokenAssociateTransactionBody protobuf object from this TokenAssociateTransaction object.

--- a/sdk/main/include/TokenBurnTransaction.h
+++ b/sdk/main/include/TokenBurnTransaction.h
@@ -59,6 +59,14 @@ public:
   explicit TokenBurnTransaction(const proto::TransactionBody& transactionBody);
 
   /**
+   * Construct from a map of TransactionIds to node account IDs and their respective Transaction protobuf objects.
+   *
+   * @param transactions The map of TransactionIds to node account IDs and their respective Transaction protobuf
+   *                     objects.
+   */
+  explicit TokenBurnTransaction(const std::map<TransactionId, std::map<AccountId, proto::Transaction>>& transactions);
+
+  /**
    * Set the ID of the token to burn.
    *
    * @param tokenId The ID of the token to burn.
@@ -110,30 +118,19 @@ private:
   friend class WrappedTransaction;
 
   /**
-   * Derived from Executable. Construct a Transaction protobuf object from this TokenBurnTransaction object.
+   * Derived from Executable. Submit a Transaction protobuf object which contains this TokenBurnTransaction's data to a
+   * Node.
    *
-   * @param client The Client trying to construct this TokenBurnTransaction.
-   * @param node   The Node to which this TokenBurnTransaction will be sent. This is unused.
-   * @return A Transaction protobuf object filled with this TokenBurnTransaction object's data.
-   * @throws UninitializedException If the input client has no operator with which to sign this
-   *                                TokenBurnTransaction.
-   */
-  [[nodiscard]] proto::Transaction makeRequest(const Client& client,
-                                               const std::shared_ptr<internal::Node>& /*node*/) const override;
-
-  /**
-   * Derived from Executable. Submit this TokenBurnTransaction to a Node.
-   *
-   * @param client   The Client submitting this TokenBurnTransaction.
-   * @param deadline The deadline for submitting this TokenBurnTransaction.
-   * @param node     Pointer to the Node to which this TokenBurnTransaction should be submitted.
-   * @param response Pointer to the TransactionResponse protobuf object that gRPC should populate with the response
-   *                 information from the gRPC server.
+   * @param request  The Transaction protobuf object to submit.
+   * @param node     The Node to which to submit the request.
+   * @param deadline The deadline for submitting the request.
+   * @param response Pointer to the ProtoResponseType object that gRPC should populate with the response information
+   *                 from the gRPC server.
    * @return The gRPC status of the submission.
    */
-  [[nodiscard]] grpc::Status submitRequest(const Client& client,
-                                           const std::chrono::system_clock::time_point& deadline,
+  [[nodiscard]] grpc::Status submitRequest(const proto::Transaction& request,
                                            const std::shared_ptr<internal::Node>& node,
+                                           const std::chrono::system_clock::time_point& deadline,
                                            proto::TransactionResponse* response) const override;
   /**
    * Derived from Transaction. Build and add the TokenBurnTransaction protobuf representation to the Transaction
@@ -142,6 +139,11 @@ private:
    * @param body The TransactionBody protobuf object being built.
    */
   void addToBody(proto::TransactionBody& body) const override;
+
+  /**
+   * Initialize this TokenBurnTransaction from its source TransactionBody protobuf object.
+   */
+  void initFromSourceTransactionBody();
 
   /**
    * Build a TokenBurnTransactionBody protobuf object from this TokenBurnTransaction object.

--- a/sdk/main/include/TokenCreateTransaction.h
+++ b/sdk/main/include/TokenCreateTransaction.h
@@ -72,6 +72,14 @@ public:
   explicit TokenCreateTransaction(const proto::TransactionBody& transactionBody);
 
   /**
+   * Construct from a map of TransactionIds to node account IDs and their respective Transaction protobuf objects.
+   *
+   * @param transactions The map of TransactionIds to node account IDs and their respective Transaction protobuf
+   *                     objects.
+   */
+  explicit TokenCreateTransaction(const std::map<TransactionId, std::map<AccountId, proto::Transaction>>& transactions);
+
+  /**
    * Set the desired name for the new token.
    *
    * @param name The desired name for the new token.
@@ -395,30 +403,19 @@ private:
   friend class WrappedTransaction;
 
   /**
-   * Derived from Executable. Construct a Transaction protobuf object from this TokenCreateTransaction object.
+   * Derived from Executable. Submit a Transaction protobuf object which contains this TokenCreateTransaction's data to
+   * a Node.
    *
-   * @param client The Client trying to construct this TokenCreateTransaction.
-   * @param node   The Node to which this TokenCreateTransaction will be sent. This is unused.
-   * @return A Transaction protobuf object filled with this TokenCreateTransaction object's data.
-   * @throws UninitializedException If the input client has no operator with which to sign this
-   *                                TokenCreateTransaction.
-   */
-  [[nodiscard]] proto::Transaction makeRequest(const Client& client,
-                                               const std::shared_ptr<internal::Node>& /*node*/) const override;
-
-  /**
-   * Derived from Executable. Submit this TokenCreateTransaction to a Node.
-   *
-   * @param client   The Client submitting this TokenCreateTransaction.
-   * @param deadline The deadline for submitting this TokenCreateTransaction.
-   * @param node     Pointer to the Node to which this TokenCreateTransaction should be submitted.
-   * @param response Pointer to the TransactionResponse protobuf object that gRPC should populate with the response
-   *                 information from the gRPC server.
+   * @param request  The Transaction protobuf object to submit.
+   * @param node     The Node to which to submit the request.
+   * @param deadline The deadline for submitting the request.
+   * @param response Pointer to the ProtoResponseType object that gRPC should populate with the response information
+   *                 from the gRPC server.
    * @return The gRPC status of the submission.
    */
-  [[nodiscard]] grpc::Status submitRequest(const Client& client,
-                                           const std::chrono::system_clock::time_point& deadline,
+  [[nodiscard]] grpc::Status submitRequest(const proto::Transaction& request,
                                            const std::shared_ptr<internal::Node>& node,
+                                           const std::chrono::system_clock::time_point& deadline,
                                            proto::TransactionResponse* response) const override;
   /**
    * Derived from Transaction. Build and add the TokenCreateTransaction protobuf representation to the Transaction
@@ -427,6 +424,11 @@ private:
    * @param body The TransactionBody protobuf object being built.
    */
   void addToBody(proto::TransactionBody& body) const override;
+
+  /**
+   * Initialize this TokenCreateTransaction from its source TransactionBody protobuf object.
+   */
+  void initFromSourceTransactionBody();
 
   /**
    * Build a TokenCreateTransactionBody protobuf object from this TokenCreateTransaction object.

--- a/sdk/main/include/TokenDeleteTransaction.h
+++ b/sdk/main/include/TokenDeleteTransaction.h
@@ -60,6 +60,14 @@ public:
   explicit TokenDeleteTransaction(const proto::TransactionBody& transactionBody);
 
   /**
+   * Construct from a map of TransactionIds to node account IDs and their respective Transaction protobuf objects.
+   *
+   * @param transactions The map of TransactionIds to node account IDs and their respective Transaction protobuf
+   *                     objects.
+   */
+  explicit TokenDeleteTransaction(const std::map<TransactionId, std::map<AccountId, proto::Transaction>>& transactions);
+
+  /**
    * Set the ID of the token to delete.
    *
    * @param tokenId The ID of the token to delete.
@@ -80,29 +88,19 @@ private:
   friend class WrappedTransaction;
 
   /**
-   * Derived from Executable. Construct a Transaction protobuf object from this TokenDeleteTransaction object.
+   * Derived from Executable. Submit a Transaction protobuf object which contains this TokenDeleteTransaction's data to
+   * a Node.
    *
-   * @param client The Client trying to construct this TokenDeleteTransaction.
-   * @param node   The Node to which this TokenDeleteTransaction will be sent. This is unused.
-   * @return A Transaction protobuf object filled with this TokenDeleteTransaction object's data.
-   * @throws UninitializedException If the input client has no operator with which to sign this TokenDeleteTransaction.
-   */
-  [[nodiscard]] proto::Transaction makeRequest(const Client& client,
-                                               const std::shared_ptr<internal::Node>& /*node*/) const override;
-
-  /**
-   * Derived from Executable. Submit this TokenDeleteTransaction to a Node.
-   *
-   * @param client   The Client submitting this TokenDeleteTransaction.
-   * @param deadline The deadline for submitting this TokenDeleteTransaction.
-   * @param node     Pointer to the Node to which this TokenDeleteTransaction should be submitted.
-   * @param response Pointer to the TransactionResponse protobuf object that gRPC should populate with the response
-   *                 information from the gRPC server.
+   * @param request  The Transaction protobuf object to submit.
+   * @param node     The Node to which to submit the request.
+   * @param deadline The deadline for submitting the request.
+   * @param response Pointer to the ProtoResponseType object that gRPC should populate with the response information
+   *                 from the gRPC server.
    * @return The gRPC status of the submission.
    */
-  [[nodiscard]] grpc::Status submitRequest(const Client& client,
-                                           const std::chrono::system_clock::time_point& deadline,
+  [[nodiscard]] grpc::Status submitRequest(const proto::Transaction& request,
                                            const std::shared_ptr<internal::Node>& node,
+                                           const std::chrono::system_clock::time_point& deadline,
                                            proto::TransactionResponse* response) const override;
   /**
    * Derived from Transaction. Build and add the TokenDeleteTransaction protobuf representation to the Transaction
@@ -111,6 +109,11 @@ private:
    * @param body The TransactionBody protobuf object being built.
    */
   void addToBody(proto::TransactionBody& body) const override;
+
+  /**
+   * Initialize this TokenDeleteTransaction from its source TransactionBody protobuf object.
+   */
+  void initFromSourceTransactionBody();
 
   /**
    * Build a TokenDeleteTransactionBody protobuf object from this TokenDeleteTransaction object.

--- a/sdk/main/include/TokenDissociateTransaction.h
+++ b/sdk/main/include/TokenDissociateTransaction.h
@@ -70,6 +70,15 @@ public:
   explicit TokenDissociateTransaction(const proto::TransactionBody& transactionBody);
 
   /**
+   * Construct from a map of TransactionIds to node account IDs and their respective Transaction protobuf objects.
+   *
+   * @param transactions The map of TransactionIds to node account IDs and their respective Transaction protobuf
+   *                     objects.
+   */
+  explicit TokenDissociateTransaction(
+    const std::map<TransactionId, std::map<AccountId, proto::Transaction>>& transactions);
+
+  /**
    * Set the ID of the account to be dissociated from the provided tokens.
    *
    * @param accountId The ID of the account to be dissociated from the provided tokens.
@@ -106,30 +115,19 @@ private:
   friend class WrappedTransaction;
 
   /**
-   * Derived from Executable. Construct a Transaction protobuf object from this TokenDissociateTransaction object.
+   * Derived from Executable. Submit a Transaction protobuf object which contains this TokenDissociateTransaction's data
+   * to a Node.
    *
-   * @param client The Client trying to construct this TokenDissociateTransaction.
-   * @param node   The Node to which this TokenDissociateTransaction will be sent. This is unused.
-   * @return A Transaction protobuf object filled with this TokenDissociateTransaction object's data.
-   * @throws UninitializedException If the input client has no operator with which to sign this
-   *                                TokenDissociateTransaction.
-   */
-  [[nodiscard]] proto::Transaction makeRequest(const Client& client,
-                                               const std::shared_ptr<internal::Node>& /*node*/) const override;
-
-  /**
-   * Derived from Executable. Submit this TokenDissociateTransaction to a Node.
-   *
-   * @param client   The Client submitting this TokenDissociateTransaction.
-   * @param deadline The deadline for submitting this TokenDissociateTransaction.
-   * @param node     Pointer to the Node to which this TokenDissociateTransaction should be submitted.
-   * @param response Pointer to the TransactionResponse protobuf object that gRPC should populate with the response
-   *                 information from the gRPC server.
+   * @param request  The Transaction protobuf object to submit.
+   * @param node     The Node to which to submit the request.
+   * @param deadline The deadline for submitting the request.
+   * @param response Pointer to the ProtoResponseType object that gRPC should populate with the response information
+   *                 from the gRPC server.
    * @return The gRPC status of the submission.
    */
-  [[nodiscard]] grpc::Status submitRequest(const Client& client,
-                                           const std::chrono::system_clock::time_point& deadline,
+  [[nodiscard]] grpc::Status submitRequest(const proto::Transaction& request,
                                            const std::shared_ptr<internal::Node>& node,
+                                           const std::chrono::system_clock::time_point& deadline,
                                            proto::TransactionResponse* response) const override;
   /**
    * Derived from Transaction. Build and add the TokenDissociateTransaction protobuf representation to the Transaction
@@ -138,6 +136,11 @@ private:
    * @param body The TransactionBody protobuf object being built.
    */
   void addToBody(proto::TransactionBody& body) const override;
+
+  /**
+   * Initialize this TokenDissociateTransaction from its source TransactionBody protobuf object.
+   */
+  void initFromSourceTransactionBody();
 
   /**
    * Build a TokenDissociateTransactionBody protobuf object from this TokenDissociateTransaction object.

--- a/sdk/main/include/TokenFeeScheduleUpdateTransaction.h
+++ b/sdk/main/include/TokenFeeScheduleUpdateTransaction.h
@@ -59,6 +59,15 @@ public:
   explicit TokenFeeScheduleUpdateTransaction(const proto::TransactionBody& transactionBody);
 
   /**
+   * Construct from a map of TransactionIds to node account IDs and their respective Transaction protobuf objects.
+   *
+   * @param transactions The map of TransactionIds to node account IDs and their respective Transaction protobuf
+   *                     objects.
+   */
+  explicit TokenFeeScheduleUpdateTransaction(
+    const std::map<TransactionId, std::map<AccountId, proto::Transaction>>& transactions);
+
+  /**
    * Set the ID of the token whose fee schedule is to be updated.
    *
    * @param tokenId The ID of the token whose fee schedule is to be updated.
@@ -94,31 +103,19 @@ private:
   friend class WrappedTransaction;
 
   /**
-   * Derived from Executable. Construct a Transaction protobuf object from this TokenFeeScheduleUpdateTransaction
-   * object.
+   * Derived from Executable. Submit a Transaction protobuf object which contains this
+   * TokenFeeScheduleUpdateTransaction's data to a Node.
    *
-   * @param client The Client trying to construct this TokenFeeScheduleUpdateTransaction.
-   * @param node   The Node to which this TokenFeeScheduleUpdateTransaction will be sent. This is unused.
-   * @return A Transaction protobuf object filled with this TokenFeeScheduleUpdateTransaction object's data.
-   * @throws UninitializedException If the input client has no operator with which to sign this
-   *                                TokenFeeScheduleUpdateTransaction.
-   */
-  [[nodiscard]] proto::Transaction makeRequest(const Client& client,
-                                               const std::shared_ptr<internal::Node>& /*node*/) const override;
-
-  /**
-   * Derived from Executable. Submit this TokenFeeScheduleUpdateTransaction to a Node.
-   *
-   * @param client   The Client submitting this TokenFeeScheduleUpdateTransaction.
-   * @param deadline The deadline for submitting this TokenFeeScheduleUpdateTransaction.
-   * @param node     Pointer to the Node to which this TokenFeeScheduleUpdateTransaction should be submitted.
-   * @param response Pointer to the TransactionResponse protobuf object that gRPC should populate with the response
-   *                 information from the gRPC server.
+   * @param request  The Transaction protobuf object to submit.
+   * @param node     The Node to which to submit the request.
+   * @param deadline The deadline for submitting the request.
+   * @param response Pointer to the ProtoResponseType object that gRPC should populate with the response information
+   *                 from the gRPC server.
    * @return The gRPC status of the submission.
    */
-  [[nodiscard]] grpc::Status submitRequest(const Client& client,
-                                           const std::chrono::system_clock::time_point& deadline,
+  [[nodiscard]] grpc::Status submitRequest(const proto::Transaction& request,
                                            const std::shared_ptr<internal::Node>& node,
+                                           const std::chrono::system_clock::time_point& deadline,
                                            proto::TransactionResponse* response) const override;
   /**
    * Derived from Transaction. Build and add the TokenFeeScheduleUpdateTransaction protobuf representation to the
@@ -127,6 +124,11 @@ private:
    * @param body The TransactionBody protobuf object being built.
    */
   void addToBody(proto::TransactionBody& body) const override;
+
+  /**
+   * Initialize this TokenFeeScheduleUpdateTransaction from its source TransactionBody protobuf object.
+   */
+  void initFromSourceTransactionBody();
 
   /**
    * Build a TokenFeeScheduleUpdateTransactionBody protobuf object from this TokenFeeScheduleUpdateTransaction object.

--- a/sdk/main/include/TokenFreezeTransaction.h
+++ b/sdk/main/include/TokenFreezeTransaction.h
@@ -64,6 +64,14 @@ public:
   explicit TokenFreezeTransaction(const proto::TransactionBody& transactionBody);
 
   /**
+   * Construct from a map of TransactionIds to node account IDs and their respective Transaction protobuf objects.
+   *
+   * @param transactions The map of TransactionIds to node account IDs and their respective Transaction protobuf
+   *                     objects.
+   */
+  explicit TokenFreezeTransaction(const std::map<TransactionId, std::map<AccountId, proto::Transaction>>& transactions);
+
+  /**
    * Set the ID of the account to be frozen for the specified token.
    *
    * @param accountId The ID of the account to be frozen for the specified token.
@@ -99,29 +107,19 @@ private:
   friend class WrappedTransaction;
 
   /**
-   * Derived from Executable. Construct a Transaction protobuf object from this TokenFreezeTransaction object.
+   * Derived from Executable. Submit a Transaction protobuf object which contains this TokenFreezeTransaction's data to
+   * a Node.
    *
-   * @param client The Client trying to construct this TokenFreezeTransaction.
-   * @param node   The Node to which this TokenFreezeTransaction will be sent. This is unused.
-   * @return A Transaction protobuf object filled with this TokenFreezeTransaction object's data.
-   * @throws UninitializedException If the input client has no operator with which to sign this TokenFreezeTransaction.
-   */
-  [[nodiscard]] proto::Transaction makeRequest(const Client& client,
-                                               const std::shared_ptr<internal::Node>& /*node*/) const override;
-
-  /**
-   * Derived from Executable. Submit this TokenFreezeTransaction to a Node.
-   *
-   * @param client   The Client submitting this TokenFreezeTransaction.
-   * @param deadline The deadline for submitting this TokenFreezeTransaction.
-   * @param node     Pointer to the Node to which this TokenFreezeTransaction should be submitted.
-   * @param response Pointer to the TransactionResponse protobuf object that gRPC should populate with the response
-   *                 information from the gRPC server.
+   * @param request  The Transaction protobuf object to submit.
+   * @param node     The Node to which to submit the request.
+   * @param deadline The deadline for submitting the request.
+   * @param response Pointer to the ProtoResponseType object that gRPC should populate with the response information
+   *                 from the gRPC server.
    * @return The gRPC status of the submission.
    */
-  [[nodiscard]] grpc::Status submitRequest(const Client& client,
-                                           const std::chrono::system_clock::time_point& deadline,
+  [[nodiscard]] grpc::Status submitRequest(const proto::Transaction& request,
                                            const std::shared_ptr<internal::Node>& node,
+                                           const std::chrono::system_clock::time_point& deadline,
                                            proto::TransactionResponse* response) const override;
   /**
    * Derived from Transaction. Build and add the TokenFreezeTransaction protobuf representation to the Transaction
@@ -130,6 +128,11 @@ private:
    * @param body The TransactionBody protobuf object being built.
    */
   void addToBody(proto::TransactionBody& body) const override;
+
+  /**
+   * Initialize this TokenFreezeTransaction from its source TransactionBody protobuf object.
+   */
+  void initFromSourceTransactionBody();
 
   /**
    * Build a TokenFreezeAccountTransactionBody protobuf object from this TokenFreezeTransaction object.

--- a/sdk/main/include/TokenGrantKycTransaction.h
+++ b/sdk/main/include/TokenGrantKycTransaction.h
@@ -66,6 +66,15 @@ public:
   explicit TokenGrantKycTransaction(const proto::TransactionBody& transactionBody);
 
   /**
+   * Construct from a map of TransactionIds to node account IDs and their respective Transaction protobuf objects.
+   *
+   * @param transactions The map of TransactionIds to node account IDs and their respective Transaction protobuf
+   *                     objects.
+   */
+  explicit TokenGrantKycTransaction(
+    const std::map<TransactionId, std::map<AccountId, proto::Transaction>>& transactions);
+
+  /**
    * Set the ID of the account to have passed KYC for this token.
    *
    * @param accountId The ID of the account to have passed KYC for this token.
@@ -101,30 +110,19 @@ private:
   friend class WrappedTransaction;
 
   /**
-   * Derived from Executable. Construct a Transaction protobuf object from this TokenGrantKycTransaction object.
+   * Derived from Executable. Submit a Transaction protobuf object which contains this TokenGrantKycTransaction's data
+   * to a Node.
    *
-   * @param client The Client trying to construct this TokenGrantKycTransaction.
-   * @param node   The Node to which this TokenGrantKycTransaction will be sent. This is unused.
-   * @return A Transaction protobuf object filled with this TokenGrantKycTransaction object's data.
-   * @throws UninitializedException If the input client has no operator with which to sign this
-   *                                TokenGrantKycTransaction.
-   */
-  [[nodiscard]] proto::Transaction makeRequest(const Client& client,
-                                               const std::shared_ptr<internal::Node>& /*node*/) const override;
-
-  /**
-   * Derived from Executable. Submit this TokenGrantKycTransaction to a Node.
-   *
-   * @param client   The Client submitting this TokenGrantKycTransaction.
-   * @param deadline The deadline for submitting this TokenGrantKycTransaction.
-   * @param node     Pointer to the Node to which this TokenGrantKycTransaction should be submitted.
-   * @param response Pointer to the TransactionResponse protobuf object that gRPC should populate with the response
-   *                 information from the gRPC server.
+   * @param request  The Transaction protobuf object to submit.
+   * @param node     The Node to which to submit the request.
+   * @param deadline The deadline for submitting the request.
+   * @param response Pointer to the ProtoResponseType object that gRPC should populate with the response information
+   *                 from the gRPC server.
    * @return The gRPC status of the submission.
    */
-  [[nodiscard]] grpc::Status submitRequest(const Client& client,
-                                           const std::chrono::system_clock::time_point& deadline,
+  [[nodiscard]] grpc::Status submitRequest(const proto::Transaction& request,
                                            const std::shared_ptr<internal::Node>& node,
+                                           const std::chrono::system_clock::time_point& deadline,
                                            proto::TransactionResponse* response) const override;
   /**
    * Derived from Transaction. Build and add the TokenGrantKycTransaction protobuf representation to the Transaction
@@ -133,6 +131,11 @@ private:
    * @param body The TransactionBody protobuf object being built.
    */
   void addToBody(proto::TransactionBody& body) const override;
+
+  /**
+   * Initialize this TokenGrantKycTransaction from its source TransactionBody protobuf object.
+   */
+  void initFromSourceTransactionBody();
 
   /**
    * Build a TokenGrantKycTransactionBody protobuf object from this TokenGrantKycTransaction object.

--- a/sdk/main/include/TokenInfoQuery.h
+++ b/sdk/main/include/TokenInfoQuery.h
@@ -54,46 +54,43 @@ public:
 
 private:
   /**
-   * Derived from Executable. Construct a Query protobuf object from this TokenInfoQuery object.
-   *
-   * @param client The Client trying to construct this TokenInfoQuery.
-   * @param node   The Node to which this TokenInfoQuery will be sent.
-   * @return A Query protobuf object filled with this TokenInfoQuery object's data.
-   */
-  [[nodiscard]] proto::Query makeRequest(const Client& client,
-                                         const std::shared_ptr<internal::Node>& node) const override;
-
-  /**
    * Derived from Executable. Construct a TokenInfo object from a Response protobuf object.
    *
    * @param response The Response protobuf object from which to construct a TokenInfo object.
-   * @return A TokenInfo object filled with the Response protobuf object's data.
+   * @return A TokenInfo object filled with the Response protobuf object's data
    */
   [[nodiscard]] TokenInfo mapResponse(const proto::Response& response) const override;
 
   /**
-   * Derived from Executable. Get the status response code for a submitted TokenInfoQuery from a Response protobuf
-   * object.
+   * Derived from Executable. Submit a Query protobuf object which contains this TokenInfoQuery's data to a Node.
    *
-   * @param response The Response protobuf object from which to grab the TokenInfoQuery status response code.
-   * @return The TokenInfoQuery status response code of the input Response protobuf object.
-   */
-  [[nodiscard]] Status mapResponseStatus(const proto::Response& response) const override;
-
-  /**
-   * Derived from Executable. Submit this TokenInfoQuery to a Node.
-   *
-   * @param client   The Client submitting this TokenInfoQuery.
-   * @param deadline The deadline for submitting this TokenInfoQuery.
-   * @param node     Pointer to the Node to which this TokenInfoQuery should be submitted.
-   * @param response Pointer to the Response protobuf object that gRPC should populate with the response information
+   * @param request  The Query protobuf object to submit.
+   * @param node     The Node to which to submit the request.
+   * @param deadline The deadline for submitting the request.
+   * @param response Pointer to the ProtoResponseType object that gRPC should populate with the response information
    *                 from the gRPC server.
    * @return The gRPC status of the submission.
    */
-  [[nodiscard]] grpc::Status submitRequest(const Client& client,
-                                           const std::chrono::system_clock::time_point& deadline,
+  [[nodiscard]] grpc::Status submitRequest(const proto::Query& request,
                                            const std::shared_ptr<internal::Node>& node,
+                                           const std::chrono::system_clock::time_point& deadline,
                                            proto::Response* response) const override;
+  /**
+   * Derived from Query. Build a Query protobuf object with this TokenInfoQuery's data, with the input QueryHeader
+   * protobuf object.
+   *
+   * @param header A pointer to the QueryHeader protobuf object to add to the Query protobuf object.
+   * @return The constructed Query protobuf object.
+   */
+  [[nodiscard]] proto::Query buildRequest(proto::QueryHeader* header) const override;
+
+  /**
+   * Derived from Query. Get the ResponseHeader protobuf object from the input Response protobuf object.
+   *
+   * @param response The Response protobuf object from which to get the ResponseHeader protobuf object.
+   * @return The ResponseHeader protobuf object of the input Response protobuf object for this derived Query.
+   */
+  [[nodiscard]] proto::ResponseHeader mapResponseHeader(const proto::Response& response) const override;
 
   /**
    * The ID of the token of which this query should get the info.

--- a/sdk/main/include/TokenMintTransaction.h
+++ b/sdk/main/include/TokenMintTransaction.h
@@ -74,6 +74,14 @@ public:
   explicit TokenMintTransaction(const proto::TransactionBody& transactionBody);
 
   /**
+   * Construct from a map of TransactionIds to node account IDs and their respective Transaction protobuf objects.
+   *
+   * @param transactions The map of TransactionIds to node account IDs and their respective Transaction protobuf
+   *                     objects.
+   */
+  explicit TokenMintTransaction(const std::map<TransactionId, std::map<AccountId, proto::Transaction>>& transactions);
+
+  /**
    * Set the ID of the token to mint.
    *
    * @param tokenId The ID of the token to mint.
@@ -130,29 +138,19 @@ private:
   friend class WrappedTransaction;
 
   /**
-   * Derived from Executable. Construct a Transaction protobuf object from this TokenMintTransaction object.
+   * Derived from Executable. Submit a Transaction protobuf object which contains this TokenMintTransaction's data to a
+   * Node.
    *
-   * @param client The Client trying to construct this TokenMintTransaction.
-   * @param node   The Node to which this TokenMintTransaction will be sent. This is unused.
-   * @return A Transaction protobuf object filled with this TokenMintTransaction object's data.
-   * @throws UninitializedException If the input client has no operator with which to sign this TokenMintTransaction.
-   */
-  [[nodiscard]] proto::Transaction makeRequest(const Client& client,
-                                               const std::shared_ptr<internal::Node>& /*node*/) const override;
-
-  /**
-   * Derived from Executable. Submit this TokenMintTransaction to a Node.
-   *
-   * @param client   The Client submitting this TokenMintTransaction.
-   * @param deadline The deadline for submitting this TokenMintTransaction.
-   * @param node     Pointer to the Node to which this TokenMintTransaction should be submitted.
-   * @param response Pointer to the TransactionResponse protobuf object that gRPC should populate with the response
-   *                 information from the gRPC server.
+   * @param request  The Transaction protobuf object to submit.
+   * @param node     The Node to which to submit the request.
+   * @param deadline The deadline for submitting the request.
+   * @param response Pointer to the ProtoResponseType object that gRPC should populate with the response information
+   *                 from the gRPC server.
    * @return The gRPC status of the submission.
    */
-  [[nodiscard]] grpc::Status submitRequest(const Client& client,
-                                           const std::chrono::system_clock::time_point& deadline,
+  [[nodiscard]] grpc::Status submitRequest(const proto::Transaction& request,
                                            const std::shared_ptr<internal::Node>& node,
+                                           const std::chrono::system_clock::time_point& deadline,
                                            proto::TransactionResponse* response) const override;
   /**
    * Derived from Transaction. Build and add the TokenMintTransaction protobuf representation to the Transaction
@@ -161,6 +159,11 @@ private:
    * @param body The TransactionBody protobuf object being built.
    */
   void addToBody(proto::TransactionBody& body) const override;
+
+  /**
+   * Initialize this TokenMintTransaction from its source TransactionBody protobuf object.
+   */
+  void initFromSourceTransactionBody();
 
   /**
    * Build a TokenMintTransactionBody protobuf object from this TokenMintTransaction object.

--- a/sdk/main/include/TokenNftInfoQuery.h
+++ b/sdk/main/include/TokenNftInfoQuery.h
@@ -59,46 +59,43 @@ public:
 
 private:
   /**
-   * Derived from Executable. Construct a Query protobuf object from this TokenNftInfoQuery object.
-   *
-   * @param client The Client trying to construct this TokenNftInfoQuery.
-   * @param node   The Node to which this TokenNftInfoQuery will be sent.
-   * @return A Query protobuf object filled with this TokenNftInfoQuery object's data.
-   */
-  [[nodiscard]] proto::Query makeRequest(const Client& client,
-                                         const std::shared_ptr<internal::Node>& node) const override;
-
-  /**
    * Derived from Executable. Construct a TokenNftInfo object from a Response protobuf object.
    *
    * @param response The Response protobuf object from which to construct a TokenNftInfo object.
-   * @return A TokenNftInfo object filled with the Response protobuf object's data.
+   * @return A TokenNftInfo object filled with the Response protobuf object's data
    */
   [[nodiscard]] TokenNftInfo mapResponse(const proto::Response& response) const override;
 
   /**
-   * Derived from Executable. Get the status response code for a submitted TokenNftInfoQuery from a Response protobuf
-   * object.
+   * Derived from Executable. Submit a Query protobuf object which contains this TokenNftInfoQuery's data to a Node.
    *
-   * @param response The Response protobuf object from which to grab the TokenNftInfoQuery status response code.
-   * @return The TokenNftInfoQuery status response code of the input Response protobuf object.
-   */
-  [[nodiscard]] Status mapResponseStatus(const proto::Response& response) const override;
-
-  /**
-   * Derived from Executable. Submit this TokenNftInfoQuery to a Node.
-   *
-   * @param client   The Client submitting this TokenNftInfoQuery.
-   * @param deadline The deadline for submitting this TokenNftInfoQuery.
-   * @param node     Pointer to the Node to which this TokenNftInfoQuery should be submitted.
-   * @param response Pointer to the Response protobuf object that gRPC should populate with the response information
+   * @param request  The Query protobuf object to submit.
+   * @param node     The Node to which to submit the request.
+   * @param deadline The deadline for submitting the request.
+   * @param response Pointer to the ProtoResponseType object that gRPC should populate with the response information
    *                 from the gRPC server.
    * @return The gRPC status of the submission.
    */
-  [[nodiscard]] grpc::Status submitRequest(const Client& client,
-                                           const std::chrono::system_clock::time_point& deadline,
+  [[nodiscard]] grpc::Status submitRequest(const proto::Query& request,
                                            const std::shared_ptr<internal::Node>& node,
+                                           const std::chrono::system_clock::time_point& deadline,
                                            proto::Response* response) const override;
+  /**
+   * Derived from Query. Build a Query protobuf object with this TokenNftInfoQuery's data, with the input QueryHeader
+   * protobuf object.
+   *
+   * @param header A pointer to the QueryHeader protobuf object to add to the Query protobuf object.
+   * @return The constructed Query protobuf object.
+   */
+  [[nodiscard]] proto::Query buildRequest(proto::QueryHeader* header) const override;
+
+  /**
+   * Derived from Query. Get the ResponseHeader protobuf object from the input Response protobuf object.
+   *
+   * @param response The Response protobuf object from which to get the ResponseHeader protobuf object.
+   * @return The ResponseHeader protobuf object of the input Response protobuf object for this derived Query.
+   */
+  [[nodiscard]] proto::ResponseHeader mapResponseHeader(const proto::Response& response) const override;
 
   /**
    * The ID of the NFT of which this query should get the info.

--- a/sdk/main/include/TokenPauseTransaction.h
+++ b/sdk/main/include/TokenPauseTransaction.h
@@ -71,6 +71,14 @@ public:
   explicit TokenPauseTransaction(const proto::TransactionBody& transactionBody);
 
   /**
+   * Construct from a map of TransactionIds to node account IDs and their respective Transaction protobuf objects.
+   *
+   * @param transactions The map of TransactionIds to node account IDs and their respective Transaction protobuf
+   *                     objects.
+   */
+  explicit TokenPauseTransaction(const std::map<TransactionId, std::map<AccountId, proto::Transaction>>& transactions);
+
+  /**
    * Set the ID of the tokens to pause.
    *
    * @param tokenId The ID of the tokens to pause.
@@ -90,30 +98,19 @@ private:
   friend class WrappedTransaction;
 
   /**
-   * Derived from Executable. Construct a Transaction protobuf object from this TokenPauseTransaction object.
+   * Derived from Executable. Submit a Transaction protobuf object which contains this TokenPauseTransaction's data to a
+   * Node.
    *
-   * @param client The Client trying to construct this TokenPauseTransaction.
-   * @param node   The Node to which this TokenPauseTransaction will be sent. This is unused.
-   * @return A Transaction protobuf object filled with this TokenPauseTransaction object's data.
-   * @throws UninitializedException If the input client has no operator with which to sign this
-   *                                TokenPauseTransaction.
-   */
-  [[nodiscard]] proto::Transaction makeRequest(const Client& client,
-                                               const std::shared_ptr<internal::Node>& /*node*/) const override;
-
-  /**
-   * Derived from Executable. Submit this TokenPauseTransaction to a Node.
-   *
-   * @param client   The Client submitting this TokenPauseTransaction.
-   * @param deadline The deadline for submitting this TokenPauseTransaction.
-   * @param node     Pointer to the Node to which this TokenPauseTransaction should be submitted.
-   * @param response Pointer to the TransactionResponse protobuf object that gRPC should populate with the response
-   *                 information from the gRPC server.
+   * @param request  The Transaction protobuf object to submit.
+   * @param node     The Node to which to submit the request.
+   * @param deadline The deadline for submitting the request.
+   * @param response Pointer to the ProtoResponseType object that gRPC should populate with the response information
+   *                 from the gRPC server.
    * @return The gRPC status of the submission.
    */
-  [[nodiscard]] grpc::Status submitRequest(const Client& client,
-                                           const std::chrono::system_clock::time_point& deadline,
+  [[nodiscard]] grpc::Status submitRequest(const proto::Transaction& request,
                                            const std::shared_ptr<internal::Node>& node,
+                                           const std::chrono::system_clock::time_point& deadline,
                                            proto::TransactionResponse* response) const override;
   /**
    * Derived from Transaction. Build and add the TokenPauseTransaction protobuf representation to the Transaction
@@ -122,6 +119,11 @@ private:
    * @param body The TransactionBody protobuf object being built.
    */
   void addToBody(proto::TransactionBody& body) const override;
+
+  /**
+   * Initialize this TokenPauseTransaction from its source TransactionBody protobuf object.
+   */
+  void initFromSourceTransactionBody();
 
   /**
    * Build a TokenPauseTransactionBody protobuf object from this TokenPauseTransaction object.

--- a/sdk/main/include/TokenRevokeKycTransaction.h
+++ b/sdk/main/include/TokenRevokeKycTransaction.h
@@ -67,6 +67,15 @@ public:
   explicit TokenRevokeKycTransaction(const proto::TransactionBody& transactionBody);
 
   /**
+   * Construct from a map of TransactionIds to node account IDs and their respective Transaction protobuf objects.
+   *
+   * @param transactions The map of TransactionIds to node account IDs and their respective Transaction protobuf
+   *                     objects.
+   */
+  explicit TokenRevokeKycTransaction(
+    const std::map<TransactionId, std::map<AccountId, proto::Transaction>>& transactions);
+
+  /**
    * Set the ID of the account to have its KYC revoked for this token.
    *
    * @param accountId The ID of the account to have its KYC revoked for this token.
@@ -102,30 +111,19 @@ private:
   friend class WrappedTransaction;
 
   /**
-   * Derived from Executable. Construct a Transaction protobuf object from this TokenRevokeKycTransaction object.
+   * Derived from Executable. Submit a Transaction protobuf object which contains this TokenRevokeKycTransaction's data
+   * to a Node.
    *
-   * @param client The Client trying to construct this TokenRevokeKycTransaction.
-   * @param node   The Node to which this TokenRevokeKycTransaction will be sent. This is unused.
-   * @return A Transaction protobuf object filled with this TokenRevokeKycTransaction object's data.
-   * @throws UninitializedException If the input client has no operator with which to sign this
-   *                                TokenRevokeKycTransaction.
-   */
-  [[nodiscard]] proto::Transaction makeRequest(const Client& client,
-                                               const std::shared_ptr<internal::Node>& /*node*/) const override;
-
-  /**
-   * Derived from Executable. Submit this TokenRevokeKycTransaction to a Node.
-   *
-   * @param client   The Client submitting this TokenRevokeKycTransaction.
-   * @param deadline The deadline for submitting this TokenRevokeKycTransaction.
-   * @param node     Pointer to the Node to which this TokenRevokeKycTransaction should be submitted.
-   * @param response Pointer to the TransactionResponse protobuf object that gRPC should populate with the response
-   *                 information from the gRPC server.
+   * @param request  The Transaction protobuf object to submit.
+   * @param node     The Node to which to submit the request.
+   * @param deadline The deadline for submitting the request.
+   * @param response Pointer to the ProtoResponseType object that gRPC should populate with the response information
+   *                 from the gRPC server.
    * @return The gRPC status of the submission.
    */
-  [[nodiscard]] grpc::Status submitRequest(const Client& client,
-                                           const std::chrono::system_clock::time_point& deadline,
+  [[nodiscard]] grpc::Status submitRequest(const proto::Transaction& request,
                                            const std::shared_ptr<internal::Node>& node,
+                                           const std::chrono::system_clock::time_point& deadline,
                                            proto::TransactionResponse* response) const override;
   /**
    * Derived from Transaction. Build and add the TokenRevokeKycTransaction protobuf representation to the Transaction
@@ -134,6 +132,11 @@ private:
    * @param body The TransactionBody protobuf object being built.
    */
   void addToBody(proto::TransactionBody& body) const override;
+
+  /**
+   * Initialize this TokenRevokeKycTransaction from its source TransactionBody protobuf object.
+   */
+  void initFromSourceTransactionBody();
 
   /**
    * Build a TokenRevokeKycTransactionBody protobuf object from this TokenRevokeKycTransaction object.

--- a/sdk/main/include/TokenUnfreezeTransaction.h
+++ b/sdk/main/include/TokenUnfreezeTransaction.h
@@ -64,6 +64,15 @@ public:
   explicit TokenUnfreezeTransaction(const proto::TransactionBody& transactionBody);
 
   /**
+   * Construct from a map of TransactionIds to node account IDs and their respective Transaction protobuf objects.
+   *
+   * @param transactions The map of TransactionIds to node account IDs and their respective Transaction protobuf
+   *                     objects.
+   */
+  explicit TokenUnfreezeTransaction(
+    const std::map<TransactionId, std::map<AccountId, proto::Transaction>>& transactions);
+
+  /**
    * Set the ID of the account to be unfrozen for the specified token.
    *
    * @param accountId The ID of the account to be unfrozen for the specified token.
@@ -99,30 +108,19 @@ private:
   friend class WrappedTransaction;
 
   /**
-   * Derived from Executable. Construct a Transaction protobuf object from this TokenUnfreezeTransaction object.
+   * Derived from Executable. Submit a Transaction protobuf object which contains this TokenUnfreezeTransaction's data
+   * to a Node.
    *
-   * @param client The Client trying to construct this TokenUnfreezeTransaction.
-   * @param node   The Node to which this TokenUnfreezeTransaction will be sent. This is unused.
-   * @return A Transaction protobuf object filled with this TokenUnfreezeTransaction object's data.
-   * @throws UninitializedException If the input client has no operator with which to sign this
-   * TokenUnfreezeTransaction.
-   */
-  [[nodiscard]] proto::Transaction makeRequest(const Client& client,
-                                               const std::shared_ptr<internal::Node>& /*node*/) const override;
-
-  /**
-   * Derived from Executable. Submit this TokenUnfreezeTransaction to a Node.
-   *
-   * @param client   The Client submitting this TokenUnfreezeTransaction.
-   * @param deadline The deadline for submitting this TokenUnfreezeTransaction.
-   * @param node     Pointer to the Node to which this TokenUnfreezeTransaction should be submitted.
-   * @param response Pointer to the TransactionResponse protobuf object that gRPC should populate with the response
-   *                 information from the gRPC server.
+   * @param request  The Transaction protobuf object to submit.
+   * @param node     The Node to which to submit the request.
+   * @param deadline The deadline for submitting the request.
+   * @param response Pointer to the ProtoResponseType object that gRPC should populate with the response information
+   *                 from the gRPC server.
    * @return The gRPC status of the submission.
    */
-  [[nodiscard]] grpc::Status submitRequest(const Client& client,
-                                           const std::chrono::system_clock::time_point& deadline,
+  [[nodiscard]] grpc::Status submitRequest(const proto::Transaction& request,
                                            const std::shared_ptr<internal::Node>& node,
+                                           const std::chrono::system_clock::time_point& deadline,
                                            proto::TransactionResponse* response) const override;
   /**
    * Derived from Transaction. Build and add the TokenUnfreezeTransaction protobuf representation to the Transaction
@@ -131,6 +129,11 @@ private:
    * @param body The TransactionBody protobuf object being built.
    */
   void addToBody(proto::TransactionBody& body) const override;
+
+  /**
+   * Initialize this TokenUnfreezeTransaction from its source TransactionBody protobuf object.
+   */
+  void initFromSourceTransactionBody();
 
   /**
    * Build a TokenUnfreezeAccountTransactionBody protobuf object from this TokenUnfreezeTransaction object.

--- a/sdk/main/include/TokenUnpauseTransaction.h
+++ b/sdk/main/include/TokenUnpauseTransaction.h
@@ -54,6 +54,15 @@ public:
   explicit TokenUnpauseTransaction(const proto::TransactionBody& transactionBody);
 
   /**
+   * Construct from a map of TransactionIds to node account IDs and their respective Transaction protobuf objects.
+   *
+   * @param transactions The map of TransactionIds to node account IDs and their respective Transaction protobuf
+   *                     objects.
+   */
+  explicit TokenUnpauseTransaction(
+    const std::map<TransactionId, std::map<AccountId, proto::Transaction>>& transactions);
+
+  /**
    * Set the ID of the token to unpause.
    *
    * @param tokenId The ID of the token to unpause.
@@ -73,30 +82,19 @@ private:
   friend class WrappedTransaction;
 
   /**
-   * Derived from Executable. Construct a Transaction protobuf object from this TokenUnpauseTransaction object.
+   * Derived from Executable. Submit a Transaction protobuf object which contains this TokenUnpauseTransaction's data to
+   * a Node.
    *
-   * @param client The Client trying to construct this TokenUnpauseTransaction.
-   * @param node   The Node to which this TokenUnpauseTransaction will be sent. This is unused.
-   * @return A Transaction protobuf object filled with this TokenUnpauseTransaction object's data.
-   * @throws UninitializedException If the input client has no operator with which to sign this
-   *                                TokenUnpauseTransaction.
-   */
-  [[nodiscard]] proto::Transaction makeRequest(const Client& client,
-                                               const std::shared_ptr<internal::Node>& /*node*/) const override;
-
-  /**
-   * Derived from Executable. Submit this TokenUnpauseTransaction to a Node.
-   *
-   * @param client   The Client submitting this TokenUnpauseTransaction.
-   * @param deadline The deadline for submitting this TokenUnpauseTransaction.
-   * @param node     Pointer to the Node to which this TokenUnpauseTransaction should be submitted.
-   * @param response Pointer to the TransactionResponse protobuf object that gRPC should populate with the response
-   *                 information from the gRPC server.
+   * @param request  The Transaction protobuf object to submit.
+   * @param node     The Node to which to submit the request.
+   * @param deadline The deadline for submitting the request.
+   * @param response Pointer to the ProtoResponseType object that gRPC should populate with the response information
+   *                 from the gRPC server.
    * @return The gRPC status of the submission.
    */
-  [[nodiscard]] grpc::Status submitRequest(const Client& client,
-                                           const std::chrono::system_clock::time_point& deadline,
+  [[nodiscard]] grpc::Status submitRequest(const proto::Transaction& request,
                                            const std::shared_ptr<internal::Node>& node,
+                                           const std::chrono::system_clock::time_point& deadline,
                                            proto::TransactionResponse* response) const override;
   /**
    * Derived from Transaction. Build and add the TokenUnpauseTransaction protobuf representation to the Transaction
@@ -105,6 +103,11 @@ private:
    * @param body The TransactionBody protobuf object being built.
    */
   void addToBody(proto::TransactionBody& body) const override;
+
+  /**
+   * Initialize this TokenUnpauseTransaction from its source TransactionBody protobuf object.
+   */
+  void initFromSourceTransactionBody();
 
   /**
    * Build a TokenUnpauseTransactionBody protobuf object from this TokenUnpauseTransaction object.

--- a/sdk/main/include/TokenUpdateTransaction.h
+++ b/sdk/main/include/TokenUpdateTransaction.h
@@ -65,6 +65,14 @@ public:
   explicit TokenUpdateTransaction(const proto::TransactionBody& transactionBody);
 
   /**
+   * Construct from a map of TransactionIds to node account IDs and their respective Transaction protobuf objects.
+   *
+   * @param transactions The map of TransactionIds to node account IDs and their respective Transaction protobuf
+   *                     objects.
+   */
+  explicit TokenUpdateTransaction(const std::map<TransactionId, std::map<AccountId, proto::Transaction>>& transactions);
+
+  /**
    * Set the ID of the token to update.
    *
    * @param tokenId The ID of the token to update.
@@ -301,30 +309,19 @@ private:
   friend class WrappedTransaction;
 
   /**
-   * Derived from Executable. Construct a Transaction protobuf object from this TokenUpdateTransaction object.
+   * Derived from Executable. Submit a Transaction protobuf object which contains this TokenUpdateTransaction's data to
+   * a Node.
    *
-   * @param client The Client trying to construct this TokenUpdateTransaction.
-   * @param node   The Node to which this TokenUpdateTransaction will be sent. This is unused.
-   * @return A Transaction protobuf object filled with this TokenUpdateTransaction object's data.
-   * @throws UninitializedException If the input client has no operator with which to sign this
-   *                                TokenUpdateTransaction.
-   */
-  [[nodiscard]] proto::Transaction makeRequest(const Client& client,
-                                               const std::shared_ptr<internal::Node>& /*node*/) const override;
-
-  /**
-   * Derived from Executable. Submit this TokenUpdateTransaction to a Node.
-   *
-   * @param client   The Client submitting this TokenUpdateTransaction.
-   * @param deadline The deadline for submitting this TokenUpdateTransaction.
-   * @param node     Pointer to the Node to which this TokenUpdateTransaction should be submitted.
-   * @param response Pointer to the TransactionResponse protobuf object that gRPC should populate with the response
-   *                 information from the gRPC server.
+   * @param request  The Transaction protobuf object to submit.
+   * @param node     The Node to which to submit the request.
+   * @param deadline The deadline for submitting the request.
+   * @param response Pointer to the ProtoResponseType object that gRPC should populate with the response information
+   *                 from the gRPC server.
    * @return The gRPC status of the submission.
    */
-  [[nodiscard]] grpc::Status submitRequest(const Client& client,
-                                           const std::chrono::system_clock::time_point& deadline,
+  [[nodiscard]] grpc::Status submitRequest(const proto::Transaction& request,
                                            const std::shared_ptr<internal::Node>& node,
+                                           const std::chrono::system_clock::time_point& deadline,
                                            proto::TransactionResponse* response) const override;
   /**
    * Derived from Transaction. Build and add the TokenUpdateTransaction protobuf representation to the Transaction
@@ -333,6 +330,11 @@ private:
    * @param body The TransactionBody protobuf object being built.
    */
   void addToBody(proto::TransactionBody& body) const override;
+
+  /**
+   * Initialize this TokenUpdateTransaction from its source TransactionBody protobuf object.
+   */
+  void initFromSourceTransactionBody();
 
   /**
    * Build a TokenUpdateTransactionBody protobuf object from this TokenUpdateTransaction object.

--- a/sdk/main/include/TokenWipeTransaction.h
+++ b/sdk/main/include/TokenWipeTransaction.h
@@ -75,6 +75,14 @@ public:
   explicit TokenWipeTransaction(const proto::TransactionBody& transactionBody);
 
   /**
+   * Construct from a map of TransactionIds to node account IDs and their respective Transaction protobuf objects.
+   *
+   * @param transactions The map of TransactionIds to node account IDs and their respective Transaction protobuf
+   *                     objects.
+   */
+  explicit TokenWipeTransaction(const std::map<TransactionId, std::map<AccountId, proto::Transaction>>& transactions);
+
+  /**
    * Set the ID of the token to wipe.
    *
    * @param tokenId The ID of the token to wipe.
@@ -143,30 +151,19 @@ private:
   friend class WrappedTransaction;
 
   /**
-   * Derived from Executable. Construct a Transaction protobuf object from this TokenWipeTransaction object.
+   * Derived from Executable. Submit a Transaction protobuf object which contains this TokenWipeTransaction's data to a
+   * Node.
    *
-   * @param client The Client trying to construct this TokenWipeTransaction.
-   * @param node   The Node to which this TokenWipeTransaction will be sent. This is unused.
-   * @return A Transaction protobuf object filled with this TokenWipeTransaction object's data.
-   * @throws UninitializedException If the input client has no operator with which to sign this
-   *                                TokenWipeTransaction.
-   */
-  [[nodiscard]] proto::Transaction makeRequest(const Client& client,
-                                               const std::shared_ptr<internal::Node>& /*node*/) const override;
-
-  /**
-   * Derived from Executable. Submit this TokenWipeTransaction to a Node.
-   *
-   * @param client   The Client submitting this TokenWipeTransaction.
-   * @param deadline The deadline for submitting this TokenWipeTransaction.
-   * @param node     Pointer to the Node to which this TokenWipeTransaction should be submitted.
-   * @param response Pointer to the TransactionResponse protobuf object that gRPC should populate with the response
-   *                 information from the gRPC server.
+   * @param request  The Transaction protobuf object to submit.
+   * @param node     The Node to which to submit the request.
+   * @param deadline The deadline for submitting the request.
+   * @param response Pointer to the ProtoResponseType object that gRPC should populate with the response information
+   *                 from the gRPC server.
    * @return The gRPC status of the submission.
    */
-  [[nodiscard]] grpc::Status submitRequest(const Client& client,
-                                           const std::chrono::system_clock::time_point& deadline,
+  [[nodiscard]] grpc::Status submitRequest(const proto::Transaction& request,
                                            const std::shared_ptr<internal::Node>& node,
+                                           const std::chrono::system_clock::time_point& deadline,
                                            proto::TransactionResponse* response) const override;
   /**
    * Derived from Transaction. Build and add the TokenWipeTransaction protobuf representation to the Transaction
@@ -175,6 +172,11 @@ private:
    * @param body The TransactionBody protobuf object being built.
    */
   void addToBody(proto::TransactionBody& body) const override;
+
+  /**
+   * Initialize this TokenWipeTransaction from its source TransactionBody protobuf object.
+   */
+  void initFromSourceTransactionBody();
 
   /**
    * Build a TokenWipeAccountTransactionBody protobuf object from this TokenWipeTransaction object.

--- a/sdk/main/include/TopicCreateTransaction.h
+++ b/sdk/main/include/TopicCreateTransaction.h
@@ -68,6 +68,14 @@ public:
   explicit TopicCreateTransaction(const proto::TransactionBody& transactionBody);
 
   /**
+   * Construct from a map of TransactionIds to node account IDs and their respective Transaction protobuf objects.
+   *
+   * @param transactions The map of TransactionIds to node account IDs and their respective Transaction protobuf
+   *                     objects.
+   */
+  explicit TopicCreateTransaction(const std::map<TransactionId, std::map<AccountId, proto::Transaction>>& transactions);
+
+  /**
    * Set the desired memo for the new topic.
    *
    * @param memo The desired memo for the new topic.
@@ -152,29 +160,19 @@ private:
   friend class WrappedTransaction;
 
   /**
-   * Derived from Executable. Construct a Transaction protobuf object from this TopicCreateTransaction object.
+   * Derived from Executable. Submit a Transaction protobuf object which contains this TopicCreateTransaction's data to
+   * a Node.
    *
-   * @param client The Client trying to construct this TopicCreateTransaction.
-   * @param node   The Node to which this TopicCreateTransaction will be sent. This is unused.
-   * @return A Transaction protobuf object filled with this TopicCreateTransaction object's data.
-   * @throws UninitializedException If the input client has no operator with which to sign this TopicCreateTransaction.
-   */
-  [[nodiscard]] proto::Transaction makeRequest(const Client& client,
-                                               const std::shared_ptr<internal::Node>& /*node*/) const override;
-
-  /**
-   * Derived from Executable. Submit this TopicCreateTransaction to a Node.
-   *
-   * @param client   The Client submitting this TopicCreateTransaction.
-   * @param deadline The deadline for submitting this TopicCreateTransaction.
-   * @param node     Pointer to the Node to which this TopicCreateTransaction should be submitted.
-   * @param response Pointer to the TransactionResponse protobuf object that gRPC should populate with the response
-   *                 information from the gRPC server.
+   * @param request  The Transaction protobuf object to submit.
+   * @param node     The Node to which to submit the request.
+   * @param deadline The deadline for submitting the request.
+   * @param response Pointer to the ProtoResponseType object that gRPC should populate with the response information
+   *                 from the gRPC server.
    * @return The gRPC status of the submission.
    */
-  [[nodiscard]] grpc::Status submitRequest(const Client& client,
-                                           const std::chrono::system_clock::time_point& deadline,
+  [[nodiscard]] grpc::Status submitRequest(const proto::Transaction& request,
                                            const std::shared_ptr<internal::Node>& node,
+                                           const std::chrono::system_clock::time_point& deadline,
                                            proto::TransactionResponse* response) const override;
   /**
    * Derived from Transaction. Build and add the TopicCreateTransaction protobuf representation to the Transaction
@@ -183,6 +181,11 @@ private:
    * @param body The TransactionBody protobuf object being built.
    */
   void addToBody(proto::TransactionBody& body) const override;
+
+  /**
+   * Initialize this TopicCreateTransaction from its source TransactionBody protobuf object.
+   */
+  void initFromSourceTransactionBody();
 
   /**
    * Build a ConsensusCreateTopicTransactionBody protobuf object from this TopicCreateTransaction object.

--- a/sdk/main/include/TopicDeleteTransaction.h
+++ b/sdk/main/include/TopicDeleteTransaction.h
@@ -58,6 +58,14 @@ public:
   explicit TopicDeleteTransaction(const proto::TransactionBody& transactionBody);
 
   /**
+   * Construct from a map of TransactionIds to node account IDs and their respective Transaction protobuf objects.
+   *
+   * @param transactions The map of TransactionIds to node account IDs and their respective Transaction protobuf
+   *                     objects.
+   */
+  explicit TopicDeleteTransaction(const std::map<TransactionId, std::map<AccountId, proto::Transaction>>& transactions);
+
+  /**
    * Set the ID of the topic to delete.
    *
    * @param topicId The ID of the topic to delete.
@@ -78,30 +86,19 @@ private:
   friend class WrappedTransaction;
 
   /**
-   * Derived from Executable. Construct a Transaction protobuf object from this TopicDeleteTransaction object.
+   * Derived from Executable. Submit a Transaction protobuf object which contains this TopicDeleteTransaction's data to
+   * a Node.
    *
-   * @param client The Client trying to construct this TopicDeleteTransaction.
-   * @param node   The Node to which this TopicDeleteTransaction will be sent. This is unused.
-   * @return A Transaction protobuf object filled with this TopicDeleteTransaction object's data.
-   * @throws UninitializedException If the input client has no operator with which to sign this
-   *                                TopicDeleteTransaction.
-   */
-  [[nodiscard]] proto::Transaction makeRequest(const Client& client,
-                                               const std::shared_ptr<internal::Node>& /*node*/) const override;
-
-  /**
-   * Derived from Executable. Submit this TopicDeleteTransaction to a Node.
-   *
-   * @param client   The Client submitting this TopicDeleteTransaction.
-   * @param deadline The deadline for submitting this TopicDeleteTransaction.
-   * @param node     Pointer to the Node to which this TopicDeleteTransaction should be submitted.
-   * @param response Pointer to the TransactionResponse protobuf object that gRPC should populate with the response
-   *                 information from the gRPC server.
+   * @param request  The Transaction protobuf object to submit.
+   * @param node     The Node to which to submit the request.
+   * @param deadline The deadline for submitting the request.
+   * @param response Pointer to the ProtoResponseType object that gRPC should populate with the response information
+   *                 from the gRPC server.
    * @return The gRPC status of the submission.
    */
-  [[nodiscard]] grpc::Status submitRequest(const Client& client,
-                                           const std::chrono::system_clock::time_point& deadline,
+  [[nodiscard]] grpc::Status submitRequest(const proto::Transaction& request,
                                            const std::shared_ptr<internal::Node>& node,
+                                           const std::chrono::system_clock::time_point& deadline,
                                            proto::TransactionResponse* response) const override;
   /**
    * Derived from Transaction. Build and add the TopicDeleteTransaction protobuf representation to the Transaction
@@ -110,6 +107,11 @@ private:
    * @param body The TransactionBody protobuf object being built.
    */
   void addToBody(proto::TransactionBody& body) const override;
+
+  /**
+   * Initialize this TopicDeleteTransaction from its source TransactionBody protobuf object.
+   */
+  void initFromSourceTransactionBody();
 
   /**
    * Build a ConsensusDeleteTopicTransactionBody protobuf object from this TopicDeleteTransaction object.

--- a/sdk/main/include/TopicInfoQuery.h
+++ b/sdk/main/include/TopicInfoQuery.h
@@ -54,46 +54,43 @@ public:
 
 private:
   /**
-   * Derived from Executable. Construct a Query protobuf object from this TopicInfoQuery object.
-   *
-   * @param client The Client trying to construct this TopicInfoQuery.
-   * @param node   The Node to which this TopicInfoQuery will be sent.
-   * @return A Query protobuf object filled with this TopicInfoQuery object's data.
-   */
-  [[nodiscard]] proto::Query makeRequest(const Client& client,
-                                         const std::shared_ptr<internal::Node>& node) const override;
-
-  /**
    * Derived from Executable. Construct a TopicInfo object from a Response protobuf object.
    *
    * @param response The Response protobuf object from which to construct a TopicInfo object.
-   * @return A TopicInfo object filled with the Response protobuf object's data.
+   * @return A TopicInfo object filled with the Response protobuf object's data
    */
   [[nodiscard]] TopicInfo mapResponse(const proto::Response& response) const override;
 
   /**
-   * Derived from Executable. Get the status response code for a submitted TopicInfoQuery from a Response protobuf
-   * object.
+   * Derived from Executable. Submit a Query protobuf object which contains this TopicInfoQuery's data to a Node.
    *
-   * @param response The Response protobuf object from which to grab the TopicInfoQuery status response code.
-   * @return The TopicInfoQuery status response code of the input Response protobuf object.
-   */
-  [[nodiscard]] Status mapResponseStatus(const proto::Response& response) const override;
-
-  /**
-   * Derived from Executable. Submit this TopicInfoQuery to a Node.
-   *
-   * @param client   The Client submitting this TopicInfoQuery.
-   * @param deadline The deadline for submitting this TopicInfoQuery.
-   * @param node     Pointer to the Node to which this TopicInfoQuery should be submitted.
-   * @param response Pointer to the Response protobuf object that gRPC should populate with the response information
+   * @param request  The Query protobuf object to submit.
+   * @param node     The Node to which to submit the request.
+   * @param deadline The deadline for submitting the request.
+   * @param response Pointer to the ProtoResponseType object that gRPC should populate with the response information
    *                 from the gRPC server.
    * @return The gRPC status of the submission.
    */
-  [[nodiscard]] grpc::Status submitRequest(const Client& client,
-                                           const std::chrono::system_clock::time_point& deadline,
+  [[nodiscard]] grpc::Status submitRequest(const proto::Query& request,
                                            const std::shared_ptr<internal::Node>& node,
+                                           const std::chrono::system_clock::time_point& deadline,
                                            proto::Response* response) const override;
+  /**
+   * Derived from Query. Build a Query protobuf object with this TopicInfoQuery's data, with the input QueryHeader
+   * protobuf object.
+   *
+   * @param header A pointer to the QueryHeader protobuf object to add to the Query protobuf object.
+   * @return The constructed Query protobuf object.
+   */
+  [[nodiscard]] proto::Query buildRequest(proto::QueryHeader* header) const override;
+
+  /**
+   * Derived from Query. Get the ResponseHeader protobuf object from the input Response protobuf object.
+   *
+   * @param response The Response protobuf object from which to get the ResponseHeader protobuf object.
+   * @return The ResponseHeader protobuf object of the input Response protobuf object for this derived Query.
+   */
+  [[nodiscard]] proto::ResponseHeader mapResponseHeader(const proto::Response& response) const override;
 
   /**
    * The ID of the topic of which this query should get the info.

--- a/sdk/main/include/TopicUpdateTransaction.h
+++ b/sdk/main/include/TopicUpdateTransaction.h
@@ -63,6 +63,14 @@ public:
   explicit TopicUpdateTransaction(const proto::TransactionBody& transactionBody);
 
   /**
+   * Construct from a map of TransactionIds to node account IDs and their respective Transaction protobuf objects.
+   *
+   * @param transactions The map of TransactionIds to node account IDs and their respective Transaction protobuf
+   *                     objects.
+   */
+  explicit TopicUpdateTransaction(const std::map<TransactionId, std::map<AccountId, proto::Transaction>>& transactions);
+
+  /**
    * Set the ID of the topic to update.
    *
    * @param topicId The ID of the topic to update.
@@ -213,29 +221,19 @@ private:
   friend class WrappedTransaction;
 
   /**
-   * Derived from Executable. Construct a Transaction protobuf object from this TopicUpdateTransaction object.
+   * Derived from Executable. Submit a Transaction protobuf object which contains this TopicUpdateTransaction's data to
+   * a Node.
    *
-   * @param client The Client trying to construct this TopicUpdateTransaction.
-   * @param node   The Node to which this TopicUpdateTransaction will be sent. This is unused.
-   * @return A Transaction protobuf object filled with this TopicUpdateTransaction object's data.
-   * @throws UninitializedException If the input client has no operator with which to sign this TopicUpdateTransaction.
-   */
-  [[nodiscard]] proto::Transaction makeRequest(const Client& client,
-                                               const std::shared_ptr<internal::Node>& /*node*/) const override;
-
-  /**
-   * Derived from Executable. Submit this TopicUpdateTransaction to a Node.
-   *
-   * @param client   The Client submitting this TopicUpdateTransaction.
-   * @param deadline The deadline for submitting this TopicUpdateTransaction.
-   * @param node     Pointer to the Node to which this TopicUpdateTransaction should be submitted.
-   * @param response Pointer to the TransactionResponse protobuf object that gRPC should populate with the response
-   *                 information from the gRPC server.
+   * @param request  The Transaction protobuf object to submit.
+   * @param node     The Node to which to submit the request.
+   * @param deadline The deadline for submitting the request.
+   * @param response Pointer to the ProtoResponseType object that gRPC should populate with the response information
+   *                 from the gRPC server.
    * @return The gRPC status of the submission.
    */
-  [[nodiscard]] grpc::Status submitRequest(const Client& client,
-                                           const std::chrono::system_clock::time_point& deadline,
+  [[nodiscard]] grpc::Status submitRequest(const proto::Transaction& request,
                                            const std::shared_ptr<internal::Node>& node,
+                                           const std::chrono::system_clock::time_point& deadline,
                                            proto::TransactionResponse* response) const override;
   /**
    * Derived from Transaction. Build and add the TopicUpdateTransaction protobuf representation to the Transaction
@@ -244,6 +242,11 @@ private:
    * @param body The TransactionBody protobuf object being built.
    */
   void addToBody(proto::TransactionBody& body) const override;
+
+  /**
+   * Initialize this TopicUpdateTransaction from its source TransactionBody protobuf object.
+   */
+  void initFromSourceTransactionBody();
 
   /**
    * Build a ConsensusUpdateTopicTransactionBody protobuf object from this TopicUpdateTransaction object.

--- a/sdk/main/include/Transaction.h
+++ b/sdk/main/include/Transaction.h
@@ -64,8 +64,8 @@ class Transaction
 {
 public:
   /**
-   * Construct a Transaction derived class from a byte array. The bytes can be a protobuf encoded TransactionBody,
-   * Transaction, or SignedTransaction. Since C++ return types must be known at compile time and the type of Transaction
+   * Construct a Transaction derived class from a byte array. The bytes can be a protobuf encoded TransactionList,
+   * Transaction, or TransactionBody. Since C++ return types must be known at compile time and the type of Transaction
    * to create may not be known at compile time, a WrappedTransaction is used to encompass all possible Transactions in
    * a std::variant. Usage of this return type would look like the following:
    *
@@ -221,7 +221,7 @@ public:
    * @return A reference to this Executable derived class with the newly-set node account IDs.
    * @throws IllegalStateException If this Transaction is frozen.
    */
-  SdkRequestType& setNodeAccountIds(const std::vector<AccountId>& nodeAccountIds) override;
+  SdkRequestType& setNodeAccountIds(std::vector<AccountId> nodeAccountIds) override;
 
   /**
    * Set the maximum transaction fee willing to be paid to execute this Transaction.
@@ -307,7 +307,7 @@ public:
 
 protected:
   Transaction();
-  virtual ~Transaction();
+  ~Transaction();
   Transaction(const Transaction&);
   Transaction& operator=(const Transaction&);
   Transaction(Transaction&&) noexcept;

--- a/sdk/main/include/Transaction.h
+++ b/sdk/main/include/Transaction.h
@@ -27,6 +27,7 @@
 
 #include <chrono>
 #include <functional>
+#include <map>
 #include <memory>
 #include <string>
 #include <utility>
@@ -44,6 +45,7 @@ class WrappedTransaction;
 namespace proto
 {
 class SchedulableTransactionBody;
+class SignedTransaction;
 class Transaction;
 class TransactionBody;
 class TransactionResponse;
@@ -96,6 +98,13 @@ public:
   [[nodiscard]] static WrappedTransaction fromBytes(const std::vector<std::byte>& bytes);
 
   /**
+   * Construct a representative byte array from this Transaction object.
+   *
+   * @return The byte array representing this Transaction object.
+   */
+  [[nodiscard]] std::vector<std::byte> toBytes() const;
+
+  /**
    * Sign this Transaction with the given PrivateKey. Signing a Transaction with a key that has already been used to
    * sign will be ignored.
    *
@@ -118,12 +127,48 @@ public:
                            const std::function<std::vector<std::byte>(const std::vector<std::byte>&)>& signer);
 
   /**
+   * Sign this Transaction with a configured Client. This will freeze this Transaction if it is not already frozen.
+   *
+   * @param client The Client with which to sign this Transaction.
+   * @return A reference to this derived Transaction object with the client signature.
+   * @throws UninitializedException If the input Client operator has not been initialized.
+   */
+  SdkRequestType& signWithOperator(const Client& client);
+
+  /**
+   * Add a signature to this Transaction.
+   *
+   * @param publicKey The associated PublicKey of the PrivateKey that generated the signature.
+   * @param signature The signature to add.
+   * @return A reference to this derived Transaction object with the newly-added signature.
+   * @throws IllegalStateException If there is not exactly one node account ID set or if this Transaction is not frozen.
+   */
+  virtual SdkRequestType& addSignature(const std::shared_ptr<PublicKey>& publicKey,
+                                       const std::vector<std::byte>& signature);
+
+  /**
+   * Get the signatures of each potential Transaction protobuf object this Transaction may send.
+   *
+   * @return The map of node account IDs to their PublicKeys and signatures.
+   */
+  [[nodiscard]] virtual std::map<AccountId, std::map<std::shared_ptr<PublicKey>, std::vector<std::byte>>>
+  getSignatures() const;
+
+  /**
+   * Freeze this Transaction.
+   *
+   * @return A reference to this derived Transaction object, now frozen.
+   * @throws IllegalStateException If this Transaction's TransactionId and node account IDs have not been manually set.
+   */
+  SdkRequestType& freeze();
+
+  /**
    * Freeze this transaction with a Client. The Client's operator will be used to generate a transaction ID, and the
-   * client's network will be used to generate a list of node account IDs.
+   * Client's network will be used to generate a list of node account IDs.
    *
    * @param client A pointer to the Client with which to freeze this Transaction.
    * @return A reference to this derived Transaction object, now frozen.
-   * @throws UninitializedException If Client operator has not been initialized.
+   * @throws UninitializedException If the input Client operator has not been initialized.
    */
   SdkRequestType& freezeWith(const Client* client);
 
@@ -131,41 +176,79 @@ public:
    * Put this Transaction in a ScheduleCreateTransaction.
    *
    * @return This Transaction put in a ScheduleCreateTransaction.
-   * @throws IllegalStateException If this transaction has node account IDs already set; it is not allowed.
+   * @throws IllegalStateException If this Transaction has node account IDs already set.
    */
   [[nodiscard]] ScheduleCreateTransaction schedule() const;
 
   /**
-   * Set the length of time that this Transaction will remain valid.
+   * Get the SHA384 hash of this Transaction.
    *
-   * @param duration The desired length of time to keep this Transaction valid.
-   * @return A reference to this derived Transaction object with the newly-set valid duration.
+   * @return The SHA384 hash of this Transaction.
+   * @throws IllegalStateException If this Transaction is not frozen.
    */
-  SdkRequestType& setValidTransactionDuration(const std::chrono::duration<double>& duration);
+  [[nodiscard]] virtual std::vector<std::byte> getTransactionHash() const;
 
   /**
-   * Set the maximum transaction fee willing to be paid to execute this Transaction.
+   * Get the SHA384 hash of each potential Transaction protobuf object this Transaction may send.
    *
-   * @param fee The desired maximum transaction fee willing to be paid to execute this Transaction.
-   * @return A reference to this derived Transaction object with the newly-set maximum transaction fee.
+   * @return The map of node account IDs to the SHA384 hash of their Transaction.
+   * @throws IllegalStateException If this Transaction is not frozen.
    */
-  SdkRequestType& setMaxTransactionFee(const Hbar& fee);
+  [[nodiscard]] virtual std::map<AccountId, std::vector<std::byte>> getTransactionHashPerNode() const;
 
   /**
-   * Set the memo for this Transaction.
+   * Require that this Transaction has exactly one node account ID set.
    *
-   * @param memo The desired memo for this Transaction.
-   * @return A reference to this derived Transaction object with the newly-set memo.
+   * @throws IllegalStateException If there is not exactly one node account ID set.
    */
-  SdkRequestType& setTransactionMemo(const std::string& memo);
+  void requireOneNodeAccountId() const;
 
   /**
    * Set the ID for this Transaction.
    *
    * @param id The desired transaction ID for this Transaction.
    * @return A reference to this derived Transaction object with the newly-set transaction ID.
+   * @throws IllegalStateException If this Transaction is frozen.
    */
   SdkRequestType& setTransactionId(const TransactionId& id);
+
+  /**
+   * Derived from Executable. Set the desired account IDs of nodes to which this Transaction will be submitted. This is
+   * not different from Executable::setNodeAccountIds() other than it checks to make sure the Transaction isn't frozen
+   * and throws if it is.
+   *
+   * @param nodeAccountIds The desired list of account IDs of nodes to submit this Transaction.
+   * @return A reference to this Executable derived class with the newly-set node account IDs.
+   * @throws IllegalStateException If this Transaction is frozen.
+   */
+  SdkRequestType& setNodeAccountIds(const std::vector<AccountId>& nodeAccountIds) override;
+
+  /**
+   * Set the maximum transaction fee willing to be paid to execute this Transaction.
+   *
+   * @param fee The desired maximum transaction fee willing to be paid to execute this Transaction.
+   * @return A reference to this derived Transaction object with the newly-set maximum transaction fee.
+   * @throws IllegalStateException If this Transaction is frozen.
+   */
+  SdkRequestType& setMaxTransactionFee(const Hbar& fee);
+
+  /**
+   * Set the length of time that this Transaction will remain valid.
+   *
+   * @param duration The desired length of time to keep this Transaction valid.
+   * @return A reference to this derived Transaction object with the newly-set valid duration.
+   * @throws IllegalStateException If this Transaction is frozen.
+   */
+  SdkRequestType& setValidTransactionDuration(const std::chrono::duration<double>& duration);
+
+  /**
+   * Set the memo for this Transaction.
+   *
+   * @param memo The desired memo for this Transaction.
+   * @return A reference to this derived Transaction object with the newly-set memo.
+   * @throws IllegalStateException If this Transaction is frozen.
+   */
+  SdkRequestType& setTransactionMemo(const std::string& memo);
 
   /**
    * Set the transaction ID regeneration policy for this Transaction.
@@ -173,95 +256,136 @@ public:
    * @param regenerate \c TRUE if it is desired for this Transaction to regenerate a transaction ID upon receiving a
    *                   TRANSACTION_EXPIRED response from the network after submission, otherwise \c FALSE.
    * @return A reference to this derived Transaction object with the newly-set transaction ID regeneration policy.
+   * @throws IllegalStateException If this Transaction is frozen.
    */
   SdkRequestType& setRegenerateTransactionIdPolicy(bool regenerate);
+
+  /**
+   * Get the ID of this Transaction.
+   *
+   * @return The ID of this Transaction.
+   * @throws IllegalStateException If no TransactionId has been generated or set yet.
+   */
+  [[nodiscard]] TransactionId getTransactionId() const;
+
+  /**
+   * Get the maximum transaction fee willing to be paid to execute this Transaction.
+   *
+   * @return The maximum transaction fee willing to be paid. Uninitialized if no maximum transaction fee has been set.
+   */
+  [[nodiscard]] std::optional<Hbar> getMaxTransactionFee() const;
+
+  /**
+   * Get the default maximum transaction fee. This can change between Transactions depending on their cost.
+   *
+   * @return The default maximum transaction fee.
+   */
+  [[nodiscard]] Hbar getDefaultMaxTransactionFee() const;
 
   /**
    * Get the desired length of time for this Transaction to remain valid upon submission.
    *
    * @return The length of time this Transaction will remain valid.
    */
-  [[nodiscard]] inline std::chrono::duration<double> getValidTransactionDuration() const
-  {
-    return mTransactionValidDuration;
-  }
-
-  /**
-   * Get the desired maximum transaction fee willing to be paid to execute this Transaction.
-   *
-   * @return The desired maximum transaction fee willing to be paid.
-   */
-  [[nodiscard]] inline std::optional<Hbar> getMaxTransactionFee() const { return mMaxTransactionFee; }
+  [[nodiscard]] std::chrono::duration<double> getValidTransactionDuration() const;
 
   /**
    * Get the memo for this Transaction.
    *
    * @return The memo for this Transaction.
    */
-  [[nodiscard]] inline std::string getTransactionMemo() const { return mTransactionMemo; }
-
-  /**
-   * Get the desired ID for this Transaction.
-   *
-   * @return The desired ID for this Transaction.
-   * @throws IllegalStateException If no TransactionId has been generated or set yet.
-   */
-  [[nodiscard]] TransactionId getTransactionId() const;
+  [[nodiscard]] std::string getTransactionMemo() const;
 
   /**
    * Get the desired transaction ID regeneration policy of this Transaction.
    *
    * @return \c TRUE if this Transaction should regenerate its transaction ID upon receipt of a TRANSACTION_EXPIRED
-   *         response from the network, otherwise \c FALSE.
+   *         response from the network, \c FALSE if this Transaction shouldn't regenerate its transaction ID, and
+   *         uninitialized if this Transaction will follow the default behavior.
    */
-  [[nodiscard]] inline std::optional<bool> getRegenerateTransactionIdPolicy() const
-  {
-    return mTransactionIdRegenerationPolicy;
-  }
+  [[nodiscard]] std::optional<bool> getRegenerateTransactionIdPolicy() const;
 
 protected:
-  /**
-   * Prevent public copying and moving to prevent slicing. Use the 'clone()' virtual method instead.
-   */
-  Transaction() = default;
-  Transaction(const Transaction&) = default;
-  Transaction& operator=(const Transaction&) = default;
-  Transaction(Transaction&&) noexcept = default;
-  Transaction& operator=(Transaction&&) noexcept = default;
+  Transaction();
+  virtual ~Transaction();
+  Transaction(const Transaction&);
+  Transaction& operator=(const Transaction&);
+  Transaction(Transaction&&) noexcept;
+  Transaction& operator=(Transaction&&) noexcept;
 
   /**
    * Construct from a TransactionBody protobuf object.
    *
-   * @param transactionBody The TransactionBody protobuf object from which to construct.
+   * @param txBody The TransactionBody protobuf object from which to construct.
    */
-  explicit Transaction(const proto::TransactionBody& transactionBody);
+  explicit Transaction(const proto::TransactionBody& txBody);
 
   /**
-   * Derived from Executable. Perform any needed actions for this Transaction when a Node has been selected to which to
-   * submit this Transaction.
+   * Construct from a map of TransactionIds to node account IDs and their respective Transaction protobuf objects.
+   * Assuming the input map isn't empty, this Transaction will set its values based on the values in the first
+   * TransactionId -> [AccountId, proto::Transaction] mapping and ignore the rest.
    *
-   * @param node The Node to which this Executable is being submitted.
+   * @param transactions The map of TransactionIds to node account IDs and their respective Transaction protobuf
+   *                     objects.
    */
-  void onSelectNode(const std::shared_ptr<internal::Node>& node) override;
+  explicit Transaction(const std::map<TransactionId, std::map<AccountId, proto::Transaction>>& transactions);
 
   /**
-   * Sign a TransactionBody protobuf object with a Client and put the signed bytes into a Transaction protobuf object.
+   * Derived from Executable. Construct a Transaction protobuf object from this Transaction, based on the node account
+   * ID at the given index.
    *
-   * @param transaction The TransactionBody to sign.
-   * @param client      The Client being used to sign the transaction.
-   * @return A Transaction protobuf object containing the TransactionBody protobuf object signed by the Client.
-   * @throws UninitializedException If the input client has no operator with which to sign this Transaction.
+   * @param index The index of the node account ID that's associated with the Node being used to execute this
+   *              Transaction.
+   * @return A Transaction protobuf object filled with this Transaction's data, based on the node account ID at the
+   *         given index.
    */
-  [[nodiscard]] proto::Transaction signTransaction(const proto::TransactionBody& transaction,
-                                                   const Client& client) const;
+  [[nodiscard]] proto::Transaction makeRequest(unsigned int index) const override;
 
   /**
-   * Create a TransactionBody protobuf object from this Transaction object's data.
+   * Build all Transaction protobuf objects for this Transaction, each going to a different previously-selected node.
+   */
+  void buildAllTransactions() const;
+
+  /**
+   * Update mSourceTransactionBody. This will update all fields of mSourceTransactionBody except the transaction ID and
+   * the node account ID.
    *
    * @param client A pointer to the Client that will sign and submit this Transaction.
-   * @return The created TransactionBody protobuf object.
    */
-  [[nodiscard]] proto::TransactionBody generateTransactionBody(const Client* client) const;
+  void updateSourceTransactionBody(const Client* client) const;
+
+  /**
+   * Generate the SignedTransaction protobuf objects for this Transaction.
+   *
+   * @param client A pointer to the Client to use to generate the SignedTransaction protobuf objects.
+   */
+  virtual void generateSignedTransactions(const Client* client);
+
+  /**
+   * Add a Transaction or SignedTransaction protobuf object to this Transaction's Transaction or SignedTransaction
+   * protobuf object list, respectively. If a Transaction protobuf object is being added, it will also parse a
+   * SignedTransaction protobuf object from the Transaction protobuf object and add that SignedTransaction protobuf
+   * object to this Transaction's SignedTransaction protobuf object list.
+   *
+   * @param transaction The Transaction or SignedTransaction protobuf object to add to this Transaction.
+   */
+  void addTransaction(const proto::Transaction& transaction);
+  void addTransaction(const proto::SignedTransaction& transaction);
+
+  /**
+   * Add a SignedTransaction protobuf object created from the input TransactionBody protobuf object for each node
+   * account ID of this Transaction. It is expected that every field in the input TransactionBody protobuf object is
+   * valid except the node account ID field, which will be filled by the function.
+   *
+   * @param transaction The TransactionBody protobuf object from which to construct the SignedTransaction protobuf
+   *                    objects.
+   */
+  void addSignedTransactionForEachNode(proto::TransactionBody& transactionBody);
+
+  /**
+   * Clear the SignedTransaction and Transaction protobuf objects held by this Transaction.
+   */
+  virtual void clearTransactions();
 
   /**
    * Check and make sure this Transaction isn't frozen.
@@ -269,6 +393,44 @@ protected:
    * @throws IllegalStateException If this Transaction is frozen.
    */
   void requireNotFrozen() const;
+
+  /**
+   * Is this Transaction frozen?
+   *
+   * @return \c TRUE if this Transaction is frozen, otherwise \c FALSE.
+   */
+  [[nodiscard]] bool isFrozen() const;
+
+  /**
+   * Set the default maximum transaction fee for this Transaction.
+   *
+   * @param fee The default maximum transaction fee for this Transaction.
+   */
+  void setDefaultMaxTransactionFee(const Hbar& fee);
+
+  /**
+   * Get the signatures of the Transaction protobuf object at the specified offset.
+   *
+   * @param offset The offset at which to grab the signatures.
+   * @return The map of node account IDs to their PublicKeys and signatures for the specified offset.
+   */
+  [[nodiscard]] std::map<AccountId, std::map<std::shared_ptr<PublicKey>, std::vector<std::byte>>> getSignaturesInternal(
+    size_t offset = 0ULL) const;
+
+  /**
+   * Get the Transaction protobuf object located at the given index in the Transaction protobuf object list.
+   *
+   * @param index The index at which to get the Transaction protobuf object.
+   * @return The Transaction protobuf object located at the given index.
+   */
+  [[nodiscard]] proto::Transaction getTransactionProtobufObject(unsigned int index) const;
+
+  /**
+   * Get the source TransactionBody protobuf object from which this Transaction constructed itself.
+   *
+   * @return The source TransactionBody protobuf object from which this Transaction constructed itself.
+   */
+  [[nodiscard]] proto::TransactionBody getSourceTransactionBody() const;
 
 private:
   /**
@@ -320,60 +482,26 @@ private:
   void onExecute(const Client& client) override;
 
   /**
-   * Helper function used to get the proper maximum transaction fee to pack into a protobuf TransactionBody. The order
-   * of priority for maximum transaction fees goes:
-   *  1. Manually-set maximum transaction fee for this Transaction.
-   *  2. Client-set default max transaction fee.
-   *  3. Default maximum transaction fee.
+   * Build a Transaction protobuf object from the SignedTransaction protobuf object at the specified index.
    *
-   * @param client A pointer to the Client submitting this Transaction.
-   * @return The proper maximum transaction fee to set for this Transaction.
+   * @param index The index in the Transaction's SignedTransaction list from which the Transaction protobuf object
+   *              should be built.
    */
-  [[nodiscard]] Hbar getMaxTransactionFee(const Client* client) const;
+  void buildTransaction(unsigned int index) const;
 
   /**
-   * Container of PublicKey and signer function pairs to use to sign this Transaction.
+   * Determine if a PublicKey has already signed this Transaction.
+   *
+   * @param publicKey The PublicKey that could have already signed this Transaction.
+   * @return \c TRUE if the input PublicKey has already signed this Transaction, otherwise \c FALSE.
    */
-  std::vector<
-    std::pair<std::shared_ptr<PublicKey>, std::function<std::vector<std::byte>(const std::vector<std::byte>&)>>>
-    mSignatures;
+  [[nodiscard]] bool keyAlreadySigned(const std::shared_ptr<PublicKey>& publicKey) const;
 
   /**
-   * Is this Transaction frozen? \c TRUE if yes, otherwise \c FALSE.
+   * Implementation object used to hide implementation details and internal headers.
    */
-  bool mIsFrozen = false;
-
-  /**
-   * The length of time this Transaction will remain valid.
-   */
-  std::chrono::duration<double> mTransactionValidDuration = std::chrono::minutes(2);
-
-  /**
-   * The account ID of the Node sending this Transaction.
-   */
-  AccountId mNodeAccountId;
-
-  /**
-   * The maximum transaction fee willing to be paid to execute this Transaction.
-   */
-  std::optional<Hbar> mMaxTransactionFee;
-
-  /**
-   * The memo to be associated with this Transaction.
-   */
-  std::string mTransactionMemo;
-
-  /**
-   * The ID of this Transaction.
-   */
-  TransactionId mTransactionId;
-
-  /**
-   * Should this Transaction regenerate its TransactionId upon a TRANSACTION_EXPIRED response from the network? If not
-   * set, this Transaction will use the Client's set transaction ID regeneration policy. If that's not set, the default
-   * behavior is to regenerate the transaction ID.
-   */
-  std::optional<bool> mTransactionIdRegenerationPolicy;
+  struct TransactionImpl;
+  std::unique_ptr<TransactionImpl> mImpl;
 };
 
 } // namespace Hedera

--- a/sdk/main/include/Transaction.h
+++ b/sdk/main/include/Transaction.h
@@ -432,6 +432,13 @@ protected:
    */
   [[nodiscard]] proto::TransactionBody getSourceTransactionBody() const;
 
+  /**
+   * Get the ID of this Transaction.
+   *
+   * @return The ID of this Transaction.
+   */
+  [[nodiscard]] virtual TransactionId getCurrentTransactionId() const;
+
 private:
   /**
    * Build and add the derived Transaction's protobuf representation to the Transaction protobuf object.

--- a/sdk/main/include/TransactionId.h
+++ b/sdk/main/include/TransactionId.h
@@ -154,6 +154,18 @@ struct hash<Hedera::TransactionId>
   size_t operator()(const Hedera::TransactionId& id) const { return hash<string>()(id.toString()); }
 };
 
+template<>
+struct less<Hedera::TransactionId>
+{
+  /**
+   * Operator override to enable use of TransactionId in a std::map, which requires fair ordering.
+   */
+  bool operator()(const Hedera::TransactionId& lhs, const Hedera::TransactionId& rhs) const
+  {
+    return lhs.toString() < rhs.toString();
+  }
+};
+
 } // namespace std
 
 #endif // HEDERA_SDK_CPP_TRANSACTION_ID_H_

--- a/sdk/main/include/TransactionId.h
+++ b/sdk/main/include/TransactionId.h
@@ -85,7 +85,15 @@ public:
    * @param other The other TransactionId with which to compare this TransactionId.
    * @return \c TRUE if this TransactionId is the same as the input TransactionId, otherwise \c FALSE.
    */
-  bool operator==(const TransactionId&) const;
+  bool operator==(const TransactionId& other) const;
+
+  /**
+   * Compare this TransactionId to another TransactionId and determine if they represent different Transactions.
+   *
+   * @param other The other TransactionId with which to compare this TransactionId.
+   * @return \c TRUE if this TransactionId is different from the input TransactionId, otherwise \c FALSE.
+   */
+  bool operator!=(const TransactionId& other) const;
 
   /**
    * Construct a TransactionID protobuf object from this TransactionId object.

--- a/sdk/main/include/TransactionReceiptQuery.h
+++ b/sdk/main/include/TransactionReceiptQuery.h
@@ -149,6 +149,13 @@ private:
   [[nodiscard]] proto::ResponseHeader mapResponseHeader(const proto::Response& response) const override;
 
   /**
+   * Derived from Query. Does this TransactionReceiptQuery require payment?
+   *
+   * @return \c FALSE, TransactionReceiptQuery is free.
+   */
+  [[nodiscard]] inline bool isPaymentRequired() const override { return false; }
+
+  /**
    * The ID of the transaction of which this query should get the receipt.
    */
   std::optional<TransactionId> mTransactionId;

--- a/sdk/main/include/TransactionReceiptQuery.h
+++ b/sdk/main/include/TransactionReceiptQuery.h
@@ -59,16 +59,6 @@ public:
 
 private:
   /**
-   * Derived from Executable. Construct a Query protobuf object from this TransactionReceiptQuery object.
-   *
-   * @param client The Client trying to construct this TransactionReceiptQuery. This is unused.
-   * @param node   The Node to which this TransactionReceiptQuery will be sent. This is unused.
-   * @return A Query protobuf object filled with this TransactionReceiptQuery object's data.
-   */
-  [[nodiscard]] proto::Query makeRequest(const Client& /*client*/,
-                                         const std::shared_ptr<internal::Node>& /*node*/) const override;
-
-  /**
    * Derived from Executable. Construct a TransactionReceipt object from a Response protobuf object.
    *
    * @param response The Response protobuf object from which to construct a TransactionReceipt object.
@@ -77,13 +67,20 @@ private:
   [[nodiscard]] TransactionReceipt mapResponse(const proto::Response& response) const override;
 
   /**
-   * Derived from Executable. Get the status response code for a submitted TransactionReceiptQuery from a Response
-   * protobuf object.
+   * Derived from Executable. Submit a Query protobuf object which contains this TransactionReceiptQuery's data to a
+   * Node.
    *
-   * @param response The Response protobuf object from which to grab the TransactionReceiptQuery status response code.
-   * @return The TransactionReceiptQuery status response code of the input Response protobuf object.
+   * @param request  The Query protobuf object to submit.
+   * @param node     The Node to which to submit the request.
+   * @param deadline The deadline for submitting the request.
+   * @param response Pointer to the ProtoResponseType object that gRPC should populate with the response information
+   *                 from the gRPC server.
+   * @return The gRPC status of the submission.
    */
-  [[nodiscard]] Status mapResponseStatus(const proto::Response& response) const override;
+  [[nodiscard]] grpc::Status submitRequest(const proto::Query& request,
+                                           const std::shared_ptr<internal::Node>& node,
+                                           const std::chrono::system_clock::time_point& deadline,
+                                           proto::Response* response) const override;
 
   /**
    * Derived from Executable. Determine the ExecutionStatus of this TransactionReceiptQuery after being submitted.
@@ -99,21 +96,23 @@ private:
   determineStatus(Status status,
                   [[maybe_unused]] const Client& client,
                   [[maybe_unused]] const proto::Response& response) override;
+  /**
+   * Derived from Query. Build a Query protobuf object with this TransactionReceiptQuery's data, with the input
+   * QueryHeader protobuf object.
+   *
+   * @param header A pointer to the QueryHeader protobuf object to add to the Query protobuf object.
+   * @return The constructed Query protobuf object.
+   */
+  [[nodiscard]] proto::Query buildRequest(proto::QueryHeader* header) const override;
 
   /**
-   * Derived from Executable. Submit this TransactionReceiptQuery to a Node.
+   * Derived from Query. Get the ResponseHeader protobuf object from the input Response protobuf object.
    *
-   * @param client   The Client submitting this TransactionReceiptQuery.
-   * @param deadline The deadline for submitting this TransactionReceiptQuery.
-   * @param node     Pointer to the Node to which this TransactionReceiptQuery should be submitted.
-   * @param response Pointer to the Response protobuf object that gRPC should populate with the response information
-   *                 from the gRPC server.
-   * @return The gRPC status of the submission.
+   * @param response The Response protobuf object from which to get the ResponseHeader protobuf object.
+   * @return The ResponseHeader protobuf object of the input Response protobuf object for this derived Query.
    */
-  [[nodiscard]] grpc::Status submitRequest(const Client& client,
-                                           const std::chrono::system_clock::time_point& deadline,
-                                           const std::shared_ptr<internal::Node>& node,
-                                           proto::Response* response) const override;
+  [[nodiscard]] proto::ResponseHeader mapResponseHeader(const proto::Response& response) const override;
+
   /**
    * The ID of the transaction of which this query should get the receipt.
    */

--- a/sdk/main/include/TransactionRecordQuery.h
+++ b/sdk/main/include/TransactionRecordQuery.h
@@ -61,31 +61,28 @@ public:
 
 private:
   /**
-   * Derived from Executable. Construct a Query protobuf object from this TransactionRecordQuery object.
-   *
-   * @param client The Client trying to construct this TransactionRecordQuery.
-   * @param node   The Node to which this TransactionRecordQuery will be sent.
-   * @return A Query protobuf object filled with this TransactionRecordQuery object's data.
-   */
-  [[nodiscard]] proto::Query makeRequest(const Client& client,
-                                         const std::shared_ptr<internal::Node>& node) const override;
-
-  /**
    * Derived from Executable. Construct a TransactionRecord object from a Response protobuf object.
    *
    * @param response The Response protobuf object from which to construct a TransactionRecord object.
-   * @return An TransactionRecord object filled with the Response protobuf object's data
+   * @return A TransactionRecord object filled with the Response protobuf object's data
    */
   [[nodiscard]] TransactionRecord mapResponse(const proto::Response& response) const override;
 
   /**
-   * Derived from Executable. Get the status response code for a submitted TransactionRecordQuery from a Response
-   * protobuf object.
+   * Derived from Executable. Submit a Query protobuf object which contains this TransactionRecordQuery's data to a
+   * Node.
    *
-   * @param response The Response protobuf object from which to grab the TransactionRecordQuery status response code.
-   * @return The TransactionRecordQuery status response code of the input Response protobuf object.
+   * @param request  The Query protobuf object to submit.
+   * @param node     The Node to which to submit the request.
+   * @param deadline The deadline for submitting the request.
+   * @param response Pointer to the ProtoResponseType object that gRPC should populate with the response information
+   *                 from the gRPC server.
+   * @return The gRPC status of the submission.
    */
-  [[nodiscard]] Status mapResponseStatus(const proto::Response& response) const override;
+  [[nodiscard]] grpc::Status submitRequest(const proto::Query& request,
+                                           const std::shared_ptr<internal::Node>& node,
+                                           const std::chrono::system_clock::time_point& deadline,
+                                           proto::Response* response) const override;
 
   /**
    * Derived from Executable. Determine the ExecutionStatus of this TransactionRecordQuery after being submitted.
@@ -100,21 +97,22 @@ private:
   determineStatus(Status status,
                   [[maybe_unused]] const Client& client,
                   [[maybe_unused]] const proto::Response& response) override;
+  /**
+   * Derived from Query. Build a Query protobuf object with this TransactionRecordQuery's data, with the input
+   * QueryHeader protobuf object.
+   *
+   * @param header A pointer to the QueryHeader protobuf object to add to the Query protobuf object.
+   * @return The constructed Query protobuf object.
+   */
+  [[nodiscard]] proto::Query buildRequest(proto::QueryHeader* header) const override;
 
   /**
-   * Derived from Executable. Submit this TransactionRecordQuery to a Node.
+   * Derived from Query. Get the ResponseHeader protobuf object from the input Response protobuf object.
    *
-   * @param client   The Client submitting this TransactionRecordQuery.
-   * @param deadline The deadline for submitting this TransactionRecordQuery.
-   * @param node     Pointer to the Node to which this TransactionRecordQuery should be submitted.
-   * @param response Pointer to the Response protobuf object that gRPC should populate with the response information
-   *                 from the gRPC server.
-   * @return The gRPC status of the submission.
+   * @param response The Response protobuf object from which to get the ResponseHeader protobuf object.
+   * @return The ResponseHeader protobuf object of the input Response protobuf object for this derived Query.
    */
-  [[nodiscard]] grpc::Status submitRequest(const Client& client,
-                                           const std::chrono::system_clock::time_point& deadline,
-                                           const std::shared_ptr<internal::Node>& node,
-                                           proto::Response* response) const override;
+  [[nodiscard]] proto::ResponseHeader mapResponseHeader(const proto::Response& response) const override;
 
   /**
    * The ID of the transaction of which this query should get the record.

--- a/sdk/main/include/TransactionResponse.h
+++ b/sdk/main/include/TransactionResponse.h
@@ -145,10 +145,12 @@ public:
 
 private:
   /**
-   * Allow Transactions to adjust this TransactionResponse's mTransactionId.
+   * Allow Transactions and ChunkedTransactions to adjust this TransactionResponse's mTransactionId.
    */
-  template<typename SdkRequestType>
-  friend class Transaction;
+  // clang-format off
+  template<typename SdkRequestType> friend class Transaction;
+  template<typename SdkRequestType> friend class ChunkedTransaction;
+  // clang-format on
 
   /**
    * The cost to execute this TransactionResponse's corresponding Transaction.

--- a/sdk/main/include/TransactionResponse.h
+++ b/sdk/main/include/TransactionResponse.h
@@ -70,7 +70,7 @@ public:
    *                                      TransactionResponse is configured to throw.
    * @throws UninitializedException       If the input Client has not yet been initialized.
    */
-  [[nodiscard]] TransactionReceipt getReceipt(const Client& client) const;
+  TransactionReceipt getReceipt(const Client& client) const;
 
   /**
    * Get a TransactionReceipt for the Transaction to which this TransactionResponse is responding.
@@ -85,7 +85,7 @@ public:
    *                                      TransactionResponse is configured to throw.
    * @throws UninitializedException       If the input Client has not yet been initialized.
    */
-  [[nodiscard]] TransactionReceipt getReceipt(const Client& client, const std::chrono::duration<double>& timeout) const;
+  TransactionReceipt getReceipt(const Client& client, const std::chrono::duration<double>& timeout) const;
 
   /**
    * Get a TransactionRecord for the Transaction to which this TransactionResponse is responding.

--- a/sdk/main/include/TransferTransaction.h
+++ b/sdk/main/include/TransferTransaction.h
@@ -63,6 +63,14 @@ public:
   explicit TransferTransaction(const proto::TransactionBody& transactionBody);
 
   /**
+   * Construct from a map of TransactionIds to node account IDs and their respective Transaction protobuf objects.
+   *
+   * @param transactions The map of TransactionIds to node account IDs and their respective Transaction protobuf
+   *                     objects.
+   */
+  explicit TransferTransaction(const std::map<TransactionId, std::map<AccountId, proto::Transaction>>& transactions);
+
+  /**
    * Add an Hbar transfer to be submitted as part of this TransferTransaction.
    *
    * @param accountId The ID of the account associated with this transfer.
@@ -196,45 +204,25 @@ private:
   /**
    * Allow queries that are not free to create Transaction protobuf objects from TransferTransactions.
    */
-  friend class AccountInfoQuery;
-  friend class AccountRecordsQuery;
-  friend class ContractByteCodeQuery;
-  friend class ContractCallQuery;
-  friend class ContractInfoQuery;
-  friend class FileContentsQuery;
-  friend class FileInfoQuery;
-  friend class ScheduleInfoQuery;
-  friend class TokenInfoQuery;
-  friend class TokenNftInfoQuery;
-  friend class TopicInfoQuery;
-  friend class TransactionRecordQuery;
+  template<typename SdkRequestType, typename SdkResponseType>
+  friend class Query;
 
   friend class WrappedTransaction;
 
   /**
-   * Derived from Executable. Construct a Transaction protobuf object from this TransferTransaction object.
+   * Derived from Executable. Submit a Transaction protobuf object which contains this TransferTransaction's data to a
+   * Node.
    *
-   * @param client The Client trying to construct this TransferTransaction.
-   * @param node   The Node to which this TransferTransaction will be sent. This is unused.
-   * @return A Transaction protobuf object filled with this TransferTransaction object's data.
-   * @throws UninitializedException If the input client has no operator with which to sign this TransferTransaction.
-   */
-  [[nodiscard]] proto::Transaction makeRequest(const Client& client,
-                                               const std::shared_ptr<internal::Node>& /*node*/) const override;
-
-  /**
-   * Derived from Executable. Submit this TransferTransaction to a Node.
-   *
-   * @param client   The Client submitting this TransferTransaction.
-   * @param deadline The deadline for submitting this TransferTransaction.
-   * @param node     Pointer to the Node to which this TransferTransaction should be submitted.
-   * @param response Pointer to the TransactionResponse protobuf object that gRPC should populate with the response
-   *                 information from the gRPC server.
+   * @param request  The Transaction protobuf object to submit.
+   * @param node     The Node to which to submit the request.
+   * @param deadline The deadline for submitting the request.
+   * @param response Pointer to the ProtoResponseType object that gRPC should populate with the response information
+   *                 from the gRPC server.
    * @return The gRPC status of the submission.
    */
-  [[nodiscard]] grpc::Status submitRequest(const Client& client,
-                                           const std::chrono::system_clock::time_point& deadline,
+  [[nodiscard]] grpc::Status submitRequest(const proto::Transaction& request,
                                            const std::shared_ptr<internal::Node>& node,
+                                           const std::chrono::system_clock::time_point& deadline,
                                            proto::TransactionResponse* response) const override;
   /**
    * Derived from Transaction. Build and add the TransferTransaction protobuf representation to the Transaction
@@ -243,6 +231,11 @@ private:
    * @param body The TransactionBody protobuf object being built.
    */
   void addToBody(proto::TransactionBody& body) const override;
+
+  /**
+   * Initialize this TransferTransaction from its source TransactionBody protobuf object.
+   */
+  void initFromSourceTransactionBody();
 
   /**
    * Build a CryptoTransferTransactionBody protobuf object from this TransferTransaction object.

--- a/sdk/main/include/exceptions/MaxQueryPaymentExceededException.h
+++ b/sdk/main/include/exceptions/MaxQueryPaymentExceededException.h
@@ -1,0 +1,60 @@
+/*-
+ *
+ * Hedera C++ SDK
+ *
+ * Copyright (C) 2020 - 2023 Hedera Hashgraph, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+#ifndef HEDERA_SDK_CPP_MAX_QUERY_PAYMENT_EXCEEDED_EXCEPTION_H_
+#define HEDERA_SDK_CPP_MAX_QUERY_PAYMENT_EXCEEDED_EXCEPTION_H_
+
+#include <exception>
+#include <string_view>
+
+namespace Hedera
+{
+/**
+ * Exception that is thrown when the cost to execute a Query is larger than the maximum allowed amount.
+ */
+class MaxQueryPaymentExceededException : public std::exception
+{
+public:
+  /**
+   * Construct with a message.
+   *
+   * @param msg The error message to further describe this exception.
+   */
+  explicit MaxQueryPaymentExceededException(std::string_view msg)
+    : mError(msg)
+  {
+  }
+
+  /**
+   * Get the descriptor message for this error.
+   *
+   * @return The descriptor message for this error.
+   */
+  [[nodiscard]] const char* what() const noexcept override { return mError.data(); };
+
+private:
+  /**
+   * Descriptive error message.
+   */
+  std::string_view mError;
+};
+
+} // namespace Hedera
+
+#endif // HEDERA_SDK_CPP_MAX_QUERY_PAYMENT_EXCEEDED_EXCEPTION_H_

--- a/sdk/main/include/impl/BaseNetwork.h
+++ b/sdk/main/include/impl/BaseNetwork.h
@@ -60,7 +60,7 @@ public:
    *
    * @param node The NodeType of which to decrease the backoff.
    */
-  void decreaseBackoff(const std::shared_ptr<NodeType>& node);
+  void decreaseBackoff(const std::shared_ptr<NodeType>& node) const;
 
   /**
    * Get the list of all proxies at a specified key.

--- a/sdk/main/include/impl/BaseNetwork.h
+++ b/sdk/main/include/impl/BaseNetwork.h
@@ -1,0 +1,326 @@
+/*-
+ *
+ * Hedera C++ SDK
+ *
+ * Copyright (C) 2020 - 2023 Hedera Hashgraph, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+#ifndef HEDERA_SDK_CPP_IMPL_BASE_NETWORK_H_
+#define HEDERA_SDK_CPP_IMPL_BASE_NETWORK_H_
+
+#include "BaseNode.h"
+#include "Defaults.h"
+#include "LedgerId.h"
+#include "impl/TLSBehavior.h"
+
+#include <chrono>
+#include <memory>
+#include <string>
+#include <string_view>
+#include <unordered_map>
+#include <unordered_set>
+
+namespace Hedera::internal
+{
+template<typename NetworkType, typename KeyType, typename NodeType>
+class BaseNetwork
+{
+public:
+  /**
+   * Set the NodeTypes in this BaseNetwork. It shutdowns and removes any NodeType from this BaseNetwork if the input
+   * network doesn't contain its representation. It will then add any new NodeTypes that don't already exist in this
+   * BaseNetwork.
+   *
+   * @param network The map of addresses to their keys that represent NodeTypes to add to this BaseNetwork.
+   * @return A reference to this derived BaseNetwork object with the newly-set NodeTypes.
+   */
+  NetworkType& setNetwork(const std::unordered_map<std::string, KeyType>& network);
+
+  /**
+   * Increase the backoff of the input NodeType.
+   *
+   * @param node The NodeType of which to increase the backoff.
+   */
+  void increaseBackoff(const std::shared_ptr<NodeType>& node);
+
+  /**
+   * Decrease the backoff of the input NodeType.
+   *
+   * @param node The NodeType of which to decrease the backoff.
+   */
+  void decreaseBackoff(const std::shared_ptr<NodeType>& node);
+
+  /**
+   * Get the list of all proxies at a specified key.
+   *
+   * @return The list of all proxies at a specified key.
+   */
+  [[nodiscard]] std::vector<std::shared_ptr<NodeType>> getNodeProxies(const KeyType& key);
+
+  /**
+   * Close the connects on this BaseNetwork.
+   */
+  void close();
+
+  /**
+   * Set the maximum number of times to try to use a NodeType to submit a request. Once the NodeType exceeds this number
+   * of submission attempts that have returned a bad gRPC status, that NodeType will be permanently removed from this
+   * BaseNetwork.
+   *
+   * @param attempts The maximum number of times a NodeType can be retried.
+   * @return A reference to this derived BaseNetwork object with the newly-set maximum node attempts.
+   */
+  NetworkType& setMaxNodeAttempts(unsigned int attempts);
+
+  /**
+   * Set the minimum amount of time to backoff from a NodeType after a bad gRPC status is received.
+   *
+   * @param backoff The minimum backoff time to use for a NodeType after a bad gRPC status is received.
+   * @return A reference to this derived BaseNetwork object with the newly-set minimum backoff.
+   */
+  NetworkType& setMinNodeBackoff(const std::chrono::duration<double>& backoff);
+
+  /**
+   * Set the maximum amount of time to backoff from a NodeType after a bad gRPC status is received.
+   *
+   * @param backoff The maximum backoff time to use for a NodeType after a bad gRPC status is received.
+   * @return A reference to this derived BaseNetwork object with the newly-set maximum backoff.
+   */
+  NetworkType& setMaxNodeBackoff(const std::chrono::duration<double>& backoff);
+
+  /**
+   * Set the minimum amount of time to wait before readmitting NodeTypes as "healthy".
+   *
+   * @param time The minimum amount of time to wait before readmitting NodeTypes as "healthy".
+   * @return A reference to this derived BaseNetwork object with the newly-set minimum node readmit time.
+   */
+  NetworkType& setMinNodeReadmitTime(const std::chrono::duration<double>& time);
+
+  /**
+   * Set the maximum amount of time to wait before readmitting NodeTypes as "healthy".
+   *
+   * @param time The maximum amount of time to wait before readmitting NodeTypes as "healthy".
+   * @return A reference to this derived BaseNetwork object with the newly-set maximum node readmit time.
+   */
+  NetworkType& setMaxNodeReadmitTime(const std::chrono::duration<double>& time);
+
+  /**
+   * Set the amount of time to allow gRPC connections on this BaseNetwork to close gracefully before forcibly
+   * terminating them.
+   *
+   * @param timeout The amount of time to allow gRPC connections on this BaseNetwork to close gracefully.
+   * @return A reference to this derived BaseNetwork object with the newly-set close timeout.
+   */
+  NetworkType& setCloseTimeout(const std::chrono::duration<double>& timeout);
+
+  /**
+   * Set the ledger ID of this BaseNetwork.
+   *
+   * @param ledgerId The ledger ID to set.
+   * @return A reference to this derived BaseNetwork object with the newly-set ledger ID.
+   */
+  virtual NetworkType& setLedgerId(const LedgerId& ledgerId);
+
+  /**
+   * Get the transport security policy of this BaseNetwork.
+   *
+   * @return The transport security policy of this BaseNetwork.
+   */
+  [[nodiscard]] inline TLSBehavior isTransportSecurity() const { return mTransportSecurity; }
+
+  /**
+   * Get the maximum number of times to try to use a NodeType before removing it from this BaseNetwork.
+   *
+   * @return The maximum number of times to try to use a NodeType before removing it from this BaseNetwork.
+   */
+  [[nodiscard]] inline unsigned int getMaxNodeAttempts() const { return mMaxNodeAttempts; }
+
+  /**
+   * Get the minimum amount of time to backoff from a NodeType after a bad gRPC status is received.
+   *
+   * @return The minimum amount of time to backoff from a NodeType after a bad gRPC status is received.
+   */
+  [[nodiscard]] inline std::chrono::duration<double> getMinNodeBackoff() const { return mMinNodeBackoff; }
+
+  /**
+   * Get the maximum amount of time to backoff from a NodeType after a bad gRPC status is received.
+   *
+   * @return The maximum amount of time to backoff from a NodeType after a bad gRPC status is received.
+   */
+  [[nodiscard]] inline std::chrono::duration<double> getMaxNodeBackoff() const { return mMaxNodeBackoff; }
+
+  /**
+   * Get the minimum amount of time to wait before readmitting NodeTypes as "healthy".
+   *
+   * @return The minimum amount of time to wait before readmitting NodeTypes as "healthy".
+   */
+  [[nodiscard]] inline std::chrono::duration<double> getMinNodeReadmitTime() const { return mMinNodeReadmitTime; }
+
+  /**
+   * Get the maximum amount of time to wait before readmitting NodeTypes as "healthy".
+   *
+   * @return The maximum amount of time to wait before readmitting NodeTypes as "healthy".
+   */
+  [[nodiscard]] inline std::chrono::duration<double> getMaxNodeReadmitTime() const { return mMaxNodeReadmitTime; }
+
+  /**
+   * Get the amount of time to allow gRPC connections on this BaseNetwork to close gracefully before forcibly
+   * terminating them.
+   *
+   * @return The amount of time to allow gRPC connections on this BaseNetwork to close gracefully before forcibly
+   *         terminating them.
+   */
+  [[nodiscard]] inline std::chrono::duration<double> getCloseTimeout() const { return mCloseTimeout; }
+
+  /**
+   * Get the ledger ID of this Network.
+   *
+   * @return The ledger ID of this Network.
+   */
+  [[nodiscard]] inline LedgerId getLedgerId() const { return mLedgerId; }
+
+protected:
+  ~BaseNetwork() = default;
+  
+  /**
+   * Get a number of the most healthy nodes on this BaseNetwork. "Healthy"-ness is determined by sort order; the lower
+   * index nodes in the returned vector are considered the most healthy.
+   *
+   * This will also remove any nodes which have hit or exceeded mMaxNodeAttempts permanently from the BaseNetwork.
+   *
+   * @param count The number of nodes to get.
+   * @return A list of pointers to the healthiest BaseNodes on this BaseNetwork.
+   */
+  [[nodiscard]] std::vector<std::shared_ptr<NodeType>> getNumberOfMostHealthyNodes(unsigned int count);
+
+  /**
+   * Set the transport security policy.
+   *
+   * @param tls The transport security policy to set.
+   */
+  void setTransportSecurity(TLSBehavior tls);
+
+  /**
+   * Get the map of KeyTypes to their NodeTypes on this BaseNetwork.
+   *
+   * @return The map of KeyTypes to their NodeTypes on this BaseNetwork.
+   */
+  [[nodiscard]] inline const std::unordered_map<KeyType, std::unordered_set<std::shared_ptr<NodeType>>>& getNetwork()
+    const
+  {
+    return mNetwork;
+  }
+
+  /**
+   * Get the list of NodeTypes on this BaseNetwork.
+   *
+   * @return The list of NodeTypes on this BaseNetwork.
+   */
+  [[nodiscard]] inline const std::unordered_set<std::shared_ptr<NodeType>>& getNodes() const { return mNodes; }
+
+private:
+  /**
+   * Create a NodeType for this BaseNetwork based on a network entry.
+   *
+   * @param address The address of the NodeType.
+   * @param key     The key for the NodeType.
+   * @return A pointer to the created NodeType.
+   */
+  [[nodiscard]] virtual std::shared_ptr<NodeType> createNodeFromNetworkEntry(
+    std::string_view address,
+    [[maybe_unused]] const KeyType& key) const = 0;
+
+  /**
+   * Readmit nodes from the mNodes list to the mHealthyNodes list when the time has passed the mEarliestReadmitTime.
+   * While readmitting nodes, mEarliestReadmitTime will be updated to a new value. This value is either the value of
+   * the node with the smallest readmission time from now, or mMinNodeReadmitTime or mMaxNodeReadmitTime.
+   */
+  void readmitNodes();
+
+  /**
+   * Remove a BaseNode from this BaseNetwork.
+   *
+   * @param node A pointer to the BaseNode to remove.
+   */
+  void removeNodeFromNetwork(const std::shared_ptr<NodeType>& node);
+
+  /**
+   * Map of node identifiers (KeyTypes) to their NodeTypes.
+   */
+  std::unordered_map<KeyType, std::unordered_set<std::shared_ptr<NodeType>>> mNetwork;
+
+  /**
+   * The list of all nodes on this BaseNetwork.
+   */
+  std::unordered_set<std::shared_ptr<NodeType>> mNodes;
+
+  /**
+   * The list of current healthy nodes on this BaseNetwork.
+   */
+  std::unordered_set<std::shared_ptr<NodeType>> mHealthyNodes;
+
+  /**
+   * The transport security policy of this BaseNetwork.
+   */
+  TLSBehavior mTransportSecurity = TLSBehavior::REQUIRE;
+
+  /**
+   * The maximum number of times to try to use a NodeType to submit a request. Once the NodeType exceeds this number of
+   * submission attempts that have returned a bad gRPC status, that NodeType will be permanently removed from this
+   * BaseNetwork.
+   */
+  unsigned int mMaxNodeAttempts = DEFAULT_MAX_NODE_ATTEMPTS;
+
+  /**
+   * The minimum amount of time to wait to use a NodeType after it has received a bad gRPC status.
+   */
+  std::chrono::duration<double> mMinNodeBackoff = DEFAULT_MIN_NODE_BACKOFF;
+
+  /**
+   * The maximum amount of time to wait to use a NodeType after it has received a bad gRPC status.
+   */
+  std::chrono::duration<double> mMaxNodeBackoff = DEFAULT_MAX_NODE_BACKOFF;
+
+  /**
+   * The minimum time to wait before attempting to readmit nodes.
+   */
+  std::chrono::duration<double> mMinNodeReadmitTime = DEFAULT_MIN_NODE_BACKOFF;
+
+  /**
+   * The maximum time to wait before attempting to readmit nodes.
+   */
+  std::chrono::duration<double> mMaxNodeReadmitTime = DEFAULT_MAX_NODE_BACKOFF;
+
+  /**
+   * The earliest time that a node should be readmitted.
+   */
+  std::chrono::system_clock::time_point mEarliestReadmitTime =
+    std::chrono::system_clock::now() +
+    std::chrono::duration_cast<std::chrono::system_clock::duration>(mMinNodeReadmitTime);
+
+  /**
+   * The timeout for closing either a single node when setting a new network, or closing the entire network.
+   */
+  std::chrono::duration<double> mCloseTimeout = DEFAULT_CLOSE_TIMEOUT;
+
+  /**
+   * The ledger ID of the network.
+   */
+  LedgerId mLedgerId;
+};
+
+} // namespace Hedera::internal
+
+#endif // HEDERA_SDK_CPP_IMPL_BASE_NETWORK_H_

--- a/sdk/main/include/impl/BaseNetwork.h
+++ b/sdk/main/include/impl/BaseNetwork.h
@@ -23,7 +23,7 @@
 #include "BaseNode.h"
 #include "Defaults.h"
 #include "LedgerId.h"
-#include "impl/TLSBehavior.h"
+#include "TLSBehavior.h"
 
 #include <chrono>
 #include <memory>

--- a/sdk/main/include/impl/BaseNetwork.h
+++ b/sdk/main/include/impl/BaseNetwork.h
@@ -72,7 +72,7 @@ public:
   /**
    * Close the connects on this BaseNetwork.
    */
-  void close();
+  void close() const;
 
   /**
    * Set the maximum number of times to try to use a NodeType to submit a request. Once the NodeType exceeds this number
@@ -217,8 +217,8 @@ protected:
    *
    * @return The map of KeyTypes to their NodeTypes on this BaseNetwork.
    */
-  [[nodiscard]] inline const std::unordered_map<KeyType, std::unordered_set<std::shared_ptr<NodeType>>>& getNetwork()
-    const
+  [[nodiscard]] inline const std::unordered_map<KeyType, std::unordered_set<std::shared_ptr<NodeType>>>&
+  getNetworkInternal() const
   {
     return mNetwork;
   }
@@ -306,9 +306,7 @@ private:
   /**
    * The earliest time that a node should be readmitted.
    */
-  std::chrono::system_clock::time_point mEarliestReadmitTime =
-    std::chrono::system_clock::now() +
-    std::chrono::duration_cast<std::chrono::system_clock::duration>(mMinNodeReadmitTime);
+  std::chrono::system_clock::time_point mEarliestReadmitTime = std::chrono::system_clock::now();
 
   /**
    * The timeout for closing either a single node when setting a new network, or closing the entire network.

--- a/sdk/main/include/impl/BaseNetwork.h
+++ b/sdk/main/include/impl/BaseNetwork.h
@@ -193,7 +193,7 @@ public:
 
 protected:
   ~BaseNetwork() = default;
-  
+
   /**
    * Get a number of the most healthy nodes on this BaseNetwork. "Healthy"-ness is determined by sort order; the lower
    * index nodes in the returned vector are considered the most healthy.
@@ -210,7 +210,7 @@ protected:
    *
    * @param tls The transport security policy to set.
    */
-  void setTransportSecurity(TLSBehavior tls);
+  void setTransportSecurityInternal(TLSBehavior tls);
 
   /**
    * Get the map of KeyTypes to their NodeTypes on this BaseNetwork.

--- a/sdk/main/include/impl/BaseNode.h
+++ b/sdk/main/include/impl/BaseNode.h
@@ -1,0 +1,232 @@
+/*-
+ *
+ * Hedera C++ SDK
+ *
+ * Copyright (C) 2020 - 2023 Hedera Hashgraph, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+#ifndef HEDERA_SDK_CPP_IMPL_BASE_NODE_H_
+#define HEDERA_SDK_CPP_IMPL_BASE_NODE_H_
+
+#include "BaseNodeAddress.h"
+#include "Defaults.h"
+
+#include <chrono>
+#include <grpcpp/channel.h>
+#include <grpcpp/security/credentials.h>
+
+namespace Hedera::internal
+{
+template<typename NodeType, typename KeyType>
+class BaseNode
+{
+public:
+  /**
+   * Get this BaseNode's key.
+   *
+   * @return This BaseNode's key.
+   */
+  [[nodiscard]] virtual KeyType getKey() const = 0;
+
+  /**
+   * Close this BaseNode's connection to its remote node.
+   */
+  void close();
+
+  /**
+   * Increase the backoff of this BaseNode.
+   */
+  void increaseBackoff();
+
+  /**
+   * Decrease the backoff of this BaseNode.
+   */
+  void decreaseBackoff();
+
+  /**
+   * Is this BaseNode currently considered healthy?
+   *
+   * @return \c TRUE if this BaseNode is healthy, otherwise \c FALSE.
+   */
+  [[nodiscard]] bool isHealthy() const;
+
+  /**
+   * Has this BaseNode failed to connect to its remote node?
+   *
+   * @return \c TRUE if this BaseNode has failed to connect to its remote node, otherwise \c FALSE.
+   */
+  [[nodiscard]] bool channelFailedToConnect();
+
+  /**
+   * Get the remaining amount of time this BaseNode has in its backoff.
+   *
+   * @return The remaining amount of time this BaseNode has in its backoff.
+   */
+  [[nodiscard]] std::chrono::duration<double> getRemainingTimeForBackoff() const;
+
+  /**
+   * Set the minimum amount of time for this BaseNode to backoff after a bad gRPC status is received.
+   *
+   * @param backoff The minimum backoff time for this BaseNode after a bad gRPC status is received.
+   * @return A reference to this derived BaseNode object with the newly-set minimum backoff.
+   */
+  NodeType& setMinNodeBackoff(const std::chrono::duration<double>& backoff);
+
+  /**
+   * Set the maximum amount of time for this BaseNode to backoff after a bad gRPC status is received.
+   *
+   * @param backoff The maximum backoff time for this BaseNode after a bad gRPC status is received.
+   * @return A reference to this derived BaseNode object with the newly-set minimum backoff.
+   */
+  NodeType& setMaxNodeBackoff(const std::chrono::duration<double>& backoff);
+
+  /**
+   * Get this BaseNode's BaseNodeAddress.
+   *
+   * @return address The BaseNodeAddress of this BaseNode.
+   */
+  [[nodiscard]] inline BaseNodeAddress getAddress() const { return mAddress; }
+
+  /**
+   * Get the minimum amount of time for this BaseNode to backoff after a bad gRPC status is received.
+   *
+   * @return The minimum amount of time for this BaseNode to backoff after a bad gRPC status is received.
+   */
+  [[nodiscard]] inline std::chrono::duration<double> getMinNodeBackoff() const { return mMinNodeBackoff; }
+
+  /**
+   * Get the maximum amount of time for this BaseNode to backoff after a bad gRPC status is received.
+   *
+   * @return The maximum amount of time for this BaseNode to backoff after a bad gRPC status is received.
+   */
+  [[nodiscard]] inline std::chrono::duration<double> getMaxNodeBackoff() const { return mMaxNodeBackoff; }
+
+  /**
+   * Get the number of times this BaseNode has received a bad gRPC status when attempting to submit a request.
+   *
+   * @return The number of times this BaseNode has received a bad gRPC status.
+   */
+  [[nodiscard]] inline unsigned int getBadGrpcStatusCount() const { return mBadGrpcStatusCount; }
+
+  /**
+   * Get the time at which this BaseNode will be considered "healthy".
+   *
+   * @return The time at which this BaseNode will be considered "healthy".
+   */
+  [[nodiscard]] inline std::chrono::system_clock::time_point getReadmitTime() const { return mReadmitTime; }
+
+protected:
+  ~BaseNode() = default;
+
+  /**
+   * Construct with a BaseNodeAddress.
+   *
+   * @param address The BaseNodeAddress of this BaseNode.
+   */
+  explicit BaseNode(BaseNodeAddress address);
+
+  /**
+   * Get this BaseNode's gRPC channel. Creates and initializes a new channel if one isn't already created.
+   *
+   * @return A pointer to this BaseNode's gRPC channel.
+   */
+  [[nodiscard]] std::shared_ptr<grpc::Channel> getChannel();
+
+private:
+  /**
+   * How often to query for the state of the channel when determining if this BaseNode has connected to its remote node.
+   */
+  static constexpr auto GET_STATE_INTERVAL = std::chrono::milliseconds(50);
+
+  /**
+   * How long to try and let the channel connect before calling the connection a failure.
+   */
+  static constexpr auto GET_STATE_TIMEOUT = std::chrono::seconds(10);
+
+  /**
+   * Get the TLS credentials for this BaseNode's gRPC channel.
+   *
+   * @return A pointer to the TLS credentials for this BaseNode's gRPC channel.
+   */
+  [[nodiscard]] virtual std::shared_ptr<grpc::ChannelCredentials> getTlsChannelCredentials() const;
+
+  /**
+   * Initialize the stubs in this derived BaseNode with a gRPC channel.
+   *
+   * @param channel The gRPC channel with which to initialize the stubs.
+   */
+  virtual void initializeStubs([[maybe_unused]] const std::shared_ptr<grpc::Channel>& channel)
+  { // Intentionally unimplemented, derived BaseNodes that don't use stubs require no functionality.
+  }
+
+  /**
+   * Close the stubs in this derived BaseNode.
+   */
+  virtual void closeStubs()
+  { // Intentionally unimplemented, derived BaseNodes that don't use stubs require no functionality.
+  }
+
+  /**
+   * Get the authority of this BaseNode.
+   *
+   * @return The authority of this BaseNode.
+   */
+  [[nodiscard]] virtual inline std::string getAuthority() const { return "127.0.0.1"; }
+
+  /**
+   * The address of this BaseNode.
+   */
+  BaseNodeAddress mAddress;
+
+  /**
+   * Pointer to the gRPC channel used to communicate with the gRPC server living on the remote node.
+   */
+  std::shared_ptr<grpc::Channel> mChannel = nullptr;
+
+  /**
+   * The minimum amount of time to wait to use this BaseNode after it has received a bad gRPC status.
+   */
+  std::chrono::duration<double> mMinNodeBackoff = DEFAULT_MIN_NODE_BACKOFF;
+
+  /**
+   * The maximum amount of time to wait to use this BaseNode after it has received a bad gRPC status.
+   */
+  std::chrono::duration<double> mMaxNodeBackoff = DEFAULT_MAX_NODE_BACKOFF;
+
+  /**
+   * The current amount of time to wait to use this BaseNode after it has received a bad gRPC status. This will increase
+   * exponentially until mMaxNodeBackoff is reached.
+   */
+  std::chrono::duration<double> mCurrentBackoff = DEFAULT_MIN_NODE_BACKOFF;
+
+  /**
+   * The time at which this BaseNode will be considered "healthy".
+   */
+  std::chrono::system_clock::time_point mReadmitTime = std::chrono::system_clock::now();
+
+  /**
+   * The number of times this BaseNode has received a bad gRPC status.
+   */
+  unsigned int mBadGrpcStatusCount = 0U;
+
+  /**
+   * Is the gRPC channel being utilized by this BaseNode to communicate with its remote node initialized?
+   */
+  bool mIsConnected = false;
+};
+
+} // namespace Hedera::internal
+
+#endif // HEDERA_SDK_CPP_IMPL_BASE_NODE_H_

--- a/sdk/main/include/impl/BaseNode.h
+++ b/sdk/main/include/impl/BaseNode.h
@@ -138,6 +138,13 @@ protected:
   explicit BaseNode(BaseNodeAddress address);
 
   /**
+   * Set the BaseNodeAddress of this BaseNode. This will also close this BaseNode's current connection.
+   *
+   * @param address The BaseNodeAddress to set.
+   */
+  NodeType& setAddress(const BaseNodeAddress& address);
+
+  /**
    * Get this BaseNode's gRPC channel. Creates and initializes a new channel if one isn't already created.
    *
    * @return A pointer to this BaseNode's gRPC channel.

--- a/sdk/main/include/impl/BaseNode.h
+++ b/sdk/main/include/impl/BaseNode.h
@@ -20,6 +20,8 @@
 #ifndef HEDERA_SDK_CPP_IMPL_BASE_NODE_H_
 #define HEDERA_SDK_CPP_IMPL_BASE_NODE_H_
 
+#include <proto/basic_types.pb.h> // This is needed for Windows to build for some reason.
+
 #include "BaseNodeAddress.h"
 #include "Defaults.h"
 

--- a/sdk/main/include/impl/BaseNodeAddress.h
+++ b/sdk/main/include/impl/BaseNodeAddress.h
@@ -1,0 +1,159 @@
+/*-
+ *
+ * Hedera C++ SDK
+ *
+ * Copyright (C) 2020 - 2023 Hedera Hashgraph, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+#ifndef HEDERA_SDK_CPP_IMPL_BASE_NODE_ADDRESS_H_
+#define HEDERA_SDK_CPP_IMPL_BASE_NODE_ADDRESS_H_
+
+#include <string>
+#include <string_view>
+
+namespace Hedera::internal
+{
+class BaseNodeAddress
+{
+public:
+  /**
+   * Port numbers for various node types and security.
+   */
+  static constexpr unsigned int PORT_MIRROR_PLAIN = 5600U;
+  static constexpr unsigned int PORT_MIRROR_TLS = 443U;
+  static constexpr unsigned int PORT_NODE_PLAIN = 50211U;
+  static constexpr unsigned int PORT_NODE_TLS = 50212U;
+
+  /**
+   * Construct with values for name, address, and port.
+   *
+   * @param name    The name with which to construct.
+   * @param address The address with which to construct.
+   * @param port    The port with which to construct.
+   */
+  explicit BaseNodeAddress(std::string_view name, std::string_view address, unsigned int port);
+
+  /**
+   * Construct a BaseNodeAddress from an address string that contains the IP and port.
+   *
+   * @param address The address of the BaseNodeAddress.
+   * @return The constructed BaseNodeAddress.
+   * @throws std::invalid_argument If the provided address is malformed.
+   */
+  [[nodiscard]] static BaseNodeAddress fromString(std::string_view address);
+
+  /**
+   * Compare this BaseNodeAddress to another BaseNodeAddress and determine if they represent the same node address.
+   *
+   * @param other The other BaseNodeAddress with which to compare this BaseNodeAddress.
+   * @return \c TRUE if this BaseNodeAddress is the same as the input BaseNodeAddress, otherwise \c FALSE.
+   */
+  bool operator==(const BaseNodeAddress& other) const;
+
+  /**
+   * Create a copy of this BaseNodeAddress but using TLS.
+   *
+   * @return The copy of this BoseNodeAddress using TLS.
+   */
+  [[nodiscard]] BaseNodeAddress toSecure() const;
+
+  /**
+   * Create a copy of this BaseNodeAddress but not using TLS.
+   *
+   * @return The copy of this BoseNodeAddress not using TLS.
+   */
+  [[nodiscard]] BaseNodeAddress toInsecure() const;
+
+  /**
+   * Get the string representation of this BaseNodeAddress.
+   *
+   * @return The string representation of this BaseNodeAddress.
+   */
+  [[nodiscard]] std::string toString() const;
+
+  /**
+   * Is this BaseNodeAddress in process?
+   *
+   * @return \c TRUE if this BaseNodeAddress is in process, otherwise \c FALSE.
+   */
+  [[nodiscard]] inline bool isInProcess() const { return !mName.empty(); }
+
+  /**
+   * Is this BaseNodeAddress using transport security?
+   *
+   * @param \c TRUE if this BaseNodeAddress is using TLS, otherwise \c FALSE.
+   */
+  [[nodiscard]] inline bool isTransportSecurity() const
+  {
+    return (mPort == PORT_NODE_TLS) || (mPort == PORT_MIRROR_TLS);
+  }
+
+  /**
+   * Get the name of this BaseNodeAddress.
+   *
+   * @return The name of this BaseNodeAddress.
+   */
+  [[nodiscard]] inline std::string getName() const { return mName; }
+
+  /**
+   * Get the IP address of this BaseNodeAddress.
+   *
+   * @return The IP address of this BaseNodeAddress.
+   */
+  [[nodiscard]] inline std::string getAddress() const { return mAddress; }
+
+  /**
+   * Get the port of this BaseNodeAddress.
+   *
+   * @return The port of this BaseNodeAddress.
+   */
+  [[nodiscard]] inline unsigned int getPort() const { return mPort; }
+
+private:
+  /**
+   * The name of the address. This is used for "in-process" addresses.
+   */
+  std::string mName;
+
+  /**
+   * The IP address.
+   */
+  std::string mAddress;
+
+  /**
+   * The port.
+   */
+  unsigned int mPort = 0U;
+};
+
+} // namespace Hedera::internal
+
+namespace std
+{
+template<>
+struct hash<Hedera::internal::BaseNodeAddress>
+{
+  /**
+   * Operator override to enable use of BaseNodeAddress as map key.
+   */
+  size_t operator()(const Hedera::internal::BaseNodeAddress& address) const
+  {
+    return hash<string>()(address.toString());
+  }
+};
+
+} // namespace std
+
+#endif // HEDERA_SDK_CPP_IMPL_BASE_NODE_ADDRESS_H_

--- a/sdk/main/include/impl/Endpoint.h
+++ b/sdk/main/include/impl/Endpoint.h
@@ -22,6 +22,9 @@
 
 #include "IPv4Address.h"
 
+#include <memory>
+#include <string>
+
 namespace proto
 {
 class ServiceEndpoint;
@@ -36,41 +39,56 @@ class Endpoint
 {
 public:
   /**
-   * Construct from an address and a port number.
+   * Construct an Endpoint object from a ServiceEndpoint protobuf object.
    *
-   * @param ipAddressV4 The IPv4 address of the endpoint.
-   * @param port        The port of the endpoint.
+   * @param proto The ServiceEndpoint protobuf object from which to construct an Endpoint object.
+   * @return The constructed Endpoint object.
    */
-  Endpoint(const IPv4Address& ipAddressV4, int port);
+  [[nodiscard]] static Endpoint fromProtobuf(const proto::ServiceEndpoint& protoServiceEndpoint);
 
   /**
-   * Create an Endpoint object from a ServiceEndpoint protobuf object.
+   * Construct a ServiceEndpoint protobuf object from this Endpoint object.
    *
-   * @param protoServiceEndpoint The ServiceEndpoint protobuf object from which to create an Endpoint object.
-   * @return The created Endpoint object.
+   * @return A pointer to the created ServiceEndpoint protobuf object filled with this Endpoint object's data.
    */
-  static Endpoint fromProtobuf(const proto::ServiceEndpoint& protoServiceEndpoint);
+  [[nodiscard]] std::unique_ptr<proto::ServiceEndpoint> toProtobuf() const;
 
   /**
-   * Get a string representation of the endpoint with the form <ip.add.re.ss>:<port>.
+   * Get a string representation of this Endpoint.
    *
-   * @return A string representation of the Endpoint.
+   * @return A string representation of this Endpoint.
    */
   [[nodiscard]] std::string toString() const;
 
   /**
-   * Get the IP address of the node.
+   * Set the IP address of this Endpoint.
    *
-   * @return The IP address (v4) of the node.
+   * @param address The IP address to set.
+   * @return A reference to this Endpoint with the newly-set IP address.
+   */
+  Endpoint& setAddress(const IPv4Address& address);
+
+  /**
+   * Set the port of this Endpoint.
+   *
+   * @param port The port to set.
+   * @return A reference to this Endpoint with the newly-set port.
+   */
+  Endpoint& setPort(unsigned int port);
+
+  /**
+   * Get the IP address of this Endpoint.
+   *
+   * @return The IP address of this Endpoint.
    */
   [[nodiscard]] inline IPv4Address getAddress() const { return mAddress; }
 
   /**
-   * Get the port of the Endpoint.
+   * Get the port of this Endpoint.
    *
-   * @return The port of the Endpoint.
+   * @return The port of this Endpoint.
    */
-  [[nodiscard]] inline int getPort() const { return mPort; }
+  [[nodiscard]] inline unsigned int getPort() const { return mPort; }
 
 private:
   /**
@@ -81,7 +99,7 @@ private:
   /**
    * The port of the Endpoint.
    */
-  int mPort;
+  unsigned int mPort = 0U;
 };
 
 } // namespace Hedera::internal

--- a/sdk/main/include/impl/IPv4Address.h
+++ b/sdk/main/include/impl/IPv4Address.h
@@ -21,8 +21,9 @@
 #define HEDERA_SDK_CPP_IMPL_IPV4_ADDRESS_H_
 
 #include <array>
+#include <cstddef>
 #include <string>
-#include <string_view>
+#include <vector>
 
 namespace Hedera::internal
 {

--- a/sdk/main/include/impl/IPv4Address.h
+++ b/sdk/main/include/impl/IPv4Address.h
@@ -20,65 +20,46 @@
 #ifndef HEDERA_SDK_CPP_IMPL_IPV4_ADDRESS_H_
 #define HEDERA_SDK_CPP_IMPL_IPV4_ADDRESS_H_
 
+#include <array>
 #include <string>
 #include <string_view>
 
 namespace Hedera::internal
 {
 /**
- * An IPv4 address (without port)
+ * An IPv4 address (without port).
  */
 class IPv4Address
 {
 public:
-  IPv4Address() = default;
-
   /**
-   * Constructor with four octets.
+   * Construct an IPv4Address object from a byte array.
    *
-   * @param octet1 The first octet.
-   * @param octet2 The second octet.
-   * @param octet3 The third octet.
-   * @param octet4 The fourth octet.
+   * @param bytes The byte array from which to construct an IPv4Address.
+   * @return The constructed IPv4Address object.
+   * @throws std::invalid_argument If an IPv4Address could not be realized from the input bytes.
    */
-  IPv4Address(std::byte octet1, std::byte octet2, std::byte octet3, std::byte octet4);
+  [[nodiscard]] static IPv4Address fromBytes(const std::vector<std::byte>& bytes);
 
   /**
-   * Creates a new IP address from a string. Supports ascii or byte representation.
+   * Get the byte array representation of this IPv4Address.
    *
-   * @param address The IP address from which to construct, in string form.
-   * @return The new IP address.
-   * @throws std::invalid_argument If the input IPv4Address string is malformed.
+   * @return The byte array representation of this IPv4Address.
    */
-  [[nodiscard]] static IPv4Address fromString(std::string_view address);
+  [[nodiscard]] std::vector<std::byte> toBytes() const;
 
   /**
-   * Get the string representation of this IPv4Address (form is <octet>.<octet>.<octet>.<octet>).
+   * Get the string representation of this IPv4Address.
    *
-   * @return The string represenation of this IPv4Address.
+   * @return The string representation of this IPv4Address.
    */
   [[nodiscard]] std::string toString() const;
 
 private:
   /**
-   * The first octet of the address
+   * The four octets of the address.
    */
-  std::byte mOctet1;
-
-  /**
-   * The second octet of the address
-   */
-  std::byte mOctet2;
-
-  /**
-   * The third octet of the address
-   */
-  std::byte mOctet3;
-
-  /**
-   * The fourth octet of the address
-   */
-  std::byte mOctet4;
+  std::array<std::byte, 4> mAddress;
 };
 
 } // namespace Hedera::internal

--- a/sdk/main/include/impl/MirrorNetwork.h
+++ b/sdk/main/include/impl/MirrorNetwork.h
@@ -20,6 +20,9 @@
 #ifndef HEDERA_SDK_CPP_IMPL_MIRROR_NETWORK_H_
 #define HEDERA_SDK_CPP_IMPL_MIRROR_NETWORK_H_
 
+#include "BaseNetwork.h"
+#include "BaseNodeAddress.h"
+
 #include <memory>
 #include <string>
 #include <unordered_map>
@@ -32,7 +35,7 @@ class MirrorNode;
 
 namespace Hedera::internal
 {
-class MirrorNetwork
+class MirrorNetwork : public BaseNetwork<MirrorNetwork, BaseNodeAddress, MirrorNode>
 {
 public:
   /**
@@ -65,27 +68,38 @@ public:
   [[nodiscard]] static MirrorNetwork forNetwork(const std::vector<std::string>& networkMap);
 
   /**
+   * Set the MirrorNodes in the MirrorNetwork. This will put the input addresses into a map of addresses to
+   * BaseNodeAddresses, and then feed it to BaseNetwork::setNetwork.
+   *
+   * @param network The network to set for this MirrorNetwork.
+   * @return A reference to this MirrorNetwork object with the newly-set network.
+   */
+  MirrorNetwork& setNetwork(const std::vector<std::string>& network);
+
+  /**
+   * Get the addresses of the MirrorNodes in this MirrorNetwork.
+   *
+   * @return The addresses of the MirrorNodes in this MirrorNetwork.
+   */
+  [[nodiscard]] std::vector<std::string> getNetwork() const;
+
+  /**
    * Get a pointer to the next MirrorNode.
    *
    * @return A pointer to the next MirrorNode.
    */
   [[nodiscard]] std::shared_ptr<MirrorNode> getNextMirrorNode() const;
 
-  /**
-   * Initiate an orderly shutdown of communications with the MirrorNodes that are a part of this MirrorNetwork.
-   *
-   * After this method returns, this MirrorNetwork can be re-used. All network communication can be re-established as
-   * needed.
-   */
-  void close() const;
-
 private:
   /**
-   * Establish communications with all MirrorNodes for this MirrorNetwork that are specified in the input address list.
+   * Derived from BaseNetwork. Create a MirrorNode for this MirrorNetwork based on a network entry.
    *
-   * @param addresses The addresses of the MirrorNodes with which this MirrorNetwork will be communicating.
+   * @param address The address of the MirrorNode.
+   * @param key     The key for the MirrorNode. This is unused.
+   * @return A pointer to the created MirrorNode.
    */
-  void setNetwork(const std::vector<std::string>& addresses);
+  [[nodiscard]] std::shared_ptr<MirrorNode> createNodeFromNetworkEntry(std::string_view address,
+                                                                       const BaseNodeAddress& /*key*/) const override;
 
   /**
    * The list of pointers to MirrorNodes with which this MirrorNetwork is communicating.

--- a/sdk/main/include/impl/MirrorNetwork.h
+++ b/sdk/main/include/impl/MirrorNetwork.h
@@ -100,11 +100,6 @@ private:
    */
   [[nodiscard]] std::shared_ptr<MirrorNode> createNodeFromNetworkEntry(std::string_view address,
                                                                        const BaseNodeAddress& /*key*/) const override;
-
-  /**
-   * The list of pointers to MirrorNodes with which this MirrorNetwork is communicating.
-   */
-  std::vector<std::shared_ptr<MirrorNode>> mNodes;
 };
 
 } // namespace Hedera::internal

--- a/sdk/main/include/impl/MirrorNode.h
+++ b/sdk/main/include/impl/MirrorNode.h
@@ -22,174 +22,79 @@
 
 #include <proto/mirror/consensus_service.grpc.pb.h>
 
-#include "Defaults.h"
-#include "impl/NodeAddress.h"
-#include "impl/TLSBehavior.h"
+#include "BaseNode.h"
 
-#include <functional>
-#include <grpcpp/channel.h>
-#include <grpcpp/security/credentials.h>
 #include <memory>
-#include <string>
 #include <string_view>
-#include <utility>
 
-namespace grpc
+namespace Hedera::internal
 {
-class ClientContext;
-class Status;
-}
-
-namespace proto
-{
-class Query;
-class Response;
-class Transaction;
-class TransactionResponse;
+class BaseNodeAddress;
 }
 
 namespace Hedera::internal
 {
 /**
- * Internal utility class used to represent a node on a Hedera network.
+ * Internal utility class used to represent a mirror node on a Hedera network.
  */
-class MirrorNode
+class MirrorNode : public BaseNode<MirrorNode, BaseNodeAddress>
 {
 public:
   /**
-   * Construct this MirrorNode from a string which contains the IP and port with which to connect.
+   * Construct with the address of the MirrorNode.
    *
-   * @param address The address to which to connect.
+   * @param address The address of the MirrorNode.
+   */
+  explicit MirrorNode(const BaseNodeAddress& address);
+
+  /**
+   * Construct with the address of the MirrorNode as a string.
+   *
+   * @param address The address of the MirrorNode as a string.
    */
   explicit MirrorNode(std::string_view address);
 
   /**
-   * Attempt to connect this MirrorNode to the remote mirror node.
+   * Derived from BaseNode. Get this MirrorNode's key, which is its BaseNodeAddress.
    *
-   * @param timeout The point in time that the attempted connection will cease and be considered a failure.
-   * @return \c TRUE if the Node is already connected or successfully connected, otherwise \c FALSE.
+   * @return This MirrorNode's key, which is its BaseNodeAddress.
    */
-  bool connect(const std::chrono::system_clock::time_point& timeout);
+  [[nodiscard]] inline BaseNodeAddress getKey() const override { return getAddress(); }
 
   /**
-   * Shutdown the connection from this MirrorNode to the remote mirror node.
-   */
-  void shutdown();
-
-  /**
-   * Set the minimum amount of time this Node should wait before being willing to resubmit a previously failed request
-   * to its remote node.
+   * Get a pointer to the ConsensusService stub used by this MirrorNode.
    *
-   * @param backoff The minimum backoff time.
+   * @return A pointer ot the ConsensusService stub used by this MirrorNode.
    */
-  void setMinBackoff(const std::chrono::duration<double>& backoff);
-
-  /**
-   * Set the maximum amount of time this Node should wait before being willing to resubmit a previously failed request
-   * to its remote node.
-   *
-   * @param backoff The maximum backoff time.
-   */
-  void setMaxBackoff(const std::chrono::duration<double>& backoff);
-
-  /**
-   * Determine if this Node is "healthy", meaning this Node has received a gRPC status responses from its remote node
-   * that indicates a successful request attempt, or if it has fully backed off for its full period of backoff time
-   * after an unsuccessful submission attempt.
-   *
-   * @return \c TRUE if this Node is "healthy", otherwise \c FALSE.
-   */
-  [[nodiscard]] bool isHealthy() const;
-
-  /**
-   * Increase the backoff of this Node. This should be called when this Node either fails to connect to its remote node
-   * or it receives a gRPC status from its remote node that indicates a failed submission attempt.
-   */
-  void increaseBackoff();
-
-  /**
-   * Decrease the backoff of this Node. This should be called when this Node successfully submits a request to its
-   * remote node.
-   */
-  void decreaseBackoff();
-
-  /**
-   * Get the amount of time remaining in this Node's current backoff.
-   *
-   * @return The amount of time that should pass before this Node is good to try and submit another request.
-   */
-  [[nodiscard]] std::chrono::duration<double> getRemainingTimeForBackoff() const;
-
-  /**
-   * Get the consensus service stub.
-   *
-   * @return The consensus service stub.
-   */
-  [[nodiscard]] inline std::shared_ptr<com::hedera::mirror::api::proto::ConsensusService::Stub>
-  getConsensusServiceStub() const
+  [[nodiscard]] std::shared_ptr<com::hedera::mirror::api::proto::ConsensusService::Stub> getConsensusServiceStub() const
   {
     return mConsensusStub;
   }
 
 private:
   /**
-   * Initialize the gRPC channel used to communicate with this Node's remote node based on mTLSBehavior.
+   * Derived from BaseNode. Get the authority of this MirrorNode.
    *
-   * @param deadline The deadline to connect. Processing will continue trying until this point to establish a connection
-   *                 and will return \c FALSE if not established by then.
-   * @return \c TRUE if initialization was successful, otherwise \c FALSE.
+   * @return There is no MirrorNode authority, so returns an empty string;
    */
-  bool initializeChannel(const std::chrono::system_clock::time_point& deadline);
+  [[nodiscard]] inline std::string getAuthority() const override { return {}; }
 
   /**
-   * The address of the MirrorNode.
+   * Derived from BaseNode. Initialize the stubs in this MirrorNode with a gRPC channel.
+   *
+   * @param channel The gRPC channel with which to initialize the stubs.
    */
-  std::string mAddress;
+  void initializeStubs(const std::shared_ptr<grpc::Channel>& channel) override;
 
   /**
-   * Pointer to this Node's TLS channel credentials. This only depends on the NodeAddress so this will be updated
-   * whenever mAddress is.
+   * Derived from BaseNode. Close the stubs in this MirrorNode.
    */
-  std::shared_ptr<grpc::ChannelCredentials> mTlsChannelCredentials = nullptr;
-
-  /**
-   * Pointer to the gRPC channel used to communicate with the gRPC server living on the remote node.
-   */
-  std::shared_ptr<grpc::Channel> mChannel = nullptr;
+  void closeStubs() override;
 
   /**
    * Pointer to the gRPC stub used to communicate with the consensus service living on the remote mirror node.
    */
   std::shared_ptr<com::hedera::mirror::api::proto::ConsensusService::Stub> mConsensusStub = nullptr;
-
-  /**
-   * The point in time that this Node would be considered healthy again.
-   */
-  std::chrono::system_clock::time_point mReadmitTime = std::chrono::system_clock::now();
-
-  /**
-   * The minimum length of time this Node should wait before being willing to attempt to send a failed request to its
-   * remote node again.
-   */
-  std::chrono::duration<double> mMinBackoff = DEFAULT_MIN_BACKOFF;
-
-  /**
-   * The maximum length of time this Node should wait before being willing to attempt to send a failed request to its
-   * remote node again.
-   */
-  std::chrono::duration<double> mMaxBackoff = DEFAULT_MAX_BACKOFF;
-
-  /**
-   * The current backoff time. Every failed submission attempt waits a certain amount of time that is double the
-   * previous amount of time a request waited for its previous submission attempt, up to the specified maximum backoff
-   * time, at which point the execution is considered a failure.
-   */
-  std::chrono::duration<double> mCurrentBackoff = mMinBackoff;
-
-  /**
-   * Is the gRPC channel being utilized by this Node to communicate with its remote node initialized?
-   */
-  bool mIsInitialized = false;
 };
 
 } // namespace Hedera::internal

--- a/sdk/main/include/impl/Network.h
+++ b/sdk/main/include/impl/Network.h
@@ -20,7 +20,7 @@
 #ifndef HEDERA_SDK_CPP_IMPL_NETWORK_H_
 #define HEDERA_SDK_CPP_IMPL_NETWORK_H_
 
-#include "AccountId.h"
+#include "BaseNetwork.h"
 #include "Node.h"
 #include "NodeAddressBook.h"
 #include "TLSBehavior.h"
@@ -37,7 +37,7 @@ class AccountId;
 
 namespace Hedera::internal
 {
-class Network
+class Network : public BaseNetwork<Network, AccountId, Node>
 {
 public:
   /**
@@ -62,41 +62,98 @@ public:
   [[nodiscard]] static Network forPreviewnet();
 
   /**
-   * Construct a Network that is pre-configured for local node access.
+   * Construct a custom Network.
    *
-   * @param networkMap The map with string representation of node addresses with their corresponding accountId.
-   * @return A Network object that is set-up to communicate with a specific node addresses.
+   * @param network The map with string representation of node addresses with their corresponding AccountIds.
+   * @return A Network object that is set-up to communicate with the custom network.
    */
-  [[nodiscard]] static Network forNetwork(const std::unordered_map<std::string, AccountId>& networkMap);
+  [[nodiscard]] static Network forNetwork(const std::unordered_map<std::string, AccountId>& network);
 
   /**
-   * Get a list of Node pointers that point to Nodes on this Network that are associated with the input account IDs. If
-   * no account IDs are specified, pointers to all Nodes on this Network are returned.
+   * Derived from BaseNetwork. Set the ledger ID of this Network.
    *
-   * @param accountIds The IDs of the accounts that are associated with the desired Nodes.
-   * @return A list of Node pointers that point to Nodes with the requested account IDs.
+   * @param ledgerId The ledger ID to set.
+   * @return A reference to this Network object with the newly-set ledger ID.
    */
-  [[nodiscard]] std::vector<std::shared_ptr<Node>> getNodesWithAccountIds(
-    const std::vector<AccountId>& accountIds) const;
+  Network& setLedgerId(const LedgerId& ledgerId) override;
 
   /**
-   * Initiate an orderly shutdown of communications with the Nodes that are a part of this Network. Preexisting
-   * transactions or queries continue but subsequent calls would be immediately cancelled.
+   * Set this Network's certificate verification policy.
    *
-   * After this method returns, this Network can be re-used. All network communication can be re-established as needed.
+   * @param verify \c TRUE if this Network should verify remote node certificates, otherwise \c FALSE.
+   * @return A reference to this Network object with the newly-set certificate verification policy.
    */
-  void close() const;
+  Network& setVerifyCertificates(bool verify);
 
   /**
-   * Set the TLS behavior of all Nodes on this Network.
+   * Set this Network's transport security policy.
    *
-   * @param desiredBehavior The desired behavior.
+   * @param tls The transport security policy to set.
+   * @return A reference to this Network object with the newly-set transport security policy.
    * @throws UninitializedException If TLS is required and a Node on this Network wasn't initialized with a certificate
    *                                hash.
    */
-  void setTLSBehavior(TLSBehavior desiredBehavior) const;
+  Network& setTransportSecurity(TLSBehavior tls);
+
+  /**
+   * Get a list of node account IDs on which to execute. This will pick 1/3 of the available nodes sorted by health and
+   * expected delay from the network.
+   *
+   * @return A list of AccountIds that are running nodes on which should be executed.
+   */
+  [[nodiscard]] std::vector<AccountId> getNodeAccountIdsForExecute();
+
+  /**
+   * Get a map of this Network, mapping the Node addresses to their AccountIds.
+   *
+   * @return A map of this Network, mapping the Node addresses to their AccountIds.
+   */
+  [[nodiscard]] std::unordered_map<std::string, AccountId> getNetwork() const;
 
 private:
+  /**
+   * Construct with a network map.
+   *
+   * @param network A map of node addresses to the AccountIds that run those nodes.
+   */
+  explicit Network(const std::unordered_map<std::string, AccountId>& network);
+
+  /**
+   * Construct a Network object configured to communicate with the network represented by the input LedgerId.
+   *
+   * @param ledgerId The LedgerId of the Network object to construct.
+   * @return The constructed Network object.
+   */
+  [[nodiscard]] static Network getNetworkForLedgerId(const LedgerId& ledgerId);
+
+  /**
+   * Get a map of AccountIds to NodeAddresses from a local file for a network based on the input LedgerId.
+   *
+   * @param ledgerId The LedgerId of the network of which to get the address book.
+   * @return The map of node addresses and AccountIds of the Nodes that exist on the network represented by the input
+   *         LedgerId.
+   */
+  [[nodiscard]] static std::unordered_map<AccountId, NodeAddress> getAddressBookForLedgerId(const LedgerId& ledgerId);
+
+  /**
+   * Derived from BaseNetwork. Create a Node for this Network based on a network entry.
+   *
+   * @param address The address of the Node.
+   * @param key     The key for the Node.
+   * @return A pointer to the created Node.
+   */
+  [[nodiscard]] std::shared_ptr<Node> createNodeFromNetworkEntry(std::string_view address,
+                                                                 const AccountId& key) const override;
+
+  /**
+   * Set the ledger ID of this Network. In addition, update the Nodes on this Network with their address book entry
+   * contained in the input map.
+   *
+   * @param ledgerId    The new LedgerId of the Network.
+   * @param addressBook The address book with which to update this Network's Node's address book entry.
+   */
+  Network& setLedgerIdInternal(const LedgerId& ledgerId, const std::unordered_map<AccountId, NodeAddress>& addressBook);
+
   /**
    * Establish communications with all Nodes for this Network that are specified in the input address book.
    *
@@ -118,9 +175,14 @@ private:
   void setNetwork(const std::unordered_map<std::string, AccountId>& networkMap, TLSBehavior tls = TLSBehavior::DISABLE);
 
   /**
-   * The list of pointers to Nodes with which this Network is communicating.
+   * The maximum number of nodes to be returned for each request.
    */
-  std::vector<std::shared_ptr<Node>> mNodes;
+  unsigned int mMaxNodesPerRequest = 0U;
+
+  /**
+   * Should the Nodes on this Network verify remote node certificates?
+   */
+  bool mVerifyCertificates = true;
 };
 
 } // namespace Hedera::internal

--- a/sdk/main/include/impl/Network.h
+++ b/sdk/main/include/impl/Network.h
@@ -155,26 +155,6 @@ private:
   Network& setLedgerIdInternal(const LedgerId& ledgerId, const std::unordered_map<AccountId, NodeAddress>& addressBook);
 
   /**
-   * Establish communications with all Nodes for this Network that are specified in the input address book.
-   *
-   * @param nodeAddressBook The address book that contains the Nodes with which this Network will be communicating.
-   * @param tls The TLS behavior all nodes should initially use. Default value is REQUIRE.
-   * @throws UninitializedException If a NodeAddress in the input NodeAddressBook wasn't initialized with a certificate
-   *                                hash.
-   */
-  void setNetwork(const NodeAddressBook& nodeAddressBook, TLSBehavior tls = TLSBehavior::REQUIRE);
-
-  /**
-   * Establish communications with all node addresses for this Network that are specified in the input map collection.
-   *
-   * @param networkMap The map containing string node addresses pointing to specific accountId object.
-   * @param tls The TLS behavior all nodes should initially use. Default value is DISABLE.
-   * @throws UninitializedException If a NodeAddress in the input NodeAddressBook wasn't initialized with a certificate
-   *         hash.
-   */
-  void setNetwork(const std::unordered_map<std::string, AccountId>& networkMap, TLSBehavior tls = TLSBehavior::DISABLE);
-
-  /**
    * The maximum number of nodes to be returned for each request.
    */
   unsigned int mMaxNodesPerRequest = 0U;

--- a/sdk/main/include/impl/Network.h
+++ b/sdk/main/include/impl/Network.h
@@ -96,6 +96,14 @@ public:
   Network& setTransportSecurity(TLSBehavior tls);
 
   /**
+   * Set the maximum number of nodes to be returned for each request.
+   *
+   * @param max The maximum number of nodes to be returned for each request.
+   * @return A reference to this Network object with the newly-set maximum nodes per request.
+   */
+  Network& setMaxNodesPerRequest(unsigned int max);
+
+  /**
    * Get a list of node account IDs on which to execute. This will pick 1/3 of the available nodes sorted by health and
    * expected delay from the network.
    *

--- a/sdk/main/include/impl/Node.h
+++ b/sdk/main/include/impl/Node.h
@@ -94,18 +94,18 @@ public:
                                  proto::TransactionResponse* response);
 
   /**
-   * Construct an insecure version of this Node.
+   * Construct an insecure version of this Node. This will close the Node's current connection.
    *
-   * @return A pointer to an insecure version of this Node.
+   * @return A reference to this Node, now using an insecure connection.
    */
-  [[nodiscard]] std::shared_ptr<Node> toInsecure() const;
+  Node& toInsecure();
 
   /**
-   * Construct a secure version of this Node.
+   * Construct a secure version of this Node. This will close the Node's current connection.
    *
-   * @return A pointer to a secure version of this Node.
+   * @return A reference to this Node, now using a secure connection.
    */
-  [[nodiscard]] std::shared_ptr<Node> toSecure() const;
+  Node& toSecure();
 
   /**
    * Set the node certificate hash of this Node.

--- a/sdk/main/include/impl/Node.h
+++ b/sdk/main/include/impl/Node.h
@@ -28,46 +28,42 @@
 #include <proto/smart_contract_service.grpc.pb.h>
 #include <proto/token_service.grpc.pb.h>
 
-#include "Defaults.h"
-#include "impl/NodeAddress.h"
-#include "impl/TLSBehavior.h"
+#include "AccountId.h"
+#include "BaseNode.h"
 
-#include <functional>
-#include <grpcpp/channel.h>
-#include <grpcpp/security/credentials.h>
+#include <cstddef>
 #include <memory>
-#include <string>
-#include <utility>
+#include <string_view>
+#include <vector>
+
+namespace Hedera::internal
+{
+class BaseNodeAddress;
+}
 
 namespace Hedera::internal
 {
 /**
  * Internal utility class used to represent a node on a Hedera network.
  */
-class Node
+class Node : public BaseNode<Node, AccountId>
 {
 public:
   /**
-   * Construct this Node with the NodeAddress of the remote node it is meant to represent.
+   * Construct with the AccountId that's running this Node and the address of the Node.
    *
-   * @param address A pointer to the desired NodeAddress for this Node.
-   * @param tls     The TLS behavior this Node should initially use.
-   * @throws UninitializedException If TLS is required and the input NodeAddress doesn't contain a certificate hash.
+   * @param accountId The AccountId that runs the remote node represented by this Node.
+   * @param address   The address of the Node.
    */
-  explicit Node(std::shared_ptr<NodeAddress> address, TLSBehavior tls = TLSBehavior::REQUIRE);
+  explicit Node(AccountId accountId, const BaseNodeAddress& address);
 
   /**
-   * Attempt to connect this Node to the remote node.
+   * Construct with the AccountId that's running this Node and the address of the Node as a string.
    *
-   * @param timeout The point in time that the attempted connection will cease and be considered a failure.
-   * @return \c TRUE if the Node is already connected or successfully connected, otherwise \c FALSE.
+   * @param accountId The AccountId that runs the remote node represented by this Node.
+   * @param address   The address of the Node as a string.
    */
-  bool connect(const std::chrono::system_clock::time_point& timeout);
-
-  /**
-   * Shutdown the connection from this Node to the remote node.
-   */
-  void shutdown();
+  explicit Node(const AccountId& accountId, std::string_view address);
 
   /**
    * Submit a Query protobuf to the remote node with which this Node is communicating.
@@ -98,89 +94,90 @@ public:
                                  proto::TransactionResponse* response);
 
   /**
-   * Set the TLS behavior this Node should utilize when communicating with its remote node.
+   * Construct an insecure version of this Node.
    *
-   * @param desiredBehavior The desired behavior.
-   * @throws UninitializedException If TLS is required and this Node's NodeAddress doesn't contain a certificate hash.
+   * @return A pointer to an insecure version of this Node.
    */
-  void setTLSBehavior(TLSBehavior desiredBehavior);
+  [[nodiscard]] std::shared_ptr<Node> toInsecure() const;
 
   /**
-   * Set the minimum amount of time this Node should wait before being willing to resubmit a previously failed request
-   * to its remote node.
+   * Construct a secure version of this Node.
    *
-   * @param backoff The minimum backoff time.
+   * @return A pointer to a secure version of this Node.
    */
-  void setMinBackoff(const std::chrono::duration<double>& backoff);
+  [[nodiscard]] std::shared_ptr<Node> toSecure() const;
 
   /**
-   * Set the maximum amount of time this Node should wait before being willing to resubmit a previously failed request
-   * to its remote node.
+   * Set the node certificate hash of this Node.
    *
-   * @param backoff The maximum backoff time.
+   * @param hash The node certificate hash to set.
+   * @return A reference to this Node with the newly-set node certificate hash.
    */
-  void setMaxBackoff(const std::chrono::duration<double>& backoff);
+  Node& setNodeCertificateHash(const std::vector<std::byte>& hash);
 
   /**
-   * Determine if this Node is "healthy", meaning this Node has received a gRPC status responses from its remote node
-   * that indicates a successful request attempt, or if it has fully backed off for its full period of backoff time
-   * after an unsuccessful submission attempt.
+   * Set the certificate verification policy of this Node.
    *
-   * @return \c TRUE if this Node is "healthy", otherwise \c FALSE.
+   * @param verify \c TRUE if this Node should verify certificates, otherwise \c FALSE.
+   * @return A reference to this Node with the newly-set certificate verification policy.
    */
-  [[nodiscard]] bool isHealthy() const;
+  Node& setVerifyCertificates(bool verify);
 
   /**
-   * Increase the backoff of this Node. This should be called when this Node either fails to connect to its remote node
-   * or it receives a gRPC status from its remote node that indicates a failed submission attempt.
-   */
-  void increaseBackoff();
-
-  /**
-   * Decrease the backoff of this Node. This should be called when this Node successfully submits a request to its
-   * remote node.
-   */
-  void decreaseBackoff();
-
-  /**
-   * Get the amount of time remaining in this Node's current backoff.
+   * Derived from BaseNode. Get this Node's key, which is its AccountId.
    *
-   * @return The amount of time that should pass before this Node is good to try and submit another request.
+   * @return This Node's key, which is its AccountId.
    */
-  [[nodiscard]] std::chrono::duration<double> getRemainingTimeForBackoff() const;
+  [[nodiscard]] inline AccountId getKey() const override { return getAccountId(); };
 
   /**
-   * Get the ID of the account associated with this Node.
+   * Get the AccountId of this Node.
    *
-   * @return The ID of the account associated with this Node.
+   * @return The AccountId of this Node.
    */
-  [[nodiscard]] inline AccountId getAccountId() const { return mAddress->getNodeAccountId(); }
+  [[nodiscard]] inline AccountId getAccountId() const { return mAccountId; };
+
+  /**
+   * Get the node certificate hash of this Node.
+   *
+   * @return The node certificate hash of this Node.
+   */
+  [[nodiscard]] inline std::vector<std::byte> getNodeCertificateHash() const { return mNodeCertificateHash; }
+
+  /**
+   * Get the certificate verification policy of this Node.
+   *
+   * @return \c TRUE if this Node is currently configured to verify certificates, otherwise \c FALSE.
+   */
+  [[nodiscard]] inline bool getVerifyCertificates() const { return mVerifyCertificates; }
 
 private:
   /**
-   * Initialize the gRPC channel used to communicate with this Node's remote node based on mTLSBehavior.
+   * Construct from another Node and a BaseNodeAddress.
    *
-   * @param deadline The deadline to connect. Processing will continue trying until this point to establish a connection
-   *                 and will return \c FALSE if not established by then.
-   * @return \c TRUE if initialization was successful, otherwise \c FALSE.
+   * @param node    The Node from which to construct.
+   * @param address The address of the Node.
    */
-  bool initializeChannel(const std::chrono::system_clock::time_point& deadline);
+  explicit Node(const Node& node, const BaseNodeAddress& address);
 
   /**
-   * Pointer to the NodeAddress of this Node.
+   * Derived from BaseNode. Get the TLS credentials of this Node's gRPC channel.
+   *
+   * @return A pointer to the TLS credentials for this Node's gRPC channel.
    */
-  std::shared_ptr<NodeAddress> mAddress = nullptr;
+  [[nodiscard]] std::shared_ptr<grpc::ChannelCredentials> getTlsChannelCredentials() const override;
 
   /**
-   * Pointer to this Node's TLS channel credentials. This only depends on the NodeAddress so this will be updated
-   * whenever mAddress is.
+   * Derived from BaseNode. Initialize the stubs in this Node with a gRPC channel.
+   *
+   * @param channel The gRPC channel with which to initialize the stubs.
    */
-  std::shared_ptr<grpc::ChannelCredentials> mTlsChannelCredentials = nullptr;
+  void initializeStubs(const std::shared_ptr<grpc::Channel>& channel) override;
 
   /**
-   * Pointer to the gRPC channel used to communicate with the gRPC server living on the remote node.
+   * Derived from BaseNode. Close the stubs in this Node.
    */
-  std::shared_ptr<grpc::Channel> mChannel = nullptr;
+  void closeStubs() override;
 
   /**
    * Pointer to the gRPC stub used to communicate with the consensus service living on the remote node.
@@ -218,38 +215,19 @@ private:
   std::unique_ptr<proto::TokenService::Stub> mTokenStub = nullptr;
 
   /**
-   * The TLS behavior this Node should use to communicate with its remote node.
+   * The AccountId that runs the remote node represented by this Node.
    */
-  TLSBehavior mTLSBehavior = TLSBehavior::REQUIRE;
+  AccountId mAccountId;
 
   /**
-   * The point in time that this Node would be considered healthy again.
+   * The node certificate hash of this Node.
    */
-  std::chrono::system_clock::time_point mReadmitTime = std::chrono::system_clock::now();
+  std::vector<std::byte> mNodeCertificateHash;
 
   /**
-   * The minimum length of time this Node should wait before being willing to attempt to send a failed request to its
-   * remote node again.
+   * Should this Node verify the certificates coming from the remote node?
    */
-  std::chrono::duration<double> mMinBackoff = DEFAULT_MIN_BACKOFF;
-
-  /**
-   * The maximum length of time this Node should wait before being willing to attempt to send a failed request to its
-   * remote node again.
-   */
-  std::chrono::duration<double> mMaxBackoff = DEFAULT_MAX_BACKOFF;
-
-  /**
-   * The current backoff time. Every failed submission attempt waits a certain amount of time that is double the
-   * previous amount of time a request waited for its previous submission attempt, up to the specified maximum backoff
-   * time, at which point the execution is considered a failure.
-   */
-  std::chrono::duration<double> mCurrentBackoff = mMinBackoff;
-
-  /**
-   * Is the gRPC channel being utilized by this Node to communicate with its remote node initialized?
-   */
-  bool mIsInitialized = false;
+  bool mVerifyCertificates = false;
 };
 
 } // namespace Hedera::internal

--- a/sdk/main/include/impl/NodeAddress.h
+++ b/sdk/main/include/impl/NodeAddress.h
@@ -69,7 +69,7 @@ public:
    * @param publicKey The hex-encoded and DER-encoded public key to set.
    * @return A reference to this NodeAddress with the newly-set public key.
    */
-  NodeAddress& setRSAPublicKey(std::string_view publicKey);
+  NodeAddress& setPublicKey(std::string_view publicKey);
 
   /**
    * Set the node ID of this NodeAddress.
@@ -85,7 +85,7 @@ public:
    * @param accountId The account ID to set.
    * @return A reference to this NodeAddress with the newly-set account ID.
    */
-  NodeAddress& setNodeAccountId(const AccountId& accountId);
+  NodeAddress& setAccountId(const AccountId& accountId);
 
   /**
    * Set the certificate hash of this NodeAddress. This should be hex-encoded SHA384 hash of the UTF-8 NFKD encoding of
@@ -94,7 +94,8 @@ public:
    * @param certHash The certificate hash to set.
    * @return A reference to this NodeAddress with the newly-set certificate hash.
    */
-  NodeAddress& setNodeCertHash(std::string_view certHash);
+  NodeAddress& setCertHash(std::string_view certHash);
+  NodeAddress& setCertHash(std::vector<std::byte> certHash);
 
   /**
    * Set the list of endpoints of this NodeAddress.
@@ -131,14 +132,14 @@ public:
    *
    * @return The account ID of this NodeAddress.
    */
-  [[nodiscard]] inline AccountId getNodeAccountId() const { return mNodeAccountId; }
+  [[nodiscard]] inline AccountId getAccountId() const { return mNodeAccountId; }
 
   /**
    * Get the node certificate hash of this NodeAddress.
    *
    * @return The node certificate hash of this NodeAddress.
    */
-  [[nodiscard]] inline std::vector<std::byte> getNodeCertHash() const { return mNodeCertHash; }
+  [[nodiscard]] inline std::vector<std::byte> getCertHash() const { return mNodeCertHash; }
 
   /**
    * Get the list of endpoints of this NodeAddress.
@@ -155,11 +156,6 @@ public:
   [[nodiscard]] inline std::string getDescription() const { return mDescription; }
 
 private:
-  /**
-   * The Endpoints associated with the node.
-   */
-  std::vector<Endpoint> mEndpoints;
-
   /**
    * The node's public key.
    */
@@ -179,6 +175,11 @@ private:
    * The SHA-384 hash of the node's certificate chain.
    */
   std::vector<std::byte> mNodeCertHash;
+
+  /**
+   * The Endpoints associated with the node.
+   */
+  std::vector<Endpoint> mEndpoints;
 
   /**
    * A string description of the node.

--- a/sdk/main/include/impl/NodeAddress.h
+++ b/sdk/main/include/impl/NodeAddress.h
@@ -23,7 +23,9 @@
 #include "AccountId.h"
 #include "impl/Endpoint.h"
 
+#include <cstddef>
 #include <string>
+#include <string_view>
 #include <vector>
 
 namespace proto
@@ -39,126 +41,76 @@ namespace Hedera::internal
 class NodeAddress
 {
 public:
-  NodeAddress() = default;
-
   /**
-   * Construct a NodeAddress instance with a given IPv4 address and port.
+   * Construct a NodeAddress object from a NodeAddress protobuf object.
    *
-   * @param ipAddressV4 The stringified IPv4 address.
-   * @param port        The port number of the server for the node.
-   * @throws std::invalid_argument If the given IP address is malformed.
-   */
-  NodeAddress(std::string_view ipAddressV4, int port);
-
-  /**
-   * Determine if a particular port number corresponds to a TLS port.
-   *
-   * @param port The port number.
-   * @return \c TRUE if the input port number corresponds to a TLS port, otherwise \c FALSE.
-   */
-  static inline bool isTlsPort(int port) { return (port == PORT_NODE_TLS) || (port == PORT_MIRROR_TLS); }
-
-  /**
-   * Determine if a particular port number corresponds to a non-TLS port.
-   *
-   * @param port The port number.
-   * @return \c TRUE if the input port number corresponds to a non-TLS port, otherwise \c FALSE.
-   */
-  static inline bool isNonTlsPort(int port) { return (port == PORT_NODE_PLAIN) || (port == PORT_MIRROR_PLAIN); }
-
-  /**
-   * Create a NodeAddress object from a NodeAddress protobuf object.
-   *
-   * @param protoNodeAddress The NodeAddress protobuf object from which to create a NodeAddress object.
-   * @return The created NodeAddress object.
+   * @param proto The NodeAddress protobuf object from which to construct a NodeAddress object.
+   * @return The constructed NodeAddress object.
    */
   [[nodiscard]] static NodeAddress fromProtobuf(const proto::NodeAddress& protoNodeAddress);
 
   /**
-   * Create a NodeAddress object from a given string.
+   * Construct a NodeAddress protobuf object from this NodeAddress object.
    *
-   * @param nodeAddress The string representation from which to create a new NodeAddress object.
-   * @return The created NodeAddress object.
-   * @throws std::invalid_argument If the given node address is malformed.
+   * @return A pointer to the created NodeAddress protobuf object filled with this NodeAddress object's data.
    */
-  [[nodiscard]] static NodeAddress fromString(std::string_view nodeAddress);
+  [[nodiscard]] std::unique_ptr<proto::NodeAddress> toProtobuf() const;
 
   /**
-   * Set a new public key for the node.
-   *
-   * @param publicKey The public key to be assigned to the node.
-   * @return A reference to this NodeAddress with the newly-set public key.
-   */
-  NodeAddress& setRSAPublicKey(std::string_view publicKey);
-
-  /**
-   * Set a new node ID for the node at this address.
-   *
-   * @param nodeId The ID of the node to set.
-   * @return A reference to this NodeAddress with the newly-set node ID.
-   */
-  NodeAddress& setNodeId(const int64_t& nodeId);
-
-  /**
-   * Set a new account ID associated with the node at this address.
-   *
-   * @param accountId The account ID to be associated with the node.
-   * @return A reference to this NodeAddress with the newly-set account ID.
-   */
-  NodeAddress& setNodeAccountId(const AccountId& accountId);
-
-  /**
-   * Set a new certificate hash for the node.
-   *
-   * @param certHash The certificate hash to be assigned to the node.
-   * @return A reference to this NodeAddress with the newly-set certificate hash.
-   */
-  NodeAddress& setNodeCertHash(std::string_view certHash);
-
-  /**
-   * Set a vector of endpoints for the node.
-   *
-   * @param endpoints The endpoints to be assigned to the node.
-   * @return A reference to this NodeAddress with the newly-set endpoints.
-   */
-  NodeAddress& setEndpoints(const std::vector<std::shared_ptr<Endpoint>>& endpoints);
-
-  /**
-   * Set а new description text for the node.
-   *
-   * @param description The description text to be assigned with the node.
-   * @return A reference to this NodeAddress with the newly-set description.
-   */
-  NodeAddress& setDescription(std::string_view description);
-
-  /**
-   * Set a new amount of tinybars staked to the node.
-   *
-   * @param stake The new amount of tinybars staked to the node.
-   * @return A reference to this NodeAddress with the newly-set staked tinybars.
-   */
-  NodeAddress& setStake(const uint64_t& stake);
-
-  /**
-   * Get a string representation of the NodeAddress.
+   * Get a string representation of this NodeAddress.
    *
    * @return A string representing this NodeAddress.
    */
   [[nodiscard]] std::string toString() const;
 
   /**
-   * Get the default IP address of this NodeAddress.
+   * Set the public key of this NodeAddress. This should be a hex-encoded string of the public key's DER encoding.
    *
-   * @return The default IP address of this NodeAddress.
+   * @param publicKey The hex-encoded and DER-encoded public key to set.
+   * @return A reference to this NodeAddress with the newly-set public key.
    */
-  [[nodiscard]] inline IPv4Address getDefaultIpAddress() const { return getDefaultEndpoint()->getAddress(); }
+  NodeAddress& setRSAPublicKey(std::string_view publicKey);
 
   /**
-   * Get the default port number of the gRPC server of this NodeAddress.
+   * Set the node ID of this NodeAddress.
    *
-   * @return The default port of this NodeAddress.
+   * @param nodeId The node ID to set.
+   * @return A reference to this NodeAddress with the newly-set node ID.
    */
-  [[nodiscard]] inline int getDefaultPort() const { return getDefaultEndpoint()->getPort(); }
+  NodeAddress& setNodeId(const int64_t& nodeId);
+
+  /**
+   * Set the account ID of this NodeAddress.
+   *
+   * @param accountId The account ID to set.
+   * @return A reference to this NodeAddress with the newly-set account ID.
+   */
+  NodeAddress& setNodeAccountId(const AccountId& accountId);
+
+  /**
+   * Set the certificate hash of this NodeAddress. This should be hex-encoded SHA384 hash of the UTF-8 NFKD encoding of
+   * the remote node's TLS cert in PEM format.
+   *
+   * @param certHash The certificate hash to set.
+   * @return A reference to this NodeAddress with the newly-set certificate hash.
+   */
+  NodeAddress& setNodeCertHash(std::string_view certHash);
+
+  /**
+   * Set the list of endpoints of this NodeAddress.
+   *
+   * @param endpoints The list of endpoints to set.
+   * @return A reference to this NodeAddress with the newly-set endpoints.
+   */
+  NodeAddress& setEndpoints(const std::vector<Endpoint>& endpoints);
+
+  /**
+   * Set the description text of this NodeAddress.
+   *
+   * @param description The description text to set.
+   * @return A reference to this NodeAddress with the newly-set description.
+   */
+  NodeAddress& setDescription(std::string_view description);
 
   /**
    * Get the node ID of this NodeAddress.
@@ -170,45 +122,30 @@ public:
   /**
    * Get the public key of this NodeAddress.
    *
-   * @return The hash value representing the public key of the node.
+   * @return The public key of this NodeAddress.
    */
   [[nodiscard]] inline std::string getPublicKey() const { return mRSAPublicKey; }
 
   /**
-   * Get the account ID associated with this NodeAddress.
+   * Get the account ID of this NodeAddress.
    *
-   * @return The account ID associated with this NodeAddress.
+   * @return The account ID of this NodeAddress.
    */
   [[nodiscard]] inline AccountId getNodeAccountId() const { return mNodeAccountId; }
 
   /**
-   * Get the SHA-384 hash of this NodeAddress's certificate chain.
+   * Get the node certificate hash of this NodeAddress.
    *
-   * @return The SHA-384 hash of this NodeAddress's certificate chain.
+   * @return The node certificate hash of this NodeAddress.
    */
   [[nodiscard]] inline std::vector<std::byte> getNodeCertHash() const { return mNodeCertHash; }
 
   /**
-   * Get the default Endpoint of this NodeAddress.
+   * Get the list of endpoints of this NodeAddress.
    *
-   * @return The default Endpoint of this NodeAddress.
+   * @return The list of endpoints of this NodeAddress.
    */
-  [[nodiscard]] inline std::shared_ptr<Endpoint> getDefaultEndpoint() const
-  {
-    if (mEndpoints.empty())
-    {
-      return nullptr;
-    }
-
-    return mEndpoints.front();
-  }
-
-  /**
-   * Get the Endpoints associated with this NodeAddress.
-   *
-   * @return The Endpoints associated with this NodeAddress.
-   */
-  [[nodiscard]] inline const std::vector<std::shared_ptr<Endpoint>>& getEndpoints() const { return mEndpoints; }
+  [[nodiscard]] inline const std::vector<Endpoint>& getEndpoints() const { return mEndpoints; }
 
   /**
    * Get the description text of this NodeAddress.
@@ -217,26 +154,11 @@ public:
    */
   [[nodiscard]] inline std::string getDescription() const { return mDescription; }
 
-  /**
-   * Get the amount of tinybars staked to the Node at this NodeAddress.
-   *
-   * @return The amount of tinybars staked to the Node at this NodeAddress.
-   */
-  [[nodiscard]] inline uint64_t getStake() const { return mStake; }
-
 private:
-  /**
-   * Port numbers for various node types and security.
-   */
-  static constexpr int PORT_MIRROR_PLAIN = 5600;
-  static constexpr int PORT_MIRROR_TLS = 443;
-  static constexpr int PORT_NODE_PLAIN = 50211;
-  static constexpr int PORT_NODE_TLS = 50212;
-
   /**
    * The Endpoints associated with the node.
    */
-  std::vector<std::shared_ptr<Endpoint>> mEndpoints;
+  std::vector<Endpoint> mEndpoints;
 
   /**
    * The node's public key.
@@ -262,11 +184,6 @@ private:
    * A string description of the node.
    */
   std::string mDescription;
-
-  /**
-   * The amount of tinybars staked to the node.
-   */
-  uint64_t mStake = 0;
 };
 
 } // namespace Hedera::internal

--- a/sdk/main/include/impl/NodeAddressBook.h
+++ b/sdk/main/include/impl/NodeAddressBook.h
@@ -20,17 +20,14 @@
 #ifndef HEDERA_SDK_CPP_IMPL_NODE_ADDRESS_BOOK_H_
 #define HEDERA_SDK_CPP_IMPL_NODE_ADDRESS_BOOK_H_
 
-#include "AccountId.h"
 #include "impl/NodeAddress.h"
 
-#include <memory>
-#include <string_view>
-#include <unordered_map>
+#include <cstddef>
+#include <vector>
 
 namespace proto
 {
 class NodeAddressBook;
-class NodeAddress;
 }
 
 namespace Hedera::internal
@@ -42,54 +39,55 @@ class NodeAddressBook
 {
 public:
   /**
-   * Construct a NodeAddressBook object from a file that contains the serialization of a NodeAddressBook protobuf
-   * object.
+   * Construct a NodeAddressBook object from a NodeAddressBook protobuf object.
    *
-   * @param fileName The name of the file where the NodeAddressBook protobuf object is encoded.
+   * @param proto The NodeAddressBook protobuf object from which to construct a NodeAddressBook object.
    * @return The constructed NodeAddressBook object.
    */
-  [[nodiscard]] static NodeAddressBook fromFile(std::string_view fileName);
+  [[nodiscard]] static NodeAddressBook fromProtobuf(const proto::NodeAddressBook& proto);
 
   /**
-   * Construct a NodeAddressBook object from the byte serialization of a NodeAddressBook protobuf object.
+   * Construct a NodeAddressBook object from a byte array.
    *
-   * @param bytes The byte serialization of the NodeAddressBook protobuf object to decode.
+   * @param bytes The byte array from which to construct a NodeAddressBook object.
    * @return The constructed NodeAddressBook object.
    */
   [[nodiscard]] static NodeAddressBook fromBytes(const std::vector<char>& bytes);
 
   /**
-   * Construct a NodeAddressBook object from a NodeAddressBook protobuf object.
+   * Construct a NodeAddressBook protobuf object from this NodeAddressBook object.
    *
-   * @param protoAddressBook The NodeAddressBook protobuf object from which to create a NodeAddressBook object.
-   * @return The constructed NodeAddressBook object.
+   * @return A pointer to the created NodeAddressBook protobuf object filled with this NodeAddressBook object's data.
    */
-  [[nodiscard]] static NodeAddressBook fromProtobuf(const proto::NodeAddressBook& protoAddressBook);
+  [[nodiscard]] std::unique_ptr<proto::NodeAddressBook> toProtobuf() const;
 
   /**
-   * Construct a NodeAddressBook object from an address map.
+   * Get the byte array representation of this NodeAddressBook.
    *
-   * @param addressMap The address map containing accountId to node address relations.
-   * @return The constructed NodeAddressBook object.
+   * @return The byte array representation of this NodeAddressBook.
    */
-  [[nodiscard]] static NodeAddressBook fromAddressMap(
-    const std::unordered_map<AccountId, std::shared_ptr<NodeAddress>>& addressMap);
+  [[nodiscard]] std::vector<std::byte> toBytes() const;
 
   /**
-   * Get a map of AccountIds to NodeAddresses contained in this NodeAddressBook.
+   * Set the list of NodeAddresses in this NodeAddressBook.
    *
-   * @return A map of AccountIds to NodeAddresses contained in this NodeAddressBook.
+   * @param addresses The list of NodeAddresses to set.
+   * @return A reference to this NodeAddressBook with the newly-set NodeAddress list.
    */
-  [[nodiscard]] inline const std::unordered_map<AccountId, std::shared_ptr<NodeAddress>>& getAddressMap() const
-  {
-    return mAddressMap;
-  }
+  NodeAddressBook& setNodeAddresses(const std::vector<NodeAddress>& addresses);
+
+  /**
+   * Get the list of NodeAddresses.
+   *
+   * @return The list of NodeAddresses.
+   */
+  [[nodiscard]] inline std::vector<NodeAddress> getNodeAddresses() const { return mNodeAddresses; }
 
 private:
   /**
-   * A map from AccountId's to NodeAddresses.
+   * The list of NodeAddresses.
    */
-  std::unordered_map<AccountId, std::shared_ptr<NodeAddress>> mAddressMap;
+  std::vector<NodeAddress> mNodeAddresses;
 };
 
 } // namespace Hedera::internal

--- a/sdk/main/include/impl/TLSBehavior.h
+++ b/sdk/main/include/impl/TLSBehavior.h
@@ -20,11 +20,6 @@
 #ifndef HEDERA_SDK_CPP_IMPL_TLS_BEHAVIOR_H_
 #define HEDERA_SDK_CPP_IMPL_TLS_BEHAVIOR_H_
 
-#include <string>
-#include <vector>
-#include <functional>
-#include <stdexcept>
-
 namespace Hedera::internal
 {
 /**

--- a/sdk/main/include/impl/Utilities.h
+++ b/sdk/main/include/impl/Utilities.h
@@ -127,6 +127,16 @@ template<typename ReturnType, typename InputType>
  */
 [[nodiscard]] std::string byteVectorToString(const std::vector<std::byte>& bytes);
 
+/**
+ * Get a random number between the two input inclusive bounds.
+ *
+ * @param lowerBound The lower bound of the random number.
+ * @param upperBound The upper bound of the random number.
+ * @return A random number between the two bounds.
+ * @throws std::invalid_argument If lowerBound is greater than or equal to upperBound.
+ */
+[[nodiscard]] unsigned int getRandomNumber(unsigned int lowerBound, unsigned int upperBound);
+
 } // namespace Hedera::internal::Utilities
 
 #endif // HEDERA_SDK_CPP_IMPL_UTILITIES_H_

--- a/sdk/main/src/AccountBalanceQuery.cc
+++ b/sdk/main/src/AccountBalanceQuery.cc
@@ -19,7 +19,6 @@
  */
 #include "AccountBalanceQuery.h"
 #include "AccountBalance.h"
-#include "Status.h"
 #include "impl/Node.h"
 
 #include <proto/crypto_get_account_balance.pb.h>
@@ -48,48 +47,45 @@ AccountBalanceQuery& AccountBalanceQuery::setContractId(const ContractId& contra
 }
 
 //-----
-proto::Query AccountBalanceQuery::makeRequest(const Client&, const std::shared_ptr<internal::Node>&) const
-{
-  proto::Query query;
-  proto::CryptoGetAccountBalanceQuery* getAccountBalanceQuery = query.mutable_cryptogetaccountbalance();
-
-  proto::QueryHeader* header = getAccountBalanceQuery->mutable_header();
-  header->set_responsetype(proto::ANSWER_ONLY);
-  // This is a free query, so no payment required
-
-  if (mAccountId)
-  {
-    getAccountBalanceQuery->set_allocated_accountid(mAccountId->toProtobuf().release());
-  }
-
-  if (mContractId)
-  {
-    getAccountBalanceQuery->set_allocated_contractid(mContractId->toProtobuf().release());
-  }
-
-  return query;
-}
-
-//-----
 AccountBalance AccountBalanceQuery::mapResponse(const proto::Response& response) const
 {
   return AccountBalance::fromProtobuf(response.cryptogetaccountbalance());
 }
 
 //-----
-Status AccountBalanceQuery::mapResponseStatus(const proto::Response& response) const
+grpc::Status AccountBalanceQuery::submitRequest(const proto::Query& request,
+                                                const std::shared_ptr<internal::Node>& node,
+                                                const std::chrono::system_clock::time_point& deadline,
+                                                proto::Response* response) const
 {
-  return gProtobufResponseCodeToStatus.at(response.cryptogetaccountbalance().header().nodetransactionprecheckcode());
+  return node->submitQuery(proto::Query::QueryCase::kCryptogetAccountBalance, request, deadline, response);
 }
 
 //-----
-grpc::Status AccountBalanceQuery::submitRequest(const Client& client,
-                                                const std::chrono::system_clock::time_point& deadline,
-                                                const std::shared_ptr<internal::Node>& node,
-                                                proto::Response* response) const
+proto::Query AccountBalanceQuery::buildRequest(proto::QueryHeader* header) const
 {
-  return node->submitQuery(
-    proto::Query::QueryCase::kCryptogetAccountBalance, makeRequest(client, node), deadline, response);
+  auto accountBalanceQuery = std::make_unique<proto::CryptoGetAccountBalanceQuery>();
+  accountBalanceQuery->set_allocated_header(header);
+
+  if (mAccountId)
+  {
+    accountBalanceQuery->set_allocated_accountid(mAccountId->toProtobuf().release());
+  }
+
+  if (mContractId)
+  {
+    accountBalanceQuery->set_allocated_contractid(mContractId->toProtobuf().release());
+  }
+
+  proto::Query query;
+  query.set_allocated_cryptogetaccountbalance(accountBalanceQuery.release());
+  return query;
+}
+
+//-----
+proto::ResponseHeader AccountBalanceQuery::mapResponseHeader(const proto::Response& response) const
+{
+  return response.cryptogetaccountbalance().header();
 }
 
 } // namespace Hedera

--- a/sdk/main/src/AccountBalanceQuery.cc
+++ b/sdk/main/src/AccountBalanceQuery.cc
@@ -85,7 +85,7 @@ proto::Query AccountBalanceQuery::buildRequest(proto::QueryHeader* header) const
 //-----
 proto::ResponseHeader AccountBalanceQuery::mapResponseHeader(const proto::Response& response) const
 {
-  Query<AccountBalanceQuery, AccountBalance>::saveCostFromHeader(response.cryptogetaccountbalance().header());
+  saveCostFromHeader(response.cryptogetaccountbalance().header());
   return response.cryptogetaccountbalance().header();
 }
 

--- a/sdk/main/src/AccountBalanceQuery.cc
+++ b/sdk/main/src/AccountBalanceQuery.cc
@@ -85,6 +85,7 @@ proto::Query AccountBalanceQuery::buildRequest(proto::QueryHeader* header) const
 //-----
 proto::ResponseHeader AccountBalanceQuery::mapResponseHeader(const proto::Response& response) const
 {
+  Query<AccountBalanceQuery, AccountBalance>::saveCostFromHeader(response.cryptogetaccountbalance().header());
   return response.cryptogetaccountbalance().header();
 }
 

--- a/sdk/main/src/AccountInfoQuery.cc
+++ b/sdk/main/src/AccountInfoQuery.cc
@@ -18,11 +18,7 @@
  *
  */
 #include "AccountInfoQuery.h"
-#include "AccountId.h"
 #include "AccountInfo.h"
-#include "Client.h"
-#include "TransactionRecord.h"
-#include "TransferTransaction.h"
 #include "impl/Node.h"
 
 #include <proto/crypto_get_info.pb.h>
@@ -40,47 +36,36 @@ AccountInfoQuery& AccountInfoQuery::setAccountId(const AccountId& accountId)
 }
 
 //-----
-proto::Query AccountInfoQuery::makeRequest(const Client& client, const std::shared_ptr<internal::Node>& node) const
-{
-  proto::Query query;
-  proto::CryptoGetInfoQuery* getAccountInfoQuery = query.mutable_cryptogetinfo();
-
-  proto::QueryHeader* header = getAccountInfoQuery->mutable_header();
-  header->set_responsetype(proto::ANSWER_ONLY);
-
-  TransferTransaction tx = TransferTransaction()
-                             .setTransactionId(TransactionId::generate(*client.getOperatorAccountId()))
-                             .setNodeAccountIds({ node->getAccountId() })
-                             .setMaxTransactionFee(Hbar(1LL))
-                             .addHbarTransfer(*client.getOperatorAccountId(), Hbar(-1LL))
-                             .addHbarTransfer(node->getAccountId(), Hbar(1LL));
-  tx.onSelectNode(node);
-  header->set_allocated_payment(new proto::Transaction(tx.makeRequest(client, node)));
-
-  getAccountInfoQuery->set_allocated_accountid(mAccountId.toProtobuf().release());
-
-  return query;
-}
-
-//-----
 AccountInfo AccountInfoQuery::mapResponse(const proto::Response& response) const
 {
   return AccountInfo::fromProtobuf(response.cryptogetinfo().accountinfo());
 }
 
 //-----
-Status AccountInfoQuery::mapResponseStatus(const proto::Response& response) const
+grpc::Status AccountInfoQuery::submitRequest(const proto::Query& request,
+                                             const std::shared_ptr<internal::Node>& node,
+                                             const std::chrono::system_clock::time_point& deadline,
+                                             proto::Response* response) const
 {
-  return gProtobufResponseCodeToStatus.at(response.cryptogetinfo().header().nodetransactionprecheckcode());
+  return node->submitQuery(proto::Query::QueryCase::kCryptoGetInfo, request, deadline, response);
 }
 
 //-----
-grpc::Status AccountInfoQuery::submitRequest(const Client& client,
-                                             const std::chrono::system_clock::time_point& deadline,
-                                             const std::shared_ptr<internal::Node>& node,
-                                             proto::Response* response) const
+proto::Query AccountInfoQuery::buildRequest(proto::QueryHeader* header) const
 {
-  return node->submitQuery(proto::Query::QueryCase::kCryptoGetInfo, makeRequest(client, node), deadline, response);
+  auto accountInfoQuery = std::make_unique<proto::CryptoGetInfoQuery>();
+  accountInfoQuery->set_allocated_header(header);
+  accountInfoQuery->set_allocated_accountid(mAccountId.toProtobuf().release());
+
+  proto::Query query;
+  query.set_allocated_cryptogetinfo(accountInfoQuery.release());
+  return query;
+}
+
+//-----
+proto::ResponseHeader AccountInfoQuery::mapResponseHeader(const proto::Response& response) const
+{
+  return response.cryptogetinfo().header();
 }
 
 } // namespace Hedera

--- a/sdk/main/src/AccountInfoQuery.cc
+++ b/sdk/main/src/AccountInfoQuery.cc
@@ -65,6 +65,7 @@ proto::Query AccountInfoQuery::buildRequest(proto::QueryHeader* header) const
 //-----
 proto::ResponseHeader AccountInfoQuery::mapResponseHeader(const proto::Response& response) const
 {
+  Query<AccountInfoQuery, AccountInfo>::saveCostFromHeader(response.cryptogetinfo().header());
   return response.cryptogetinfo().header();
 }
 

--- a/sdk/main/src/AccountInfoQuery.cc
+++ b/sdk/main/src/AccountInfoQuery.cc
@@ -65,7 +65,7 @@ proto::Query AccountInfoQuery::buildRequest(proto::QueryHeader* header) const
 //-----
 proto::ResponseHeader AccountInfoQuery::mapResponseHeader(const proto::Response& response) const
 {
-  Query<AccountInfoQuery, AccountInfo>::saveCostFromHeader(response.cryptogetinfo().header());
+  saveCostFromHeader(response.cryptogetinfo().header());
   return response.cryptogetinfo().header();
 }
 

--- a/sdk/main/src/AccountRecordsQuery.cc
+++ b/sdk/main/src/AccountRecordsQuery.cc
@@ -65,6 +65,7 @@ proto::Query AccountRecordsQuery::buildRequest(proto::QueryHeader* header) const
 //-----
 proto::ResponseHeader AccountRecordsQuery::mapResponseHeader(const proto::Response& response) const
 {
+  Query<AccountRecordsQuery, AccountRecords>::saveCostFromHeader(response.cryptogetaccountrecords().header());
   return response.cryptogetaccountrecords().header();
 }
 

--- a/sdk/main/src/AccountRecordsQuery.cc
+++ b/sdk/main/src/AccountRecordsQuery.cc
@@ -65,7 +65,7 @@ proto::Query AccountRecordsQuery::buildRequest(proto::QueryHeader* header) const
 //-----
 proto::ResponseHeader AccountRecordsQuery::mapResponseHeader(const proto::Response& response) const
 {
-  Query<AccountRecordsQuery, AccountRecords>::saveCostFromHeader(response.cryptogetaccountrecords().header());
+  saveCostFromHeader(response.cryptogetaccountrecords().header());
   return response.cryptogetaccountrecords().header();
 }
 

--- a/sdk/main/src/AccountStakersQuery.cc
+++ b/sdk/main/src/AccountStakersQuery.cc
@@ -39,54 +39,42 @@ AccountStakersQuery& AccountStakersQuery::setAccountId(const AccountId& accountI
 }
 
 //-----
-proto::Query AccountStakersQuery::makeRequest(const Client& client, const std::shared_ptr<internal::Node>& node) const
-{
-  proto::Query query;
-  proto::CryptoGetStakersQuery* getAccountStakersQuery = query.mutable_cryptogetproxystakers();
-
-  proto::QueryHeader* header = getAccountStakersQuery->mutable_header();
-  header->set_responsetype(proto::ANSWER_ONLY);
-
-  TransferTransaction tx = TransferTransaction()
-                             .setTransactionId(TransactionId::generate(*client.getOperatorAccountId()))
-                             .setNodeAccountIds({ node->getAccountId() })
-                             .setMaxTransactionFee(Hbar(1LL))
-                             .addHbarTransfer(*client.getOperatorAccountId(), Hbar(-1LL))
-                             .addHbarTransfer(node->getAccountId(), Hbar(1LL));
-  tx.onSelectNode(node);
-  header->set_allocated_payment(new proto::Transaction(tx.makeRequest(client, node)));
-
-  getAccountStakersQuery->set_allocated_accountid(mAccountId.toProtobuf().release());
-
-  return query;
-}
-
-//-----
 AccountStakers AccountStakersQuery::mapResponse(const proto::Response& response) const
 {
   AccountStakers accountStakers;
-
   for (int i = 0; i < response.cryptogetproxystakers().stakers().proxystaker_size(); ++i)
   {
+    accountStakers.push_back(ProxyStaker::fromProtobuf(response.cryptogetproxystakers().stakers().proxystaker(i)));
   }
 
   return accountStakers;
 }
 
 //-----
-Status AccountStakersQuery::mapResponseStatus(const proto::Response& response) const
+grpc::Status AccountStakersQuery::submitRequest(const proto::Query& request,
+                                                const std::shared_ptr<internal::Node>& node,
+                                                const std::chrono::system_clock::time_point& deadline,
+                                                proto::Response* response) const
 {
-  return gProtobufResponseCodeToStatus.at(response.cryptogetproxystakers().header().nodetransactionprecheckcode());
+  return node->submitQuery(proto::Query::QueryCase::kCryptoGetProxyStakers, request, deadline, response);
 }
 
 //-----
-grpc::Status AccountStakersQuery::submitRequest(const Client& client,
-                                                const std::chrono::system_clock::time_point& deadline,
-                                                const std::shared_ptr<internal::Node>& node,
-                                                proto::Response* response) const
+proto::Query AccountStakersQuery::buildRequest(proto::QueryHeader* header) const
 {
-  return node->submitQuery(
-    proto::Query::QueryCase::kCryptoGetProxyStakers, makeRequest(client, node), deadline, response);
+  auto accountStakersQuery = std::make_unique<proto::CryptoGetStakersQuery>();
+  accountStakersQuery->set_allocated_header(header);
+  accountStakersQuery->set_allocated_accountid(mAccountId.toProtobuf().release());
+
+  proto::Query query;
+  query.set_allocated_cryptogetproxystakers(accountStakersQuery.release());
+  return query;
+}
+
+//-----
+proto::ResponseHeader AccountStakersQuery::mapResponseHeader(const proto::Response& response) const
+{
+  return response.cryptogetproxystakers().header();
 }
 
 } // namespace Hedera

--- a/sdk/main/src/AccountStakersQuery.cc
+++ b/sdk/main/src/AccountStakersQuery.cc
@@ -74,6 +74,7 @@ proto::Query AccountStakersQuery::buildRequest(proto::QueryHeader* header) const
 //-----
 proto::ResponseHeader AccountStakersQuery::mapResponseHeader(const proto::Response& response) const
 {
+  Query<AccountStakersQuery, AccountStakers>::saveCostFromHeader(response.cryptogetproxystakers().header());
   return response.cryptogetproxystakers().header();
 }
 

--- a/sdk/main/src/AccountStakersQuery.cc
+++ b/sdk/main/src/AccountStakersQuery.cc
@@ -74,7 +74,7 @@ proto::Query AccountStakersQuery::buildRequest(proto::QueryHeader* header) const
 //-----
 proto::ResponseHeader AccountStakersQuery::mapResponseHeader(const proto::Response& response) const
 {
-  Query<AccountStakersQuery, AccountStakers>::saveCostFromHeader(response.cryptogetproxystakers().header());
+  saveCostFromHeader(response.cryptogetproxystakers().header());
   return response.cryptogetproxystakers().header();
 }
 

--- a/sdk/main/src/ChunkedTransaction.cc
+++ b/sdk/main/src/ChunkedTransaction.cc
@@ -272,7 +272,8 @@ unsigned int ChunkedTransaction<SdkRequestType>::getChunkSize() const
 //-----
 template<typename SdkRequestType>
 ChunkedTransaction<SdkRequestType>::ChunkedTransaction()
-  : mImpl(std::make_unique<ChunkedTransactionImpl>())
+  : Transaction<SdkRequestType>()
+  , mImpl(std::make_unique<ChunkedTransactionImpl>())
 {
 }
 
@@ -283,7 +284,8 @@ ChunkedTransaction<SdkRequestType>::~ChunkedTransaction() = default;
 //-----
 template<typename SdkRequestType>
 ChunkedTransaction<SdkRequestType>::ChunkedTransaction(const ChunkedTransaction& other)
-  : mImpl(std::make_unique<ChunkedTransactionImpl>(*other.mImpl))
+  : Transaction<SdkRequestType>(other)
+  , mImpl(std::make_unique<ChunkedTransactionImpl>(*other.mImpl))
 {
 }
 
@@ -293,6 +295,7 @@ ChunkedTransaction<SdkRequestType>& ChunkedTransaction<SdkRequestType>::operator
 {
   if (this != &other)
   {
+    Transaction<SdkRequestType>::operator=(other);
     mImpl = std::make_unique<ChunkedTransactionImpl>(*other.mImpl);
   }
 
@@ -302,7 +305,8 @@ ChunkedTransaction<SdkRequestType>& ChunkedTransaction<SdkRequestType>::operator
 //-----
 template<typename SdkRequestType>
 ChunkedTransaction<SdkRequestType>::ChunkedTransaction(ChunkedTransaction&& other) noexcept
-  : mImpl(std::move(other.mImpl))
+  : Transaction<SdkRequestType>(std::move(other))
+  , mImpl(std::move(other.mImpl)) // NOLINT
 {
 }
 
@@ -312,7 +316,8 @@ ChunkedTransaction<SdkRequestType>& ChunkedTransaction<SdkRequestType>::operator
 {
   if (this != &other)
   {
-    mImpl = std::move(other.mImpl);
+    Transaction<SdkRequestType>::operator=(std::move(other));
+    mImpl = std::move(other.mImpl); // NOLINT
   }
 
   return *this;
@@ -322,6 +327,7 @@ ChunkedTransaction<SdkRequestType>& ChunkedTransaction<SdkRequestType>::operator
 template<typename SdkRequestType>
 ChunkedTransaction<SdkRequestType>::ChunkedTransaction(const proto::TransactionBody& txBody)
   : Transaction<SdkRequestType>(txBody)
+  , mImpl(std::make_unique<ChunkedTransactionImpl>())
 {
 }
 
@@ -330,6 +336,7 @@ template<typename SdkRequestType>
 ChunkedTransaction<SdkRequestType>::ChunkedTransaction(
   const std::map<TransactionId, std::map<AccountId, proto::Transaction>>& transactions)
   : Transaction<SdkRequestType>(transactions)
+  , mImpl(std::make_unique<ChunkedTransactionImpl>())
 {
   // Make sure there's more than one chunk.
   if (transactions.size() <= 1)
@@ -359,7 +366,6 @@ ChunkedTransaction<SdkRequestType>::ChunkedTransaction(
 template<typename SdkRequestType>
 SdkRequestType& ChunkedTransaction<SdkRequestType>::setData(const std::vector<std::byte>& data)
 {
-  Transaction<SdkRequestType>::requireNotFrozen();
   mImpl->mData = data;
   return static_cast<SdkRequestType&>(*this);
 }

--- a/sdk/main/src/ChunkedTransaction.cc
+++ b/sdk/main/src/ChunkedTransaction.cc
@@ -25,12 +25,40 @@
 #include "TransactionResponse.h"
 #include "exceptions/IllegalStateException.h"
 #include "impl/Utilities.h"
+#include "impl/openssl_utils/OpenSSLUtils.h"
 
 #include <algorithm>
-#include <iostream>
+#include <cmath>
+#include <iterator>
+#include <proto/transaction.pb.h>
+#include <proto/transaction_contents.pb.h>
 
 namespace Hedera
 {
+//-----
+template<typename SdkRequestType>
+struct ChunkedTransaction<SdkRequestType>::ChunkedTransactionImpl
+{
+  // The TransactionIds of all chunks that are to be sent as part of this ChunkedTransaction, minus the first chunk
+  // (which is stored in Transaction<SdkRequestType>::mTransactionId).
+  std::vector<TransactionId> mChunkedTransactionIds;
+
+  // This ChunkedTransaction's data.
+  std::vector<std::byte> mData;
+
+  // The size of this ChunkedTransaction's chunks, in bytes.
+  unsigned int mChunkSize = 1024U;
+
+  // The maximum number of chunks into which this ChunkedTransaction will get broken up.
+  unsigned int mMaxChunks = DEFAULT_MAX_CHUNKS;
+
+  // Should this ChunkedTransaction get a receipt for each submitted chunk?
+  bool mShouldGetReceipt = false;
+
+  // The current chunk attempting to be sent.
+  unsigned int mCurrentChunk = 0U;
+};
+
 //-----
 template<typename SdkRequestType>
 TransactionResponse ChunkedTransaction<SdkRequestType>::execute(const Client& client)
@@ -61,75 +89,152 @@ std::vector<TransactionResponse> ChunkedTransaction<SdkRequestType>::executeAll(
 {
   // Determine how many chunks are going to be required to send this whole ChunkedTransaction and make sure it's within
   // the set limit.
-  const auto requiredChunks =
-    static_cast<unsigned int>(std::ceil(static_cast<double>(mData.size()) / static_cast<double>(mChunkSize)));
-  if (requiredChunks > mMaxChunks)
+  const unsigned int requiredChunks = getNumberOfChunksRequired();
+  if (requiredChunks > mImpl->mMaxChunks)
   {
     throw IllegalStateException("Transaction requires " + std::to_string(requiredChunks) + " but is only allotted " +
-                                std::to_string(mMaxChunks) + ". Try using setMaxChunks()");
+                                std::to_string(mImpl->mMaxChunks) + ". Try using setMaxChunks()");
   }
 
   // Container to hold responses.
   std::vector<TransactionResponse> responses;
+  responses.reserve(requiredChunks);
 
-  // The transaction chunks being sent should all have the same TransactionId besides their valid start time being a
-  // little off. The first TransactionId should be saved so that it can be used to generate the IDs for the other
-  // chunks.
-  TransactionId firstTransactionId;
-
-  // Move the data out to prevent an unnecessary copy of all the data.
-  std::vector<std::byte> data = std::move(mData);
-  mData.clear();
-  mData.reserve(mChunkSize);
-
-  for (int chunk = 0; chunk < requiredChunks; ++chunk)
+  for (; mImpl->mCurrentChunk < requiredChunks; ++mImpl->mCurrentChunk)
   {
-    // Create a copy of this entire transaction. This should carry over all manually-set items, if any.
-    SdkRequestType tx = *static_cast<SdkRequestType*>(this);
+    responses.push_back(
+      Executable<SdkRequestType, proto::Transaction, proto::TransactionResponse, TransactionResponse>::execute(
+        client, timeout));
 
-    // Create the chunk and set it in the transaction.
-    const unsigned int startingByteForChunk = mChunkSize * chunk;
-    const auto start = data.cbegin() + startingByteForChunk;
-    tx.mData = { start,
-                 start + ((mChunkSize + startingByteForChunk > data.size()) ? data.size() - startingByteForChunk
-                                                                            : mChunkSize) };
-
-    // Adjust the TransactionId if this is not the first chunk.
-    if (chunk != 0)
+    if (mImpl->mShouldGetReceipt)
     {
-      tx.setTransactionId(TransactionId::withValidStart(
-        firstTransactionId.getAccountId(),
-        firstTransactionId.getValidTransactionTime() +
-          std::chrono::duration<int, std::chrono::system_clock::duration::period>(chunk)));
-    }
-
-    // Get the transaction ready to execute.
-    tx.freezeWith(&client);
-
-    // Grab the first transaction if this is the first transaction.
-    if (chunk == 0)
-    {
-      firstTransactionId = tx.getTransactionId();
-    }
-
-    // Do any needed post-chunk processing on the transaction. This is required to happen after freezing so that
-    // TopicMessageSubmitTransaction can read the transaction ID.
-    tx.onChunk(firstTransactionId, chunk, requiredChunks);
-
-    // Execute the chunk.
-    responses.push_back(tx.wrappedExecute(client, timeout));
-
-    // Wait for the transaction to fully complete, if configured
-    if (mShouldGetReceipt)
-    {
-      const TransactionReceipt txReceipt = responses.back().getReceipt(client);
+      const TransactionReceipt txReceipt = responses.back().getReceipt(client, timeout);
     }
   }
 
-  // Move the data back into mData.
-  mData = std::move(data);
+  // Reset current chunk.
+  mImpl->mCurrentChunk = 0U;
 
   return responses;
+}
+
+//-----
+template<typename SdkRequestType>
+SdkRequestType& ChunkedTransaction<SdkRequestType>::addSignature(const std::shared_ptr<PublicKey>& publicKey,
+                                                                 const std::vector<std::byte>& signature)
+{
+  if (mImpl->mData.size() > mImpl->mChunkSize)
+  {
+    throw IllegalStateException(
+      "Cannot manually add a signature to a ChunkedTransaction with data length greater than " +
+      std::to_string(mImpl->mChunkSize));
+  }
+
+  return Transaction<SdkRequestType>::addSignature(publicKey, signature);
+}
+
+//-----
+template<typename SdkRequestType>
+std::map<AccountId, std::map<std::shared_ptr<PublicKey>, std::vector<std::byte>>>
+ChunkedTransaction<SdkRequestType>::getSignatures() const
+{
+  if (mImpl->mData.size() > mImpl->mChunkSize)
+  {
+    throw IllegalStateException("Cannot get signatures for a ChunkedTransaction with data length greater than " +
+                                std::to_string(mImpl->mChunkSize) + ". Try calling getAllSignatures() instead.");
+  }
+
+  return Transaction<SdkRequestType>::getSignatures();
+}
+
+//-----
+template<typename SdkRequestType>
+std::vector<std::map<AccountId, std::map<std::shared_ptr<PublicKey>, std::vector<std::byte>>>>
+ChunkedTransaction<SdkRequestType>::getAllSignatures() const
+{
+  // Grab the signatures of the first chunk. If there are no signatures, there are no signers.
+  std::vector<std::map<AccountId, std::map<std::shared_ptr<PublicKey>, std::vector<std::byte>>>> signatures;
+  signatures.push_back(Transaction<SdkRequestType>::getSignatures());
+
+  if (signatures.cbegin()->empty())
+  {
+    return {};
+  }
+
+  // All Transaction protobuf objects get built in Transaction<SdkRequestType>::getSignatures(), so the signatures just
+  // need to be grabbed for each transaction chunk. The first transaction chunk is already in the signatures map, so
+  // start at index 1.
+  for (size_t i = 1; i < mImpl->mChunkedTransactionIds.size(); ++i)
+  {
+    signatures.push_back(Transaction<SdkRequestType>::getSignaturesInternal(i));
+  }
+
+  return signatures;
+}
+
+//-----
+template<typename SdkRequestType>
+std::vector<std::byte> ChunkedTransaction<SdkRequestType>::getTransactionHash() const
+{
+  if (!mImpl->mChunkedTransactionIds.empty())
+  {
+    throw IllegalStateException(
+      "A single hash cannot be generated for this transaction, try calling 'getAllTransactionHashesPerNode()'");
+  }
+
+  return Transaction<SdkRequestType>::getTransactionHash();
+}
+
+//-----
+template<typename SdkRequestType>
+std::map<AccountId, std::vector<std::byte>> ChunkedTransaction<SdkRequestType>::getTransactionHashPerNode() const
+{
+  if (!mImpl->mChunkedTransactionIds.empty())
+  {
+    throw IllegalStateException(
+      "A single hash cannot be generated for this transaction, try calling 'getAllTransactionHashesPerNode()'");
+  }
+
+  return Transaction<SdkRequestType>::getTransactionHashPerNode();
+}
+
+//-----
+template<typename SdkRequestType>
+std::vector<std::map<AccountId, std::vector<std::byte>>>
+ChunkedTransaction<SdkRequestType>::getAllTransactionHashesPerNode() const
+{
+  if (!Transaction<SdkRequestType>::isFrozen())
+  {
+    throw IllegalStateException("Transaction must be frozen in order to calculate the hashes.");
+  }
+
+  // Build all the Transaction protobuf objects.
+  Transaction<SdkRequestType>::buildAllTransactions();
+
+  // Grab the node account IDs being used for this ChunkedTransaction.
+  const std::vector<AccountId> nodeAccountIds =
+    Executable<SdkRequestType, proto::Transaction, proto::TransactionResponse, TransactionResponse>::
+      getNodeAccountIds();
+
+  // Add one to the mChunkedTransactionIds size to include the first TransactionId stored in the Transaction base class.
+  std::vector<std::map<AccountId, std::vector<std::byte>>> hashes;
+  for (unsigned int i = 0; i < mImpl->mChunkedTransactionIds.size() + 1; ++i)
+  {
+    // For each node account ID, grab the correct Transaction protobuf object and generate the hash.
+    std::map<AccountId, std::vector<std::byte>> hashMap;
+    for (unsigned int j = 0; j < nodeAccountIds.size(); ++j)
+    {
+      hashMap.emplace(nodeAccountIds.at(j),
+                      internal::OpenSSLUtils::computeSHA384(internal::Utilities::stringToByteVector(
+                        Transaction<SdkRequestType>::getTransactionProtobufObject(
+                          (i * static_cast<unsigned int>(nodeAccountIds.size())) + j)
+                          .signedtransactionbytes())));
+    }
+
+    hashes.push_back(hashMap);
+  }
+
+  return hashes;
 }
 
 //-----
@@ -137,7 +242,7 @@ template<typename SdkRequestType>
 SdkRequestType& ChunkedTransaction<SdkRequestType>::setMaxChunks(unsigned int chunks)
 {
   Transaction<SdkRequestType>::requireNotFrozen();
-  mMaxChunks = chunks;
+  mImpl->mMaxChunks = chunks;
   return static_cast<SdkRequestType&>(*this);
 }
 
@@ -146,8 +251,108 @@ template<typename SdkRequestType>
 SdkRequestType& ChunkedTransaction<SdkRequestType>::setChunkSize(unsigned int size)
 {
   Transaction<SdkRequestType>::requireNotFrozen();
-  mChunkSize = size;
+  mImpl->mChunkSize = size;
   return static_cast<SdkRequestType&>(*this);
+}
+
+//-----
+template<typename SdkRequestType>
+unsigned int ChunkedTransaction<SdkRequestType>::getMaxChunks() const
+{
+  return mImpl->mMaxChunks;
+}
+
+//-----
+template<typename SdkRequestType>
+unsigned int ChunkedTransaction<SdkRequestType>::getChunkSize() const
+{
+  return mImpl->mChunkSize;
+}
+
+//-----
+template<typename SdkRequestType>
+ChunkedTransaction<SdkRequestType>::ChunkedTransaction()
+  : mImpl(std::make_unique<ChunkedTransactionImpl>())
+{
+}
+
+//-----
+template<typename SdkRequestType>
+ChunkedTransaction<SdkRequestType>::~ChunkedTransaction() = default;
+
+//-----
+template<typename SdkRequestType>
+ChunkedTransaction<SdkRequestType>::ChunkedTransaction(const ChunkedTransaction& other)
+  : mImpl(std::make_unique<ChunkedTransactionImpl>(*other.mImpl))
+{
+}
+
+//-----
+template<typename SdkRequestType>
+ChunkedTransaction<SdkRequestType>& ChunkedTransaction<SdkRequestType>::operator=(const ChunkedTransaction& other)
+{
+  if (this != &other)
+  {
+    mImpl = std::make_unique<ChunkedTransactionImpl>(*other.mImpl);
+  }
+
+  return *this;
+}
+
+//-----
+template<typename SdkRequestType>
+ChunkedTransaction<SdkRequestType>::ChunkedTransaction(ChunkedTransaction&& other) noexcept
+  : mImpl(std::move(other.mImpl))
+{
+}
+
+//-----
+template<typename SdkRequestType>
+ChunkedTransaction<SdkRequestType>& ChunkedTransaction<SdkRequestType>::operator=(ChunkedTransaction&& other) noexcept
+{
+  if (this != &other)
+  {
+    mImpl = std::move(other.mImpl);
+  }
+
+  return *this;
+}
+
+//-----
+template<typename SdkRequestType>
+ChunkedTransaction<SdkRequestType>::ChunkedTransaction(const proto::TransactionBody& txBody)
+  : Transaction<SdkRequestType>(txBody)
+{
+}
+
+//-----
+template<typename SdkRequestType>
+ChunkedTransaction<SdkRequestType>::ChunkedTransaction(
+  const std::map<TransactionId, std::map<AccountId, proto::Transaction>>& transactions)
+  : Transaction<SdkRequestType>(transactions)
+{
+  // Make sure there's more than one chunk.
+  if (transactions.size() <= 1)
+  {
+    return;
+  }
+
+  // Go through each additional TransactionId and store its information.
+  auto iter = transactions.cbegin();
+  std::advance(iter, 1);
+
+  for (; iter != transactions.cend(); ++iter)
+  {
+    // Save the TransactionId.
+    mImpl->mChunkedTransactionIds.push_back(iter->first);
+
+    // Add each Transaction protobuf object to this ChunkedTransaction's Transaction protobuf object list. The node
+    // account IDs should be in the same order as each other for each TransactionId.
+    for (const auto& [accountId, transaction] : iter->second)
+    {
+      Transaction<SdkRequestType>::addTransaction(transaction);
+    }
+  }
 }
 
 //-----
@@ -155,7 +360,7 @@ template<typename SdkRequestType>
 SdkRequestType& ChunkedTransaction<SdkRequestType>::setData(const std::vector<std::byte>& data)
 {
   Transaction<SdkRequestType>::requireNotFrozen();
-  mData = data;
+  mImpl->mData = data;
   return static_cast<SdkRequestType&>(*this);
 }
 
@@ -168,17 +373,88 @@ SdkRequestType& ChunkedTransaction<SdkRequestType>::setData(std::string_view dat
 
 //-----
 template<typename SdkRequestType>
-void ChunkedTransaction<SdkRequestType>::setShouldGetReceipt(bool retrieveReceipt)
+std::vector<std::byte> ChunkedTransaction<SdkRequestType>::getData() const
 {
-  mShouldGetReceipt = retrieveReceipt;
+  return mImpl->mData;
 }
+
 //-----
 template<typename SdkRequestType>
-TransactionResponse ChunkedTransaction<SdkRequestType>::wrappedExecute(const Client& client,
-                                                                       const std::chrono::duration<double>& timeout)
+std::vector<std::byte> ChunkedTransaction<SdkRequestType>::getDataForChunk(unsigned int chunk) const
 {
-  return Executable<SdkRequestType, proto::Transaction, proto::TransactionResponse, TransactionResponse>::execute(
-    client, timeout);
+  const unsigned int startingByteForChunk = mImpl->mChunkSize * chunk;
+  const auto start = mImpl->mData.cbegin() + startingByteForChunk;
+  return { start,
+           start + ((mImpl->mChunkSize + startingByteForChunk > mImpl->mData.size())
+                      ? mImpl->mData.size() - startingByteForChunk
+                      : mImpl->mChunkSize) };
+}
+
+//-----
+template<typename SdkRequestType>
+void ChunkedTransaction<SdkRequestType>::setShouldGetReceipt(bool retrieveReceipt)
+{
+  mImpl->mShouldGetReceipt = retrieveReceipt;
+}
+
+//-----
+template<typename SdkRequestType>
+bool ChunkedTransaction<SdkRequestType>::getShouldGetReceipt() const
+{
+  return mImpl->mShouldGetReceipt;
+}
+
+//-----
+template<typename SdkRequestType>
+proto::Transaction ChunkedTransaction<SdkRequestType>::makeRequest(unsigned int attempt) const
+{
+  // Adjust the index to account for the current chunk.
+  return Transaction<SdkRequestType>::makeRequest(attempt * mImpl->mCurrentChunk);
+}
+
+//-----
+template<typename SdkRequestType>
+void ChunkedTransaction<SdkRequestType>::generateSignedTransactions(const Client* client)
+{
+  // Update this Transaction's source TransactionBody protobuf object.
+  Transaction<SdkRequestType>::updateSourceTransactionBody(client);
+  proto::TransactionBody sourceTransactionBody = Transaction<SdkRequestType>::getSourceTransactionBody();
+
+  const unsigned int requiredChunks = getNumberOfChunksRequired();
+  for (int i = 0; i < requiredChunks; ++i)
+  {
+    // Generate a new TransactionId if this isn't the first chunk. Add one to the nanoseconds to make cascading
+    // transaction IDs.
+    if (i > 0)
+    {
+      sourceTransactionBody.mutable_transactionid()->mutable_transactionvalidstart()->set_nanos(
+        sourceTransactionBody.transactionid().transactionvalidstart().nanos() + 1);
+      mImpl->mChunkedTransactionIds.push_back(TransactionId::fromProtobuf(sourceTransactionBody.transactionid()));
+    }
+
+    // Generate the chunk and add it to sourceTransactionBody.
+    addToChunk(i, requiredChunks, sourceTransactionBody);
+
+    // Create a SignedTransaction protobuf object for each node account ID and add it to this ChunkedTransaction's
+    // SignedTransaction protobuf object list.
+    Transaction<SdkRequestType>::addSignedTransactionForEachNode(sourceTransactionBody);
+  }
+}
+
+//-----
+template<typename SdkRequestType>
+void ChunkedTransaction<SdkRequestType>::clearTransactions()
+{
+  Transaction<SdkRequestType>::clearTransactions();
+  mImpl->mChunkedTransactionIds.clear();
+}
+
+//-----
+template<typename SdkRequestType>
+unsigned int ChunkedTransaction<SdkRequestType>::getNumberOfChunksRequired() const
+{
+  return static_cast<unsigned int>(
+    std::ceil(static_cast<double>(mImpl->mData.size()) / static_cast<double>(mImpl->mChunkSize)));
 }
 
 /**

--- a/sdk/main/src/ContractByteCodeQuery.cc
+++ b/sdk/main/src/ContractByteCodeQuery.cc
@@ -65,6 +65,7 @@ proto::Query ContractByteCodeQuery::buildRequest(proto::QueryHeader* header) con
 //-----
 proto::ResponseHeader ContractByteCodeQuery::mapResponseHeader(const proto::Response& response) const
 {
+  Query<ContractByteCodeQuery, ContractByteCode>::saveCostFromHeader(response.contractgetbytecoderesponse().header());
   return response.contractgetbytecoderesponse().header();
 }
 

--- a/sdk/main/src/ContractByteCodeQuery.cc
+++ b/sdk/main/src/ContractByteCodeQuery.cc
@@ -18,9 +18,6 @@
  *
  */
 #include "ContractByteCodeQuery.h"
-#include "Client.h"
-#include "Status.h"
-#include "TransferTransaction.h"
 #include "impl/Node.h"
 #include "impl/Utilities.h"
 
@@ -39,49 +36,36 @@ ContractByteCodeQuery& ContractByteCodeQuery::setContractId(const ContractId& co
 }
 
 //-----
-proto::Query ContractByteCodeQuery::makeRequest(const Client& client, const std::shared_ptr<internal::Node>& node) const
-{
-  proto::Query query;
-  proto::ContractGetBytecodeQuery* getByteCodeQuery = query.mutable_contractgetbytecode();
-
-  proto::QueryHeader* header = getByteCodeQuery->mutable_header();
-  header->set_responsetype(proto::ANSWER_ONLY);
-
-  TransferTransaction tx = TransferTransaction()
-                             .setTransactionId(TransactionId::generate(*client.getOperatorAccountId()))
-                             .setNodeAccountIds({ node->getAccountId() })
-                             .setMaxTransactionFee(Hbar(1LL))
-                             .addHbarTransfer(*client.getOperatorAccountId(), Hbar(-1LL))
-                             .addHbarTransfer(node->getAccountId(), Hbar(1LL));
-  tx.onSelectNode(node);
-  header->set_allocated_payment(new proto::Transaction(tx.makeRequest(client, node)));
-
-  getByteCodeQuery->set_allocated_contractid(mContractId.toProtobuf().release());
-
-  return query;
-}
-
-//-----
 ContractByteCode ContractByteCodeQuery::mapResponse(const proto::Response& response) const
 {
   return internal::Utilities::stringToByteVector(response.contractgetbytecoderesponse().bytecode());
 }
 
 //-----
-Status ContractByteCodeQuery::mapResponseStatus(const proto::Response& response) const
+grpc::Status ContractByteCodeQuery::submitRequest(const proto::Query& request,
+                                                  const std::shared_ptr<internal::Node>& node,
+                                                  const std::chrono::system_clock::time_point& deadline,
+                                                  proto::Response* response) const
 {
-  return gProtobufResponseCodeToStatus.at(
-    response.contractgetbytecoderesponse().header().nodetransactionprecheckcode());
+  return node->submitQuery(proto::Query::QueryCase::kContractGetBytecode, request, deadline, response);
 }
 
 //-----
-grpc::Status ContractByteCodeQuery::submitRequest(const Client& client,
-                                                  const std::chrono::system_clock::time_point& deadline,
-                                                  const std::shared_ptr<internal::Node>& node,
-                                                  proto::Response* response) const
+proto::Query ContractByteCodeQuery::buildRequest(proto::QueryHeader* header) const
 {
-  return node->submitQuery(
-    proto::Query::QueryCase::kContractGetBytecode, makeRequest(client, node), deadline, response);
+  auto contractByteCodeQuery = std::make_unique<proto::ContractGetBytecodeQuery>();
+  contractByteCodeQuery->set_allocated_header(header);
+  contractByteCodeQuery->set_allocated_contractid(mContractId.toProtobuf().release());
+
+  proto::Query query;
+  query.set_allocated_contractgetbytecode(contractByteCodeQuery.release());
+  return query;
+}
+
+//-----
+proto::ResponseHeader ContractByteCodeQuery::mapResponseHeader(const proto::Response& response) const
+{
+  return response.contractgetbytecoderesponse().header();
 }
 
 } // namespace Hedera

--- a/sdk/main/src/ContractByteCodeQuery.cc
+++ b/sdk/main/src/ContractByteCodeQuery.cc
@@ -65,7 +65,7 @@ proto::Query ContractByteCodeQuery::buildRequest(proto::QueryHeader* header) con
 //-----
 proto::ResponseHeader ContractByteCodeQuery::mapResponseHeader(const proto::Response& response) const
 {
-  Query<ContractByteCodeQuery, ContractByteCode>::saveCostFromHeader(response.contractgetbytecoderesponse().header());
+  saveCostFromHeader(response.contractgetbytecoderesponse().header());
   return response.contractgetbytecoderesponse().header();
 }
 

--- a/sdk/main/src/ContractCallQuery.cc
+++ b/sdk/main/src/ContractCallQuery.cc
@@ -100,6 +100,7 @@ proto::Query ContractCallQuery::buildRequest(proto::QueryHeader* header) const
 //-----
 proto::ResponseHeader ContractCallQuery::mapResponseHeader(const proto::Response& response) const
 {
+  Query<ContractCallQuery, ContractFunctionResult>::saveCostFromHeader(response.contractcalllocal().header());
   return response.contractcalllocal().header();
 }
 

--- a/sdk/main/src/ContractCallQuery.cc
+++ b/sdk/main/src/ContractCallQuery.cc
@@ -100,7 +100,7 @@ proto::Query ContractCallQuery::buildRequest(proto::QueryHeader* header) const
 //-----
 proto::ResponseHeader ContractCallQuery::mapResponseHeader(const proto::Response& response) const
 {
-  Query<ContractCallQuery, ContractFunctionResult>::saveCostFromHeader(response.contractcalllocal().header());
+  saveCostFromHeader(response.contractcalllocal().header());
   return response.contractcalllocal().header();
 }
 

--- a/sdk/main/src/ContractInfoQuery.cc
+++ b/sdk/main/src/ContractInfoQuery.cc
@@ -65,7 +65,7 @@ proto::Query ContractInfoQuery::buildRequest(proto::QueryHeader* header) const
 //-----
 proto::ResponseHeader ContractInfoQuery::mapResponseHeader(const proto::Response& response) const
 {
-  Query<ContractInfoQuery, ContractInfo>::saveCostFromHeader(response.contractgetinfo().header());
+  saveCostFromHeader(response.contractgetinfo().header());
   return response.contractgetinfo().header();
 }
 

--- a/sdk/main/src/ContractInfoQuery.cc
+++ b/sdk/main/src/ContractInfoQuery.cc
@@ -18,10 +18,7 @@
  *
  */
 #include "ContractInfoQuery.h"
-#include "Client.h"
 #include "ContractInfo.h"
-#include "Status.h"
-#include "TransferTransaction.h"
 #include "impl/Node.h"
 
 #include <proto/contract_get_info.pb.h>
@@ -39,47 +36,36 @@ ContractInfoQuery& ContractInfoQuery::setContractId(const ContractId& contractId
 }
 
 //-----
-proto::Query ContractInfoQuery::makeRequest(const Client& client, const std::shared_ptr<internal::Node>& node) const
-{
-  proto::Query query;
-  proto::ContractGetInfoQuery* getContractInfoQuery = query.mutable_contractgetinfo();
-
-  proto::QueryHeader* header = getContractInfoQuery->mutable_header();
-  header->set_responsetype(proto::ANSWER_ONLY);
-
-  TransferTransaction tx = TransferTransaction()
-                             .setTransactionId(TransactionId::generate(*client.getOperatorAccountId()))
-                             .setNodeAccountIds({ node->getAccountId() })
-                             .setMaxTransactionFee(Hbar(1LL))
-                             .addHbarTransfer(*client.getOperatorAccountId(), Hbar(-1LL))
-                             .addHbarTransfer(node->getAccountId(), Hbar(1LL));
-  tx.onSelectNode(node);
-  header->set_allocated_payment(new proto::Transaction(tx.makeRequest(client, node)));
-
-  getContractInfoQuery->set_allocated_contractid(mContractId.toProtobuf().release());
-
-  return query;
-}
-
-//-----
 ContractInfo ContractInfoQuery::mapResponse(const proto::Response& response) const
 {
   return ContractInfo::fromProtobuf(response.contractgetinfo().contractinfo());
 }
 
 //-----
-Status ContractInfoQuery::mapResponseStatus(const proto::Response& response) const
+grpc::Status ContractInfoQuery::submitRequest(const proto::Query& request,
+                                              const std::shared_ptr<internal::Node>& node,
+                                              const std::chrono::system_clock::time_point& deadline,
+                                              proto::Response* response) const
 {
-  return gProtobufResponseCodeToStatus.at(response.contractgetinfo().header().nodetransactionprecheckcode());
+  return node->submitQuery(proto::Query::QueryCase::kContractGetInfo, request, deadline, response);
 }
 
 //-----
-grpc::Status ContractInfoQuery::submitRequest(const Client& client,
-                                              const std::chrono::system_clock::time_point& deadline,
-                                              const std::shared_ptr<internal::Node>& node,
-                                              proto::Response* response) const
+proto::Query ContractInfoQuery::buildRequest(proto::QueryHeader* header) const
 {
-  return node->submitQuery(proto::Query::QueryCase::kContractGetInfo, makeRequest(client, node), deadline, response);
+  auto contractGetInfoQuery = std::make_unique<proto::ContractGetInfoQuery>();
+  contractGetInfoQuery->set_allocated_header(header);
+  contractGetInfoQuery->set_allocated_contractid(mContractId.toProtobuf().release());
+
+  proto::Query query;
+  query.set_allocated_contractgetinfo(contractGetInfoQuery.release());
+  return query;
+}
+
+//-----
+proto::ResponseHeader ContractInfoQuery::mapResponseHeader(const proto::Response& response) const
+{
+  return response.contractgetinfo().header();
 }
 
 } // namespace Hedera

--- a/sdk/main/src/ContractInfoQuery.cc
+++ b/sdk/main/src/ContractInfoQuery.cc
@@ -65,6 +65,7 @@ proto::Query ContractInfoQuery::buildRequest(proto::QueryHeader* header) const
 //-----
 proto::ResponseHeader ContractInfoQuery::mapResponseHeader(const proto::Response& response) const
 {
+  Query<ContractInfoQuery, ContractInfo>::saveCostFromHeader(response.contractgetinfo().header());
   return response.contractgetinfo().header();
 }
 

--- a/sdk/main/src/ECDSAsecp256k1PublicKey.cc
+++ b/sdk/main/src/ECDSAsecp256k1PublicKey.cc
@@ -424,6 +424,16 @@ std::vector<std::byte> ECDSAsecp256k1PublicKey::toBytesRaw() const
 }
 
 //-----
+std::unique_ptr<proto::SignaturePair> ECDSAsecp256k1PublicKey::toSignaturePairProtobuf(
+  const std::vector<std::byte>& signature) const
+{
+  auto signaturePair = std::make_unique<proto::SignaturePair>();
+  signaturePair->set_pubkeyprefix(internal::Utilities::byteVectorToString(toBytesRaw()));
+  signaturePair->set_ecdsa_secp256k1(internal::Utilities::byteVectorToString(signature));
+  return signaturePair;
+}
+
+//-----
 EvmAddress ECDSAsecp256k1PublicKey::toEvmAddress() const
 {
   // Generate hash without "0x04" prefix of uncompressed bytes.

--- a/sdk/main/src/ED25519PublicKey.cc
+++ b/sdk/main/src/ED25519PublicKey.cc
@@ -186,6 +186,16 @@ std::vector<std::byte> ED25519PublicKey::toBytesRaw() const
 }
 
 //-----
+std::unique_ptr<proto::SignaturePair> ED25519PublicKey::toSignaturePairProtobuf(
+  const std::vector<std::byte>& signature) const
+{
+  auto signaturePair = std::make_unique<proto::SignaturePair>();
+  signaturePair->set_pubkeyprefix(internal::Utilities::byteVectorToString(toBytesRaw()));
+  signaturePair->set_ed25519(internal::Utilities::byteVectorToString(signature));
+  return signaturePair;
+}
+
+//-----
 ED25519PublicKey::ED25519PublicKey(internal::OpenSSLUtils::EVP_PKEY&& key)
   : PublicKey(std::move(key))
 {

--- a/sdk/main/src/EthereumTransaction.cc
+++ b/sdk/main/src/EthereumTransaction.cc
@@ -31,7 +31,7 @@ namespace Hedera
 EthereumTransaction::EthereumTransaction(const proto::TransactionBody& transactionBody)
   : Transaction<EthereumTransaction>(transactionBody)
 {
-  EthereumTransaction();
+  initFromSourceTransactionBody();
 }
 
 //-----

--- a/sdk/main/src/Executable.cc
+++ b/sdk/main/src/Executable.cc
@@ -153,6 +153,8 @@ SdkResponseType Executable<SdkRequestType, ProtoRequestType, ProtoResponseType, 
     // Make sure the Node is connected. If it can't connect, mark this Node as unhealthy and try another Node.
     if (node->channelFailedToConnect())
     {
+      std::cout << "Failed to connect to node " << node->getAccountId().toString() << " at address "
+                << node->getAddress().toString() << " on attempt " << attempt << std::endl;
       node->increaseBackoff();
       continue;
     }
@@ -319,7 +321,7 @@ Executable<SdkRequestType, ProtoRequestType, ProtoResponseType, SdkResponseType>
     const std::vector<std::shared_ptr<internal::Node>> nodeProxies = client.getNetwork()->getNodeProxies(accountId);
 
     // Verify the node account ID mapped to a valid Node.
-    if (nodes.empty())
+    if (nodeProxies.empty())
     {
       throw IllegalStateException("Node account ID " + accountId.toString() +
                                   " did not map to a valid node in the input Client's network.");

--- a/sdk/main/src/Executable.cc
+++ b/sdk/main/src/Executable.cc
@@ -134,7 +134,7 @@ SdkResponseType Executable<SdkRequestType, ProtoRequestType, ProtoResponseType, 
 
   for (unsigned int attempt = 0U;; ++attempt)
   {
-    if (attempt > mCurrentMaxAttempts)
+    if (attempt >= mCurrentMaxAttempts)
     {
       throw MaxAttemptsExceededException("Max number of attempts made (max attempts allowed: " +
                                          std::to_string(mCurrentMaxAttempts));
@@ -188,7 +188,7 @@ SdkResponseType Executable<SdkRequestType, ProtoRequestType, ProtoResponseType, 
       case ExecutionStatus::RETRY:
       {
         std::this_thread::sleep_for(mCurrentBackoff);
-        mCurrentBackoff *= 2;
+        mCurrentBackoff *= 2.0;
         break;
       }
       case ExecutionStatus::REQUEST_ERROR:
@@ -264,7 +264,6 @@ Executable<SdkRequestType, ProtoRequestType, ProtoResponseType, SdkResponseType>
     case Status::BUSY:
       return ExecutionStatus::SERVER_ERROR;
     case Status::OK:
-    case Status::SUCCESS:
       return ExecutionStatus::SUCCESS;
       // Let derived class handle this status, assume request error
     default:

--- a/sdk/main/src/Executable.cc
+++ b/sdk/main/src/Executable.cc
@@ -206,9 +206,9 @@ SdkResponseType Executable<SdkRequestType, ProtoRequestType, ProtoResponseType, 
 //-----
 template<typename SdkRequestType, typename ProtoRequestType, typename ProtoResponseType, typename SdkResponseType>
 SdkRequestType& Executable<SdkRequestType, ProtoRequestType, ProtoResponseType, SdkResponseType>::setNodeAccountIds(
-  const std::vector<AccountId>& nodeAccountIds)
+  std::vector<AccountId> nodeAccountIds)
 {
-  mNodeAccountIds = nodeAccountIds;
+  mNodeAccountIds = std::move(nodeAccountIds);
   return static_cast<SdkRequestType&>(*this);
 }
 

--- a/sdk/main/src/FileAppendTransaction.cc
+++ b/sdk/main/src/FileAppendTransaction.cc
@@ -30,6 +30,7 @@ namespace Hedera
 {
 //-----
 FileAppendTransaction::FileAppendTransaction()
+  : ChunkedTransaction<FileAppendTransaction>()
 {
   setDefaultMaxTransactionFee(Hbar(5LL));
   setChunkSize(DEFAULT_CHUNK_SIZE);
@@ -40,8 +41,6 @@ FileAppendTransaction::FileAppendTransaction()
 FileAppendTransaction::FileAppendTransaction(const proto::TransactionBody& transactionBody)
   : ChunkedTransaction<FileAppendTransaction>(transactionBody)
 {
-  setDefaultMaxTransactionFee(Hbar(5LL));
-  setChunkSize(DEFAULT_CHUNK_SIZE);
   setShouldGetReceipt(true);
   initFromSourceTransactionBody();
 }
@@ -51,8 +50,6 @@ FileAppendTransaction::FileAppendTransaction(
   const std::map<TransactionId, std::map<AccountId, proto::Transaction>>& transactions)
   : ChunkedTransaction<FileAppendTransaction>(transactions)
 {
-  setDefaultMaxTransactionFee(Hbar(5LL));
-  setChunkSize(DEFAULT_CHUNK_SIZE);
   setShouldGetReceipt(true);
   initFromSourceTransactionBody();
 }

--- a/sdk/main/src/FileAppendTransaction.cc
+++ b/sdk/main/src/FileAppendTransaction.cc
@@ -33,7 +33,7 @@ FileAppendTransaction::FileAppendTransaction()
   : ChunkedTransaction<FileAppendTransaction>()
 {
   setDefaultMaxTransactionFee(Hbar(5LL));
-  setChunkSize(DEFAULT_CHUNK_SIZE);
+  setChunkSize(2048U);
   setShouldGetReceipt(true);
 }
 

--- a/sdk/main/src/FileContentsQuery.cc
+++ b/sdk/main/src/FileContentsQuery.cc
@@ -65,6 +65,7 @@ proto::Query FileContentsQuery::buildRequest(proto::QueryHeader* header) const
 //-----
 proto::ResponseHeader FileContentsQuery::mapResponseHeader(const proto::Response& response) const
 {
+  Query<FileContentsQuery, FileContents>::saveCostFromHeader(response.filegetcontents().header());
   return response.filegetcontents().header();
 }
 

--- a/sdk/main/src/FileContentsQuery.cc
+++ b/sdk/main/src/FileContentsQuery.cc
@@ -18,9 +18,6 @@
  *
  */
 #include "FileContentsQuery.h"
-#include "Client.h"
-#include "Status.h"
-#include "TransferTransaction.h"
 #include "impl/Node.h"
 #include "impl/Utilities.h"
 
@@ -39,48 +36,36 @@ FileContentsQuery& FileContentsQuery::setFileId(const FileId& fileId)
 }
 
 //-----
-proto::Query FileContentsQuery::makeRequest(const Client& client, const std::shared_ptr<internal::Node>& node) const
-{
-  proto::Query query;
-  proto::FileGetContentsQuery* getFileContentsQuery = query.mutable_filegetcontents();
-
-  proto::QueryHeader* header = getFileContentsQuery->mutable_header();
-  header->set_responsetype(proto::ANSWER_ONLY);
-
-  TransferTransaction tx = TransferTransaction()
-                             .setTransactionId(TransactionId::generate(*client.getOperatorAccountId()))
-                             .setNodeAccountIds({ node->getAccountId() })
-                             .setMaxTransactionFee(Hbar(1LL))
-                             .addHbarTransfer(*client.getOperatorAccountId(), Hbar(-1LL))
-                             .addHbarTransfer(node->getAccountId(), Hbar(1LL));
-  tx.onSelectNode(node);
-  header->set_allocated_payment(new proto::Transaction(tx.makeRequest(client, node)));
-
-  getFileContentsQuery->set_allocated_fileid(mFileId.toProtobuf().release());
-
-  return query;
-}
-
-//-----
 FileContents FileContentsQuery::mapResponse(const proto::Response& response) const
 {
   return internal::Utilities::stringToByteVector(response.filegetcontents().filecontents().contents());
 }
 
 //-----
-Status FileContentsQuery::mapResponseStatus(const proto::Response& response) const
+grpc::Status FileContentsQuery::submitRequest(const proto::Query& request,
+                                              const std::shared_ptr<internal::Node>& node,
+                                              const std::chrono::system_clock::time_point& deadline,
+                                              proto::Response* response) const
 {
-  return gProtobufResponseCodeToStatus.at(
-    response.contractgetbytecoderesponse().header().nodetransactionprecheckcode());
+  return node->submitQuery(proto::Query::QueryCase::kFileGetContents, request, deadline, response);
 }
 
 //-----
-grpc::Status FileContentsQuery::submitRequest(const Client& client,
-                                              const std::chrono::system_clock::time_point& deadline,
-                                              const std::shared_ptr<internal::Node>& node,
-                                              proto::Response* response) const
+proto::Query FileContentsQuery::buildRequest(proto::QueryHeader* header) const
 {
-  return node->submitQuery(proto::Query::QueryCase::kFileGetContents, makeRequest(client, node), deadline, response);
+  auto fileGetContentsQuery = std::make_unique<proto::FileGetContentsQuery>();
+  fileGetContentsQuery->set_allocated_header(header);
+  fileGetContentsQuery->set_allocated_fileid(mFileId.toProtobuf().release());
+
+  proto::Query query;
+  query.set_allocated_filegetcontents(fileGetContentsQuery.release());
+  return query;
+}
+
+//-----
+proto::ResponseHeader FileContentsQuery::mapResponseHeader(const proto::Response& response) const
+{
+  return response.filegetcontents().header();
 }
 
 } // namespace Hedera

--- a/sdk/main/src/FileContentsQuery.cc
+++ b/sdk/main/src/FileContentsQuery.cc
@@ -65,7 +65,7 @@ proto::Query FileContentsQuery::buildRequest(proto::QueryHeader* header) const
 //-----
 proto::ResponseHeader FileContentsQuery::mapResponseHeader(const proto::Response& response) const
 {
-  Query<FileContentsQuery, FileContents>::saveCostFromHeader(response.filegetcontents().header());
+  saveCostFromHeader(response.filegetcontents().header());
   return response.filegetcontents().header();
 }
 

--- a/sdk/main/src/FileInfoQuery.cc
+++ b/sdk/main/src/FileInfoQuery.cc
@@ -65,7 +65,7 @@ proto::Query FileInfoQuery::buildRequest(proto::QueryHeader* header) const
 //-----
 proto::ResponseHeader FileInfoQuery::mapResponseHeader(const proto::Response& response) const
 {
-  Query<FileInfoQuery, FileInfo>::saveCostFromHeader(response.filegetinfo().header());
+  saveCostFromHeader(response.filegetinfo().header());
   return response.filegetinfo().header();
 }
 

--- a/sdk/main/src/FileInfoQuery.cc
+++ b/sdk/main/src/FileInfoQuery.cc
@@ -65,6 +65,7 @@ proto::Query FileInfoQuery::buildRequest(proto::QueryHeader* header) const
 //-----
 proto::ResponseHeader FileInfoQuery::mapResponseHeader(const proto::Response& response) const
 {
+  Query<FileInfoQuery, FileInfo>::saveCostFromHeader(response.filegetinfo().header());
   return response.filegetinfo().header();
 }
 

--- a/sdk/main/src/NetworkVersionInfoQuery.cc
+++ b/sdk/main/src/NetworkVersionInfoQuery.cc
@@ -60,7 +60,7 @@ proto::Query NetworkVersionInfoQuery::buildRequest(proto::QueryHeader* header) c
 //-----
 proto::ResponseHeader NetworkVersionInfoQuery::mapResponseHeader(const proto::Response& response) const
 {
-  Query<NetworkVersionInfoQuery, NetworkVersionInfo>::saveCostFromHeader(response.networkgetversioninfo().header());
+  saveCostFromHeader(response.networkgetversioninfo().header());
   return response.networkgetversioninfo().header();
 }
 

--- a/sdk/main/src/NetworkVersionInfoQuery.cc
+++ b/sdk/main/src/NetworkVersionInfoQuery.cc
@@ -60,6 +60,7 @@ proto::Query NetworkVersionInfoQuery::buildRequest(proto::QueryHeader* header) c
 //-----
 proto::ResponseHeader NetworkVersionInfoQuery::mapResponseHeader(const proto::Response& response) const
 {
+  Query<NetworkVersionInfoQuery, NetworkVersionInfo>::saveCostFromHeader(response.networkgetversioninfo().header());
   return response.networkgetversioninfo().header();
 }
 

--- a/sdk/main/src/NetworkVersionInfoQuery.cc
+++ b/sdk/main/src/NetworkVersionInfoQuery.cc
@@ -32,47 +32,35 @@
 namespace Hedera
 {
 //-----
-proto::Query NetworkVersionInfoQuery::makeRequest(const Client& client,
-                                                  const std::shared_ptr<internal::Node>& node) const
-{
-  proto::Query query;
-  proto::NetworkGetVersionInfoQuery* getNetworkVersionInfoQuery = query.mutable_networkgetversioninfo();
-
-  proto::QueryHeader* header = getNetworkVersionInfoQuery->mutable_header();
-  header->set_responsetype(proto::ANSWER_ONLY);
-
-  TransferTransaction tx = TransferTransaction()
-                             .setTransactionId(TransactionId::generate(*client.getOperatorAccountId()))
-                             .setNodeAccountIds({ node->getAccountId() })
-                             .setMaxTransactionFee(Hbar(1LL))
-                             .addHbarTransfer(*client.getOperatorAccountId(), Hbar(-1LL))
-                             .addHbarTransfer(node->getAccountId(), Hbar(1LL));
-  tx.onSelectNode(node);
-  header->set_allocated_payment(new proto::Transaction(tx.makeRequest(client, node)));
-
-  return query;
-}
-
-//-----
 NetworkVersionInfo NetworkVersionInfoQuery::mapResponse(const proto::Response& response) const
 {
   return NetworkVersionInfo::fromProtobuf(response.networkgetversioninfo());
 }
 
 //-----
-Status NetworkVersionInfoQuery::mapResponseStatus(const proto::Response& response) const
+grpc::Status NetworkVersionInfoQuery::submitRequest(const proto::Query& request,
+                                                    const std::shared_ptr<internal::Node>& node,
+                                                    const std::chrono::system_clock::time_point& deadline,
+                                                    proto::Response* response) const
 {
-  return gProtobufResponseCodeToStatus.at(response.networkgetversioninfo().header().nodetransactionprecheckcode());
+  return node->submitQuery(proto::Query::QueryCase::kNetworkGetVersionInfo, request, deadline, response);
 }
 
 //-----
-grpc::Status NetworkVersionInfoQuery::submitRequest(const Client& client,
-                                                    const std::chrono::system_clock::time_point& deadline,
-                                                    const std::shared_ptr<internal::Node>& node,
-                                                    proto::Response* response) const
+proto::Query NetworkVersionInfoQuery::buildRequest(proto::QueryHeader* header) const
 {
-  return node->submitQuery(
-    proto::Query::QueryCase::kNetworkGetVersionInfo, makeRequest(client, node), deadline, response);
+  auto networkVersionInfoQuery = std::make_unique<proto::NetworkGetVersionInfoQuery>();
+  networkVersionInfoQuery->set_allocated_header(header);
+
+  proto::Query query;
+  query.set_allocated_networkgetversioninfo(networkVersionInfoQuery.release());
+  return query;
+}
+
+//-----
+proto::ResponseHeader NetworkVersionInfoQuery::mapResponseHeader(const proto::Response& response) const
+{
+  return response.networkgetversioninfo().header();
 }
 
 } // namespace Hedera

--- a/sdk/main/src/PublicKey.cc
+++ b/sdk/main/src/PublicKey.cc
@@ -49,6 +49,24 @@ std::unique_ptr<PublicKey> PublicKey::fromStringDer(std::string_view key)
 }
 
 //-----
+std::unique_ptr<PublicKey> PublicKey::fromBytes(const std::vector<std::byte>& bytes)
+{
+  if (bytes.size() == ED25519PublicKey::KEY_SIZE)
+  {
+    return ED25519PublicKey::fromBytes(bytes);
+  }
+  else if (bytes.size() == ECDSAsecp256k1PublicKey::COMPRESSED_KEY_SIZE ||
+           bytes.size() == ECDSAsecp256k1PublicKey::UNCOMPRESSED_KEY_SIZE)
+  {
+    return ECDSAsecp256k1PublicKey::fromBytes(bytes);
+  }
+  else
+  {
+    return PublicKey::fromBytesDer(bytes);
+  }
+}
+
+//-----
 std::unique_ptr<PublicKey> PublicKey::fromBytesDer(const std::vector<std::byte>& bytes)
 {
   if (internal::Utilities::isPrefixOf(bytes, ED25519PublicKey::DER_ENCODED_PREFIX_BYTES))

--- a/sdk/main/src/Query.cc
+++ b/sdk/main/src/Query.cc
@@ -22,6 +22,7 @@
 #include "AccountBalanceQuery.h"
 #include "AccountRecords.h"
 #include "AccountRecordsQuery.h"
+#include "Client.h"
 #include "ContractCallQuery.h"
 #include "ContractFunctionResult.h"
 #include "ContractInfo.h"
@@ -29,21 +30,250 @@
 #include "FileContentsQuery.h"
 #include "FileInfo.h"
 #include "FileInfoQuery.h"
+#include "Hbar.h"
 #include "ScheduleInfo.h"
 #include "ScheduleInfoQuery.h"
+#include "Status.h"
 #include "TokenInfo.h"
 #include "TokenInfoQuery.h"
 #include "TokenNftInfo.h"
 #include "TokenNftInfoQuery.h"
 #include "TopicInfo.h"
 #include "TopicInfoQuery.h"
+#include "TransactionId.h"
 #include "TransactionReceipt.h"
 #include "TransactionReceiptQuery.h"
 #include "TransactionRecord.h"
 #include "TransactionRecordQuery.h"
+#include "TransferTransaction.h"
+#include "exceptions/MaxQueryPaymentExceededException.h"
+#include "impl/Network.h"
+
+#include <optional>
+#include <proto/query.pb.h>
+#include <proto/query_header.pb.h>
+#include <proto/transaction.pb.h>
+#include <unordered_map>
 
 namespace Hedera
 {
+//-----
+template<typename SdkRequestType, typename SdkResponseType>
+struct Query<SdkRequestType, SdkResponseType>::QueryImpl
+{
+  // The explicit amount to pay for this Query.
+  std::optional<Hbar> mPayment;
+
+  // The maximum amount to pay for this Query.
+  std::optional<Hbar> mMaxPayment;
+
+  // Is this Query meant to get the cost?
+  bool mGetCost = false;
+
+  // The cost to execute this Query.
+  Hbar mCost;
+
+  // The Client that should be used to pay for the payment transaction of this Query.
+  Client* mClient;
+
+  // The TransactionID of the payment transactions for this Query.
+  TransactionId mPaymentTransactionId;
+
+  // The map of node account IDs to their respective payment Transaction protobuf objects that could be sent.
+  std::unordered_map<AccountId, proto::Transaction> mPaymentTransactions;
+};
+
+//-----
+template<typename SdkRequestType, typename SdkResponseType>
+SdkRequestType& Query<SdkRequestType, SdkResponseType>::setQueryPayment(const Hbar& amount)
+{
+  mImpl->mPayment = amount;
+  return static_cast<SdkRequestType&>(*this);
+}
+
+//-----
+template<typename SdkRequestType, typename SdkResponseType>
+SdkRequestType& Query<SdkRequestType, SdkResponseType>::setMaxQueryPayment(const Hbar& maxAmount)
+{
+  mImpl->mMaxPayment = maxAmount;
+  return static_cast<SdkRequestType&>(*this);
+}
+
+//-----
+template<typename SdkRequestType, typename SdkResponseType>
+Hbar Query<SdkRequestType, SdkResponseType>::getCost(const Client& client)
+{
+  return getCost(client, client.getRequestTimeout());
+}
+
+//-----
+template<typename SdkRequestType, typename SdkResponseType>
+Hbar Query<SdkRequestType, SdkResponseType>::getCost(const Client& client, const std::chrono::duration<double>& timeout)
+{
+  // Initialize this Query with node account IDs.
+  setNodeAccountIds(client);
+
+  // Construct a separate derived Query and set it to get the cost.
+  SdkRequestType costQuery;
+  costQuery.mImpl->mGetCost = true;
+  costQuery.setNodeAccountIds(client);
+
+  // Execute the cost query and return the cost.
+  costQuery.execute(client, timeout);
+  return costQuery.mImpl->mCost;
+}
+
+//-----
+template<typename SdkRequestType, typename SdkResponseType>
+void Query<SdkRequestType, SdkResponseType>::saveCostFromHeader(const proto::ResponseHeader& header)
+{
+  if (mImpl->mGetCost)
+  {
+    mImpl->mCost = Hbar(static_cast<int64_t>(header.cost()), HbarUnit::TINYBAR());
+  }
+}
+
+//-----
+template<typename SdkRequestType, typename SdkResponseType>
+Query<SdkRequestType, SdkResponseType>::~Query() = default;
+
+//-----
+template<typename SdkRequestType, typename SdkResponseType>
+Query<SdkRequestType, SdkResponseType>::Query(const Query<SdkRequestType, SdkResponseType>& other)
+  : mImpl(std::make_unique<QueryImpl>(*other.mImpl))
+{
+}
+
+//-----
+template<typename SdkRequestType, typename SdkResponseType>
+Query<SdkRequestType, SdkResponseType>& Query<SdkRequestType, SdkResponseType>::operator=(
+  const Query<SdkRequestType, SdkResponseType>& other)
+{
+  if (this != &other)
+  {
+    mImpl = std::make_unique<QueryImpl>(*other.mImpl);
+  }
+
+  return *this;
+}
+
+//-----
+template<typename SdkRequestType, typename SdkResponseType>
+Query<SdkRequestType, SdkResponseType>::Query(Query<SdkRequestType, SdkResponseType>&& other) noexcept
+  : mImpl(std::move(other.mImpl))
+{
+  // Leave moved-from object in a valid state.
+  other.mImpl = std::make_unique<QueryImpl>();
+}
+
+//-----
+template<typename SdkRequestType, typename SdkResponseType>
+Query<SdkRequestType, SdkResponseType>& Query<SdkRequestType, SdkResponseType>::operator=(
+  Query<SdkRequestType, SdkResponseType>&& other) noexcept
+{
+  if (this != &other)
+  {
+    mImpl = std::move(other.mImpl);
+
+    // Leave moved-from object in a valid state.
+    other.mImpl = std::make_unique<QueryImpl>();
+  }
+
+  return *this;
+}
+
+//-----
+template<typename SdkRequestType, typename SdkResponseType>
+proto::Query Query<SdkRequestType, SdkResponseType>::makeRequest(unsigned int index) const
+{
+  auto header = std::make_unique<proto::QueryHeader>();
+
+  if (isPaymentRequired() && !mImpl->mGetCost)
+  {
+    // Get the node account ID for this index.
+    const AccountId accountId =
+      Executable<SdkRequestType, proto::Query, proto::Response, SdkResponseType>::getNodeAccountIds().at(index);
+
+    // See if the payment transaction has been created for this index already.
+    if (mImpl->mPaymentTransactions.find(accountId) == mImpl->mPaymentTransactions.end())
+    {
+      if (mImpl->mPaymentTransactionId == TransactionId())
+      {
+        mImpl->mPaymentTransactionId = TransactionId::generate(mImpl->mClient->getOperatorAccountId().value());
+      }
+
+      mImpl->mPaymentTransactions[accountId] =
+        makePaymentTransaction(mImpl->mPaymentTransactionId, accountId, *mImpl->mClient, mImpl->mCost);
+    }
+
+    header->set_allocated_payment(
+      std::make_unique<proto::Transaction>(mImpl->mPaymentTransactions.at(accountId)).release());
+  }
+
+  header->set_responsetype(mImpl->mGetCost ? proto::ResponseType::COST_ANSWER : proto::ResponseType::ANSWER_ONLY);
+  return buildRequest(header.release());
+}
+
+//-----
+template<typename SdkRequestType, typename SdkResponseType>
+Status Query<SdkRequestType, SdkResponseType>::mapResponseStatus(const proto::Response& response) const
+{
+  return gProtobufResponseCodeToStatus.at(mapResponseHeader(response).nodetransactionprecheckcode());
+}
+
+//-----
+template<typename SdkRequestType, typename SdkResponseType>
+void Query<SdkRequestType, SdkResponseType>::onExecute(const Client& client)
+{
+  if (!isPaymentRequired())
+  {
+    return;
+  }
+
+  // Get the cost and make sure it's willing to be paid.
+  mImpl->mCost = getCost(client);
+  if (mImpl->mCost.toTinybars() > ((mImpl->mMaxPayment.has_value()) ? mImpl->mMaxPayment->toTinybars()
+                                                                    : ((client.getMaxQueryPayment().has_value())
+                                                                         ? client.getMaxQueryPayment()->toTinybars()
+                                                                         : DEFAULT_MAX_QUERY_PAYMENT.toTinybars())))
+  {
+    throw MaxQueryPaymentExceededException("Cost to execute Query (" + std::to_string(mImpl->mCost.toTinybars()) +
+                                           HbarUnit::TINYBAR().getSymbol() + ") is larger than allowed amount.");
+  }
+}
+
+//-----
+template<typename SdkRequestType, typename SdkResponseType>
+proto::Transaction Query<SdkRequestType, SdkResponseType>::makePaymentTransaction(const TransactionId& transactionId,
+                                                                                  const AccountId& nodeAccountId,
+                                                                                  const Client& client,
+                                                                                  const Hbar& amount) const
+{
+  return TransferTransaction()
+    .setTransactionId(transactionId)
+    .setNodeAccountIds({ nodeAccountId })
+    .setMaxTransactionFee(Hbar(1LL))
+    .addHbarTransfer(client.getOperatorAccountId().value(), amount.negated())
+    .addHbarTransfer(nodeAccountId, amount)
+    .freeze()
+    .signWith(client.getOperatorPublicKey(), client.getOperatorSigner())
+    // There's only one node account ID, therefore only one Transaction protobuf object will be created, and that will
+    // be put in the 0th index.
+    .makeRequest(0);
+}
+
+//-----
+template<typename SdkRequestType, typename SdkResponseType>
+void Query<SdkRequestType, SdkResponseType>::setNodeAccountIds(const Client& client)
+{
+  // Do nothing if node account IDs have already been set.
+  if (!Executable<SdkRequestType, proto::Query, proto::Response, SdkResponseType>::getNodeAccountIds().empty())
+  {
+    Executable<SdkRequestType, proto::Query, proto::Response, SdkResponseType>::setNodeAccountIds(
+      client.getNetwork()->getNodeAccountIdsForExecute());
+  }
+}
+
 /**
  * Explicit template instantiations.
  */

--- a/sdk/main/src/Query.cc
+++ b/sdk/main/src/Query.cc
@@ -24,12 +24,9 @@
 #include "AccountInfoQuery.h"
 #include "AccountRecords.h"
 #include "AccountRecordsQuery.h"
-<<<<<<< HEAD
+#include "AccountStakersQuery.h"
 #include "Client.h"
 #include "ContractByteCodeQuery.h"
-=======
-#include "AccountStakersQuery.h"
->>>>>>> main
 #include "ContractCallQuery.h"
 #include "ContractFunctionResult.h"
 #include "ContractInfo.h"
@@ -37,12 +34,9 @@
 #include "FileContentsQuery.h"
 #include "FileInfo.h"
 #include "FileInfoQuery.h"
-<<<<<<< HEAD
 #include "Hbar.h"
-=======
 #include "NetworkVersionInfo.h"
 #include "NetworkVersionInfoQuery.h"
->>>>>>> main
 #include "ScheduleInfo.h"
 #include "ScheduleInfoQuery.h"
 #include "Status.h"
@@ -299,11 +293,8 @@ void Query<SdkRequestType, SdkResponseType>::setNodeAccountIds(const Client& cli
 template class Query<AccountBalanceQuery, AccountBalance>;
 template class Query<AccountInfoQuery, AccountInfo>;
 template class Query<AccountRecordsQuery, AccountRecords>;
-<<<<<<< HEAD
-template class Query<ContractByteCodeQuery, ContractByteCode>;
-=======
 template class Query<AccountStakersQuery, AccountStakers>;
->>>>>>> main
+template class Query<ContractByteCodeQuery, ContractByteCode>;
 template class Query<ContractCallQuery, ContractFunctionResult>;
 template class Query<ContractInfoQuery, ContractInfo>;
 template class Query<FileContentsQuery, FileContents>;

--- a/sdk/main/src/Query.cc
+++ b/sdk/main/src/Query.cc
@@ -20,9 +20,12 @@
 #include "Query.h"
 #include "AccountBalance.h"
 #include "AccountBalanceQuery.h"
+#include "AccountInfo.h"
+#include "AccountInfoQuery.h"
 #include "AccountRecords.h"
 #include "AccountRecordsQuery.h"
 #include "Client.h"
+#include "ContractByteCodeQuery.h"
 #include "ContractCallQuery.h"
 #include "ContractFunctionResult.h"
 #include "ContractInfo.h"
@@ -74,7 +77,7 @@ struct Query<SdkRequestType, SdkResponseType>::QueryImpl
   Hbar mCost;
 
   // The Client that should be used to pay for the payment transaction of this Query.
-  Client* mClient;
+  Client* mClient = nullptr;
 
   // The TransactionID of the payment transactions for this Query.
   TransactionId mPaymentTransactionId;
@@ -131,6 +134,13 @@ void Query<SdkRequestType, SdkResponseType>::saveCostFromHeader(const proto::Res
   {
     mImpl->mCost = Hbar(static_cast<int64_t>(header.cost()), HbarUnit::TINYBAR());
   }
+}
+
+//-----
+template<typename SdkRequestType, typename SdkResponseType>
+Query<SdkRequestType, SdkResponseType>::Query()
+  : mImpl(std::make_unique<QueryImpl>())
+{
 }
 
 //-----
@@ -278,7 +288,9 @@ void Query<SdkRequestType, SdkResponseType>::setNodeAccountIds(const Client& cli
  * Explicit template instantiations.
  */
 template class Query<AccountBalanceQuery, AccountBalance>;
+template class Query<AccountInfoQuery, AccountInfo>;
 template class Query<AccountRecordsQuery, AccountRecords>;
+template class Query<ContractByteCodeQuery, ContractByteCode>;
 template class Query<ContractCallQuery, ContractFunctionResult>;
 template class Query<ContractInfoQuery, ContractInfo>;
 template class Query<FileContentsQuery, FileContents>;

--- a/sdk/main/src/ScheduleCreateTransaction.cc
+++ b/sdk/main/src/ScheduleCreateTransaction.cc
@@ -55,7 +55,8 @@ struct ScheduleCreateTransaction::ScheduleCreateTransactionImpl
 
 //-----
 ScheduleCreateTransaction::ScheduleCreateTransaction()
-  : mImpl(std::make_unique<ScheduleCreateTransactionImpl>())
+  : Transaction<ScheduleCreateTransaction>()
+  , mImpl(std::make_unique<ScheduleCreateTransactionImpl>())
 {
   setDefaultMaxTransactionFee(Hbar(5LL));
 }
@@ -65,7 +66,8 @@ ScheduleCreateTransaction::~ScheduleCreateTransaction() = default;
 
 //-----
 ScheduleCreateTransaction::ScheduleCreateTransaction(const ScheduleCreateTransaction& other)
-  : mImpl(std::make_unique<ScheduleCreateTransactionImpl>(*other.mImpl))
+  : Transaction<ScheduleCreateTransaction>(other)
+  , mImpl(std::make_unique<ScheduleCreateTransactionImpl>(*other.mImpl))
 {
 }
 
@@ -74,6 +76,7 @@ ScheduleCreateTransaction& ScheduleCreateTransaction::operator=(const ScheduleCr
 {
   if (this != &other)
   {
+    Transaction<ScheduleCreateTransaction>::operator=(other);
     mImpl = std::make_unique<ScheduleCreateTransactionImpl>(*other.mImpl);
   }
 
@@ -82,10 +85,11 @@ ScheduleCreateTransaction& ScheduleCreateTransaction::operator=(const ScheduleCr
 
 //-----
 ScheduleCreateTransaction::ScheduleCreateTransaction(ScheduleCreateTransaction&& other) noexcept
-  : mImpl(std::move(other.mImpl))
+  : Transaction<ScheduleCreateTransaction>(std::move(other))
+  , mImpl(std::move(other.mImpl)) // NOLINT
 {
   // Leave the moved-from ScheduleCreateTransaction in a valid state.
-  other.mImpl = std::make_unique<ScheduleCreateTransactionImpl>();
+  other.mImpl = std::make_unique<ScheduleCreateTransactionImpl>(); // NOLINT
 }
 
 //-----
@@ -93,7 +97,8 @@ ScheduleCreateTransaction& ScheduleCreateTransaction::operator=(ScheduleCreateTr
 {
   if (this != &other)
   {
-    mImpl = std::move(other.mImpl);
+    Transaction<ScheduleCreateTransaction>::operator=(std::move(other));
+    mImpl = std::move(other.mImpl); // NOLINT
 
     // Leave the moved-from ScheduleCreateTransaction in a valid state.
     other.mImpl = std::make_unique<ScheduleCreateTransactionImpl>();

--- a/sdk/main/src/ScheduleCreateTransaction.cc
+++ b/sdk/main/src/ScheduleCreateTransaction.cc
@@ -55,8 +55,9 @@ struct ScheduleCreateTransaction::ScheduleCreateTransactionImpl
 
 //-----
 ScheduleCreateTransaction::ScheduleCreateTransaction()
+  : mImpl(std::make_unique<ScheduleCreateTransactionImpl>())
 {
-  initImpl();
+  setDefaultMaxTransactionFee(Hbar(5LL));
 }
 
 //-----
@@ -92,7 +93,7 @@ ScheduleCreateTransaction& ScheduleCreateTransaction::operator=(ScheduleCreateTr
 {
   if (this != &other)
   {
-    mImpl = std::make_unique<ScheduleCreateTransactionImpl>(*other.mImpl);
+    mImpl = std::move(other.mImpl);
 
     // Leave the moved-from ScheduleCreateTransaction in a valid state.
     other.mImpl = std::make_unique<ScheduleCreateTransactionImpl>();
@@ -104,39 +105,20 @@ ScheduleCreateTransaction& ScheduleCreateTransaction::operator=(ScheduleCreateTr
 //-----
 ScheduleCreateTransaction::ScheduleCreateTransaction(const proto::TransactionBody& transactionBody)
   : Transaction<ScheduleCreateTransaction>(transactionBody)
+  , mImpl(std::make_unique<ScheduleCreateTransactionImpl>())
 {
-  initImpl();
+  setDefaultMaxTransactionFee(Hbar(5LL));
+  initFromSourceTransactionBody();
+}
 
-  if (!transactionBody.has_schedulecreate())
-  {
-    throw std::invalid_argument("Transaction body doesn't contain ScheduleCreate data");
-  }
-
-  const proto::ScheduleCreateTransactionBody& body = transactionBody.schedulecreate();
-
-  if (body.has_scheduledtransactionbody())
-  {
-    mImpl->mTransactionToSchedule = WrappedTransaction::fromProtobuf(body.scheduledtransactionbody());
-  }
-
-  mImpl->mMemo = body.memo();
-
-  if (body.has_adminkey())
-  {
-    mImpl->mAdminKey = Key::fromProtobuf(body.adminkey());
-  }
-
-  if (body.has_payeraccountid())
-  {
-    mImpl->mPayerAccountId = AccountId::fromProtobuf(body.payeraccountid());
-  }
-
-  if (body.has_expiration_time())
-  {
-    mImpl->mExpirationTime = internal::TimestampConverter::fromProtobuf(body.expiration_time());
-  }
-
-  mImpl->mWaitForExpiration = body.wait_for_expiry();
+//-----
+ScheduleCreateTransaction::ScheduleCreateTransaction(
+  const std::map<TransactionId, std::map<AccountId, proto::Transaction>>& transactions)
+  : Transaction<ScheduleCreateTransaction>(transactions)
+  , mImpl(std::make_unique<ScheduleCreateTransactionImpl>())
+{
+  setDefaultMaxTransactionFee(Hbar(5LL));
+  initFromSourceTransactionBody();
 }
 
 //-----
@@ -225,20 +207,12 @@ bool ScheduleCreateTransaction::isWaitForExpiry() const
 }
 
 //-----
-proto::Transaction ScheduleCreateTransaction::makeRequest(const Client& client,
-                                                          const std::shared_ptr<internal::Node>&) const
-{
-  return signTransaction(generateTransactionBody(&client), client);
-}
-
-//-----
-grpc::Status ScheduleCreateTransaction::submitRequest(const Client& client,
-                                                      const std::chrono::system_clock::time_point& deadline,
+grpc::Status ScheduleCreateTransaction::submitRequest(const proto::Transaction& request,
                                                       const std::shared_ptr<internal::Node>& node,
+                                                      const std::chrono::system_clock::time_point& deadline,
                                                       proto::TransactionResponse* response) const
 {
-  return node->submitTransaction(
-    proto::TransactionBody::DataCase::kScheduleCreate, makeRequest(client, node), deadline, response);
+  return node->submitTransaction(proto::TransactionBody::DataCase::kScheduleCreate, request, deadline, response);
 }
 
 //-----
@@ -248,10 +222,47 @@ void ScheduleCreateTransaction::addToBody(proto::TransactionBody& body) const
 }
 
 //-----
+void ScheduleCreateTransaction::initFromSourceTransactionBody()
+{
+  const proto::TransactionBody transactionBody = getSourceTransactionBody();
+
+  if (!transactionBody.has_schedulecreate())
+  {
+    throw std::invalid_argument("Transaction body doesn't contain ScheduleCreate data");
+  }
+
+  const proto::ScheduleCreateTransactionBody& body = transactionBody.schedulecreate();
+
+  if (body.has_scheduledtransactionbody())
+  {
+    mImpl->mTransactionToSchedule = WrappedTransaction::fromProtobuf(body.scheduledtransactionbody());
+  }
+
+  mImpl->mMemo = body.memo();
+
+  if (body.has_adminkey())
+  {
+    mImpl->mAdminKey = Key::fromProtobuf(body.adminkey());
+  }
+
+  if (body.has_payeraccountid())
+  {
+    mImpl->mPayerAccountId = AccountId::fromProtobuf(body.payeraccountid());
+  }
+
+  if (body.has_expiration_time())
+  {
+    mImpl->mExpirationTime = internal::TimestampConverter::fromProtobuf(body.expiration_time());
+  }
+
+  mImpl->mWaitForExpiration = body.wait_for_expiry();
+}
+
+//-----
 proto::ScheduleCreateTransactionBody* ScheduleCreateTransaction::build() const
 {
   auto body = std::make_unique<proto::ScheduleCreateTransactionBody>();
-  
+
   body->set_allocated_scheduledtransactionbody(mImpl->mTransactionToSchedule.toSchedulableProtobuf().release());
   body->set_memo(mImpl->mMemo);
 
@@ -273,12 +284,6 @@ proto::ScheduleCreateTransactionBody* ScheduleCreateTransaction::build() const
   body->set_wait_for_expiry(mImpl->mWaitForExpiration);
 
   return body.release();
-}
-
-//-----
-void ScheduleCreateTransaction::initImpl()
-{
-  mImpl = std::make_unique<ScheduleCreateTransactionImpl>();
 }
 
 } // namespace Hedera

--- a/sdk/main/src/ScheduleInfoQuery.cc
+++ b/sdk/main/src/ScheduleInfoQuery.cc
@@ -65,7 +65,7 @@ proto::Query ScheduleInfoQuery::buildRequest(proto::QueryHeader* header) const
 //-----
 proto::ResponseHeader ScheduleInfoQuery::mapResponseHeader(const proto::Response& response) const
 {
-  Query<ScheduleInfoQuery, ScheduleInfo>::saveCostFromHeader(response.schedulegetinfo().header());
+  saveCostFromHeader(response.schedulegetinfo().header());
   return response.schedulegetinfo().header();
 }
 

--- a/sdk/main/src/ScheduleInfoQuery.cc
+++ b/sdk/main/src/ScheduleInfoQuery.cc
@@ -65,6 +65,7 @@ proto::Query ScheduleInfoQuery::buildRequest(proto::QueryHeader* header) const
 //-----
 proto::ResponseHeader ScheduleInfoQuery::mapResponseHeader(const proto::Response& response) const
 {
+  Query<ScheduleInfoQuery, ScheduleInfo>::saveCostFromHeader(response.schedulegetinfo().header());
   return response.schedulegetinfo().header();
 }
 

--- a/sdk/main/src/ScheduleInfoQuery.cc
+++ b/sdk/main/src/ScheduleInfoQuery.cc
@@ -18,10 +18,7 @@
  *
  */
 #include "ScheduleInfoQuery.h"
-#include "Client.h"
 #include "ScheduleInfo.h"
-#include "TransactionRecord.h"
-#include "TransferTransaction.h"
 #include "impl/Node.h"
 
 #include <proto/query.pb.h>
@@ -39,47 +36,36 @@ ScheduleInfoQuery& ScheduleInfoQuery::setScheduleId(const ScheduleId& scheduleId
 }
 
 //-----
-proto::Query ScheduleInfoQuery::makeRequest(const Client& client, const std::shared_ptr<internal::Node>& node) const
-{
-  proto::Query query;
-  proto::ScheduleGetInfoQuery* getScheduleInfoQuery = query.mutable_schedulegetinfo();
-
-  proto::QueryHeader* header = getScheduleInfoQuery->mutable_header();
-  header->set_responsetype(proto::ANSWER_ONLY);
-
-  TransferTransaction tx = TransferTransaction()
-                             .setTransactionId(TransactionId::generate(*client.getOperatorAccountId()))
-                             .setNodeAccountIds({ node->getAccountId() })
-                             .setMaxTransactionFee(Hbar(1LL))
-                             .addHbarTransfer(*client.getOperatorAccountId(), Hbar(-1LL))
-                             .addHbarTransfer(node->getAccountId(), Hbar(1LL));
-  tx.onSelectNode(node);
-  header->set_allocated_payment(new proto::Transaction(tx.makeRequest(client, node)));
-
-  getScheduleInfoQuery->set_allocated_scheduleid(mScheduleId.toProtobuf().release());
-
-  return query;
-}
-
-//-----
 ScheduleInfo ScheduleInfoQuery::mapResponse(const proto::Response& response) const
 {
   return ScheduleInfo::fromProtobuf(response.schedulegetinfo().scheduleinfo());
 }
 
 //-----
-Status ScheduleInfoQuery::mapResponseStatus(const proto::Response& response) const
+grpc::Status ScheduleInfoQuery::submitRequest(const proto::Query& request,
+                                              const std::shared_ptr<internal::Node>& node,
+                                              const std::chrono::system_clock::time_point& deadline,
+                                              proto::Response* response) const
 {
-  return gProtobufResponseCodeToStatus.at(response.schedulegetinfo().header().nodetransactionprecheckcode());
+  return node->submitQuery(proto::Query::QueryCase::kScheduleGetInfo, request, deadline, response);
 }
 
 //-----
-grpc::Status ScheduleInfoQuery::submitRequest(const Client& client,
-                                              const std::chrono::system_clock::time_point& deadline,
-                                              const std::shared_ptr<internal::Node>& node,
-                                              proto::Response* response) const
+proto::Query ScheduleInfoQuery::buildRequest(proto::QueryHeader* header) const
 {
-  return node->submitQuery(proto::Query::QueryCase::kScheduleGetInfo, makeRequest(client, node), deadline, response);
+  auto scheduleGetInfoQuery = std::make_unique<proto::ScheduleGetInfoQuery>();
+  scheduleGetInfoQuery->set_allocated_header(header);
+  scheduleGetInfoQuery->set_allocated_scheduleid(mScheduleId.toProtobuf().release());
+
+  proto::Query query;
+  query.set_allocated_schedulegetinfo(scheduleGetInfoQuery.release());
+  return query;
+}
+
+//-----
+proto::ResponseHeader ScheduleInfoQuery::mapResponseHeader(const proto::Response& response) const
+{
+  return response.schedulegetinfo().header();
 }
 
 } // namespace Hedera

--- a/sdk/main/src/TokenFeeScheduleUpdateTransaction.cc
+++ b/sdk/main/src/TokenFeeScheduleUpdateTransaction.cc
@@ -31,22 +31,15 @@ namespace Hedera
 TokenFeeScheduleUpdateTransaction::TokenFeeScheduleUpdateTransaction(const proto::TransactionBody& transactionBody)
   : Transaction<TokenFeeScheduleUpdateTransaction>(transactionBody)
 {
-  if (!transactionBody.has_token_fee_schedule_update())
-  {
-    throw std::invalid_argument("Transaction body doesn't contain TokenFeeScheduleUpdate data");
-  }
+  initFromSourceTransactionBody();
+}
 
-  const proto::TokenFeeScheduleUpdateTransactionBody& body = transactionBody.token_fee_schedule_update();
-
-  if (body.has_token_id())
-  {
-    mTokenId = TokenId::fromProtobuf(body.token_id());
-  }
-
-  for (int i = 0; i < body.custom_fees_size(); ++i)
-  {
-    mCustomFees.push_back(CustomFee::fromProtobuf(body.custom_fees(i)));
-  }
+//-----
+TokenFeeScheduleUpdateTransaction::TokenFeeScheduleUpdateTransaction(
+  const std::map<TransactionId, std::map<AccountId, proto::Transaction>>& transactions)
+  : Transaction<TokenFeeScheduleUpdateTransaction>(transactions)
+{
+  initFromSourceTransactionBody();
 }
 
 //-----
@@ -67,26 +60,42 @@ TokenFeeScheduleUpdateTransaction& TokenFeeScheduleUpdateTransaction::setCustomF
 }
 
 //-----
-proto::Transaction TokenFeeScheduleUpdateTransaction::makeRequest(const Client& client,
-                                                                  const std::shared_ptr<internal::Node>&) const
-{
-  return signTransaction(generateTransactionBody(&client), client);
-}
-
-//-----
-grpc::Status TokenFeeScheduleUpdateTransaction::submitRequest(const Client& client,
-                                                              const std::chrono::system_clock::time_point& deadline,
+grpc::Status TokenFeeScheduleUpdateTransaction::submitRequest(const proto::Transaction& request,
                                                               const std::shared_ptr<internal::Node>& node,
+                                                              const std::chrono::system_clock::time_point& deadline,
                                                               proto::TransactionResponse* response) const
 {
   return node->submitTransaction(
-    proto::TransactionBody::DataCase::kTokenFeeScheduleUpdate, makeRequest(client, node), deadline, response);
+    proto::TransactionBody::DataCase::kTokenFeeScheduleUpdate, request, deadline, response);
 }
 
 //-----
 void TokenFeeScheduleUpdateTransaction::addToBody(proto::TransactionBody& body) const
 {
   body.set_allocated_token_fee_schedule_update(build());
+}
+
+//-----
+void TokenFeeScheduleUpdateTransaction::initFromSourceTransactionBody()
+{
+  const proto::TransactionBody transactionBody = getSourceTransactionBody();
+
+  if (!transactionBody.has_token_fee_schedule_update())
+  {
+    throw std::invalid_argument("Transaction body doesn't contain TokenFeeScheduleUpdate data");
+  }
+
+  const proto::TokenFeeScheduleUpdateTransactionBody& body = transactionBody.token_fee_schedule_update();
+
+  if (body.has_token_id())
+  {
+    mTokenId = TokenId::fromProtobuf(body.token_id());
+  }
+
+  for (int i = 0; i < body.custom_fees_size(); ++i)
+  {
+    mCustomFees.push_back(CustomFee::fromProtobuf(body.custom_fees(i)));
+  }
 }
 
 //-----

--- a/sdk/main/src/TokenInfoQuery.cc
+++ b/sdk/main/src/TokenInfoQuery.cc
@@ -65,7 +65,7 @@ proto::Query TokenInfoQuery::buildRequest(proto::QueryHeader* header) const
 //-----
 proto::ResponseHeader TokenInfoQuery::mapResponseHeader(const proto::Response& response) const
 {
-  Query<TokenInfoQuery, TokenInfo>::saveCostFromHeader(response.tokengetinfo().header());
+  saveCostFromHeader(response.tokengetinfo().header());
   return response.tokengetinfo().header();
 }
 

--- a/sdk/main/src/TokenInfoQuery.cc
+++ b/sdk/main/src/TokenInfoQuery.cc
@@ -65,6 +65,7 @@ proto::Query TokenInfoQuery::buildRequest(proto::QueryHeader* header) const
 //-----
 proto::ResponseHeader TokenInfoQuery::mapResponseHeader(const proto::Response& response) const
 {
+  Query<TokenInfoQuery, TokenInfo>::saveCostFromHeader(response.tokengetinfo().header());
   return response.tokengetinfo().header();
 }
 

--- a/sdk/main/src/TokenInfoQuery.cc
+++ b/sdk/main/src/TokenInfoQuery.cc
@@ -18,10 +18,7 @@
  *
  */
 #include "TokenInfoQuery.h"
-#include "Client.h"
 #include "TokenInfo.h"
-#include "TransactionRecord.h"
-#include "TransferTransaction.h"
 #include "impl/Node.h"
 
 #include <proto/query.pb.h>
@@ -39,47 +36,36 @@ TokenInfoQuery& TokenInfoQuery::setTokenId(const TokenId& tokenId)
 }
 
 //-----
-proto::Query TokenInfoQuery::makeRequest(const Client& client, const std::shared_ptr<internal::Node>& node) const
-{
-  proto::Query query;
-  proto::TokenGetInfoQuery* getTokenInfoQuery = query.mutable_tokengetinfo();
-
-  proto::QueryHeader* header = getTokenInfoQuery->mutable_header();
-  header->set_responsetype(proto::ANSWER_ONLY);
-
-  TransferTransaction tx = TransferTransaction()
-                             .setTransactionId(TransactionId::generate(*client.getOperatorAccountId()))
-                             .setNodeAccountIds({ node->getAccountId() })
-                             .setMaxTransactionFee(Hbar(1LL))
-                             .addHbarTransfer(*client.getOperatorAccountId(), Hbar(-1LL))
-                             .addHbarTransfer(node->getAccountId(), Hbar(1LL));
-  tx.onSelectNode(node);
-  header->set_allocated_payment(new proto::Transaction(tx.makeRequest(client, node)));
-
-  getTokenInfoQuery->set_allocated_token(mTokenId.toProtobuf().release());
-
-  return query;
-}
-
-//-----
 TokenInfo TokenInfoQuery::mapResponse(const proto::Response& response) const
 {
   return TokenInfo::fromProtobuf(response.tokengetinfo().tokeninfo());
 }
 
 //-----
-Status TokenInfoQuery::mapResponseStatus(const proto::Response& response) const
+grpc::Status TokenInfoQuery::submitRequest(const proto::Query& request,
+                                           const std::shared_ptr<internal::Node>& node,
+                                           const std::chrono::system_clock::time_point& deadline,
+                                           proto::Response* response) const
 {
-  return gProtobufResponseCodeToStatus.at(response.tokengetinfo().header().nodetransactionprecheckcode());
+  return node->submitQuery(proto::Query::QueryCase::kTokenGetInfo, request, deadline, response);
 }
 
 //-----
-grpc::Status TokenInfoQuery::submitRequest(const Client& client,
-                                           const std::chrono::system_clock::time_point& deadline,
-                                           const std::shared_ptr<internal::Node>& node,
-                                           proto::Response* response) const
+proto::Query TokenInfoQuery::buildRequest(proto::QueryHeader* header) const
 {
-  return node->submitQuery(proto::Query::QueryCase::kTokenGetInfo, makeRequest(client, node), deadline, response);
+  auto tokenGetInfoQuery = std::make_unique<proto::TokenGetInfoQuery>();
+  tokenGetInfoQuery->set_allocated_header(header);
+  tokenGetInfoQuery->set_allocated_token(mTokenId.toProtobuf().release());
+
+  proto::Query query;
+  query.set_allocated_tokengetinfo(tokenGetInfoQuery.release());
+  return query;
+}
+
+//-----
+proto::ResponseHeader TokenInfoQuery::mapResponseHeader(const proto::Response& response) const
+{
+  return response.tokengetinfo().header();
 }
 
 } // namespace Hedera

--- a/sdk/main/src/TokenNftInfoQuery.cc
+++ b/sdk/main/src/TokenNftInfoQuery.cc
@@ -68,7 +68,7 @@ proto::Query TokenNftInfoQuery::buildRequest(proto::QueryHeader* header) const
 //-----
 proto::ResponseHeader TokenNftInfoQuery::mapResponseHeader(const proto::Response& response) const
 {
-  Query<TokenNftInfoQuery, TokenNftInfo>::saveCostFromHeader(response.tokengetnftinfo().header());
+  saveCostFromHeader(response.tokengetnftinfo().header());
   return response.tokengetnftinfo().header();
 }
 

--- a/sdk/main/src/TokenNftInfoQuery.cc
+++ b/sdk/main/src/TokenNftInfoQuery.cc
@@ -68,6 +68,7 @@ proto::Query TokenNftInfoQuery::buildRequest(proto::QueryHeader* header) const
 //-----
 proto::ResponseHeader TokenNftInfoQuery::mapResponseHeader(const proto::Response& response) const
 {
+  Query<TokenNftInfoQuery, TokenNftInfo>::saveCostFromHeader(response.tokengetnftinfo().header());
   return response.tokengetnftinfo().header();
 }
 

--- a/sdk/main/src/TokenNftInfoQuery.cc
+++ b/sdk/main/src/TokenNftInfoQuery.cc
@@ -39,47 +39,36 @@ TokenNftInfoQuery& TokenNftInfoQuery::setNftId(const NftId& nft)
 }
 
 //-----
-proto::Query TokenNftInfoQuery::makeRequest(const Client& client, const std::shared_ptr<internal::Node>& node) const
-{
-  proto::Query query;
-  proto::TokenGetNftInfoQuery* getTokenNftInfoQuery = query.mutable_tokengetnftinfo();
-
-  proto::QueryHeader* header = getTokenNftInfoQuery->mutable_header();
-  header->set_responsetype(proto::ANSWER_ONLY);
-
-  TransferTransaction tx = TransferTransaction()
-                             .setTransactionId(TransactionId::generate(*client.getOperatorAccountId()))
-                             .setNodeAccountIds({ node->getAccountId() })
-                             .setMaxTransactionFee(Hbar(1LL))
-                             .addHbarTransfer(*client.getOperatorAccountId(), Hbar(-1LL))
-                             .addHbarTransfer(node->getAccountId(), Hbar(1LL));
-  tx.onSelectNode(node);
-  header->set_allocated_payment(new proto::Transaction(tx.makeRequest(client, node)));
-
-  getTokenNftInfoQuery->set_allocated_nftid(mNftId.toProtobuf().release());
-
-  return query;
-}
-
-//-----
 TokenNftInfo TokenNftInfoQuery::mapResponse(const proto::Response& response) const
 {
   return TokenNftInfo::fromProtobuf(response.tokengetnftinfo().nft());
 }
 
 //-----
-Status TokenNftInfoQuery::mapResponseStatus(const proto::Response& response) const
+grpc::Status TokenNftInfoQuery::submitRequest(const proto::Query& request,
+                                              const std::shared_ptr<internal::Node>& node,
+                                              const std::chrono::system_clock::time_point& deadline,
+                                              proto::Response* response) const
 {
-  return gProtobufResponseCodeToStatus.at(response.tokengetnftinfo().header().nodetransactionprecheckcode());
+  return node->submitQuery(proto::Query::QueryCase::kTokenGetNftInfo, request, deadline, response);
 }
 
 //-----
-grpc::Status TokenNftInfoQuery::submitRequest(const Client& client,
-                                              const std::chrono::system_clock::time_point& deadline,
-                                              const std::shared_ptr<internal::Node>& node,
-                                              proto::Response* response) const
+proto::Query TokenNftInfoQuery::buildRequest(proto::QueryHeader* header) const
 {
-  return node->submitQuery(proto::Query::QueryCase::kTokenGetNftInfo, makeRequest(client, node), deadline, response);
+  auto tokenGetNftInfoQuery = std::make_unique<proto::TokenGetNftInfoQuery>();
+  tokenGetNftInfoQuery->set_allocated_header(header);
+  tokenGetNftInfoQuery->set_allocated_nftid(mNftId.toProtobuf().release());
+
+  proto::Query query;
+  query.set_allocated_tokengetnftinfo(tokenGetNftInfoQuery.release());
+  return query;
+}
+
+//-----
+proto::ResponseHeader TokenNftInfoQuery::mapResponseHeader(const proto::Response& response) const
+{
+  return response.tokengetnftinfo().header();
 }
 
 } // namespace Hedera

--- a/sdk/main/src/TokenUpdateTransaction.cc
+++ b/sdk/main/src/TokenUpdateTransaction.cc
@@ -32,81 +32,17 @@ namespace Hedera
 {
 //-----
 TokenUpdateTransaction::TokenUpdateTransaction(const proto::TransactionBody& transactionBody)
+  : Transaction<TokenUpdateTransaction>(transactionBody)
 {
-  if (!transactionBody.has_tokenupdate())
-  {
-    throw std::invalid_argument("Transaction body doesn't contain TokenUpdate data");
-  }
+  initFromSourceTransactionBody();
+}
 
-  const proto::TokenUpdateTransactionBody& body = transactionBody.tokenupdate();
-
-  if (body.has_token())
-  {
-    mTokenId = TokenId::fromProtobuf(body.token());
-  }
-
-  mTokenName = body.name();
-  mTokenSymbol = body.symbol();
-
-  if (body.has_treasury())
-  {
-    mTreasuryAccountId = AccountId::fromProtobuf(body.treasury());
-  }
-
-  if (body.has_adminkey())
-  {
-    mAdminKey = Key::fromProtobuf(body.adminkey());
-  }
-
-  if (body.has_kyckey())
-  {
-    mKycKey = Key::fromProtobuf(body.kyckey());
-  }
-
-  if (body.has_freezekey())
-  {
-    mFreezeKey = Key::fromProtobuf(body.freezekey());
-  }
-
-  if (body.has_wipekey())
-  {
-    mWipeKey = Key::fromProtobuf(body.wipekey());
-  }
-
-  if (body.has_supplykey())
-  {
-    mSupplyKey = Key::fromProtobuf(body.supplykey());
-  }
-
-  if (body.has_autorenewaccount())
-  {
-    mAutoRenewAccountId = AccountId::fromProtobuf(body.autorenewaccount());
-  }
-
-  if (body.has_autorenewperiod())
-  {
-    mAutoRenewPeriod = internal::DurationConverter::fromProtobuf(body.autorenewperiod());
-  }
-
-  if (body.has_expiry())
-  {
-    mExpirationTime = internal::TimestampConverter::fromProtobuf(body.expiry());
-  }
-
-  if (body.has_memo())
-  {
-    mTokenMemo = body.memo().value();
-  }
-
-  if (body.has_fee_schedule_key())
-  {
-    mFeeScheduleKey = Key::fromProtobuf(body.fee_schedule_key());
-  }
-
-  if (body.has_pause_key())
-  {
-    mPauseKey = Key::fromProtobuf(body.pause_key());
-  }
+//-----
+TokenUpdateTransaction::TokenUpdateTransaction(
+  const std::map<TransactionId, std::map<AccountId, proto::Transaction>>& transactions)
+  : Transaction<TokenUpdateTransaction>(transactions)
+{
+  initFromSourceTransactionBody();
 }
 
 //-----
@@ -231,26 +167,99 @@ TokenUpdateTransaction& TokenUpdateTransaction::setPauseKey(const std::shared_pt
 }
 
 //-----
-proto::Transaction TokenUpdateTransaction::makeRequest(const Client& client,
-                                                       const std::shared_ptr<internal::Node>&) const
-{
-  return signTransaction(generateTransactionBody(&client), client);
-}
-
-//-----
-grpc::Status TokenUpdateTransaction::submitRequest(const Client& client,
-                                                   const std::chrono::system_clock::time_point& deadline,
+grpc::Status TokenUpdateTransaction::submitRequest(const proto::Transaction& request,
                                                    const std::shared_ptr<internal::Node>& node,
+                                                   const std::chrono::system_clock::time_point& deadline,
                                                    proto::TransactionResponse* response) const
 {
-  return node->submitTransaction(
-    proto::TransactionBody::DataCase::kTokenUpdate, makeRequest(client, node), deadline, response);
+  return node->submitTransaction(proto::TransactionBody::DataCase::kTokenUpdate, request, deadline, response);
 }
 
 //-----
 void TokenUpdateTransaction::addToBody(proto::TransactionBody& body) const
 {
   body.set_allocated_tokenupdate(build());
+}
+
+//-----
+void TokenUpdateTransaction::initFromSourceTransactionBody()
+{
+  const proto::TransactionBody transactionBody = getSourceTransactionBody();
+
+  if (!transactionBody.has_tokenupdate())
+  {
+    throw std::invalid_argument("Transaction body doesn't contain TokenUpdate data");
+  }
+
+  const proto::TokenUpdateTransactionBody& body = transactionBody.tokenupdate();
+
+  if (body.has_token())
+  {
+    mTokenId = TokenId::fromProtobuf(body.token());
+  }
+
+  mTokenName = body.name();
+  mTokenSymbol = body.symbol();
+
+  if (body.has_treasury())
+  {
+    mTreasuryAccountId = AccountId::fromProtobuf(body.treasury());
+  }
+
+  if (body.has_adminkey())
+  {
+    mAdminKey = Key::fromProtobuf(body.adminkey());
+  }
+
+  if (body.has_kyckey())
+  {
+    mKycKey = Key::fromProtobuf(body.kyckey());
+  }
+
+  if (body.has_freezekey())
+  {
+    mFreezeKey = Key::fromProtobuf(body.freezekey());
+  }
+
+  if (body.has_wipekey())
+  {
+    mWipeKey = Key::fromProtobuf(body.wipekey());
+  }
+
+  if (body.has_supplykey())
+  {
+    mSupplyKey = Key::fromProtobuf(body.supplykey());
+  }
+
+  if (body.has_autorenewaccount())
+  {
+    mAutoRenewAccountId = AccountId::fromProtobuf(body.autorenewaccount());
+  }
+
+  if (body.has_autorenewperiod())
+  {
+    mAutoRenewPeriod = internal::DurationConverter::fromProtobuf(body.autorenewperiod());
+  }
+
+  if (body.has_expiry())
+  {
+    mExpirationTime = internal::TimestampConverter::fromProtobuf(body.expiry());
+  }
+
+  if (body.has_memo())
+  {
+    mTokenMemo = body.memo().value();
+  }
+
+  if (body.has_fee_schedule_key())
+  {
+    mFeeScheduleKey = Key::fromProtobuf(body.fee_schedule_key());
+  }
+
+  if (body.has_pause_key())
+  {
+    mPauseKey = Key::fromProtobuf(body.pause_key());
+  }
 }
 
 //-----

--- a/sdk/main/src/TopicDeleteTransaction.cc
+++ b/sdk/main/src/TopicDeleteTransaction.cc
@@ -31,17 +31,15 @@ namespace Hedera
 TopicDeleteTransaction::TopicDeleteTransaction(const proto::TransactionBody& transactionBody)
   : Transaction<TopicDeleteTransaction>(transactionBody)
 {
-  if (!transactionBody.has_consensusdeletetopic())
-  {
-    throw std::invalid_argument("Transaction body doesn't contain ConsensusDeleteTopic data");
-  }
+  initFromSourceTransactionBody();
+}
 
-  const proto::ConsensusDeleteTopicTransactionBody& body = transactionBody.consensusdeletetopic();
-
-  if (body.has_topicid())
-  {
-    mTopicId = TopicId::fromProtobuf(body.topicid());
-  }
+//-----
+TopicDeleteTransaction::TopicDeleteTransaction(
+  const std::map<TransactionId, std::map<AccountId, proto::Transaction>>& transactions)
+  : Transaction<TopicDeleteTransaction>(transactions)
+{
+  initFromSourceTransactionBody();
 }
 
 //-----
@@ -53,26 +51,36 @@ TopicDeleteTransaction& TopicDeleteTransaction::setTopicId(const TopicId& TopicI
 }
 
 //-----
-proto::Transaction TopicDeleteTransaction::makeRequest(const Client& client,
-                                                       const std::shared_ptr<internal::Node>&) const
-{
-  return signTransaction(generateTransactionBody(&client), client);
-}
-
-//-----
-grpc::Status TopicDeleteTransaction::submitRequest(const Client& client,
-                                                   const std::chrono::system_clock::time_point& deadline,
+grpc::Status TopicDeleteTransaction::submitRequest(const proto::Transaction& request,
                                                    const std::shared_ptr<internal::Node>& node,
+                                                   const std::chrono::system_clock::time_point& deadline,
                                                    proto::TransactionResponse* response) const
 {
-  return node->submitTransaction(
-    proto::TransactionBody::DataCase::kConsensusDeleteTopic, makeRequest(client, node), deadline, response);
+  return node->submitTransaction(proto::TransactionBody::DataCase::kConsensusDeleteTopic, request, deadline, response);
 }
 
 //-----
 void TopicDeleteTransaction::addToBody(proto::TransactionBody& body) const
 {
   body.set_allocated_consensusdeletetopic(build());
+}
+
+//-----
+void TopicDeleteTransaction::initFromSourceTransactionBody()
+{
+  const proto::TransactionBody transactionBody = getSourceTransactionBody();
+
+  if (!transactionBody.has_consensusdeletetopic())
+  {
+    throw std::invalid_argument("Transaction body doesn't contain ConsensusDeleteTopic data");
+  }
+
+  const proto::ConsensusDeleteTopicTransactionBody& body = transactionBody.consensusdeletetopic();
+
+  if (body.has_topicid())
+  {
+    mTopicId = TopicId::fromProtobuf(body.topicid());
+  }
 }
 
 //-----

--- a/sdk/main/src/TopicInfoQuery.cc
+++ b/sdk/main/src/TopicInfoQuery.cc
@@ -68,7 +68,7 @@ proto::Query TopicInfoQuery::buildRequest(proto::QueryHeader* header) const
 //-----
 proto::ResponseHeader TopicInfoQuery::mapResponseHeader(const proto::Response& response) const
 {
-  Query<TopicInfoQuery, TopicInfo>::saveCostFromHeader(response.consensusgettopicinfo().header());
+  saveCostFromHeader(response.consensusgettopicinfo().header());
   return response.consensusgettopicinfo().header();
 }
 

--- a/sdk/main/src/TopicInfoQuery.cc
+++ b/sdk/main/src/TopicInfoQuery.cc
@@ -39,48 +39,36 @@ TopicInfoQuery& TopicInfoQuery::setTopicId(const TopicId& topicId)
 }
 
 //-----
-proto::Query TopicInfoQuery::makeRequest(const Client& client, const std::shared_ptr<internal::Node>& node) const
-{
-  proto::Query query;
-  proto::ConsensusGetTopicInfoQuery* getTopicInfoQuery = query.mutable_consensusgettopicinfo();
-
-  proto::QueryHeader* header = getTopicInfoQuery->mutable_header();
-  header->set_responsetype(proto::ANSWER_ONLY);
-
-  TransferTransaction tx = TransferTransaction()
-                             .setTransactionId(TransactionId::generate(*client.getOperatorAccountId()))
-                             .setNodeAccountIds({ node->getAccountId() })
-                             .setMaxTransactionFee(Hbar(1LL))
-                             .addHbarTransfer(*client.getOperatorAccountId(), Hbar(-1LL))
-                             .addHbarTransfer(node->getAccountId(), Hbar(1LL));
-  tx.onSelectNode(node);
-  header->set_allocated_payment(new proto::Transaction(tx.makeRequest(client, node)));
-
-  getTopicInfoQuery->set_allocated_topicid(mTopicId.toProtobuf().release());
-
-  return query;
-}
-
-//-----
 TopicInfo TopicInfoQuery::mapResponse(const proto::Response& response) const
 {
   return TopicInfo::fromProtobuf(response.consensusgettopicinfo());
 }
 
 //-----
-Status TopicInfoQuery::mapResponseStatus(const proto::Response& response) const
+grpc::Status TopicInfoQuery::submitRequest(const proto::Query& request,
+                                           const std::shared_ptr<internal::Node>& node,
+                                           const std::chrono::system_clock::time_point& deadline,
+                                           proto::Response* response) const
 {
-  return gProtobufResponseCodeToStatus.at(response.consensusgettopicinfo().header().nodetransactionprecheckcode());
+  return node->submitQuery(proto::Query::QueryCase::kConsensusGetTopicInfo, request, deadline, response);
 }
 
 //-----
-grpc::Status TopicInfoQuery::submitRequest(const Client& client,
-                                           const std::chrono::system_clock::time_point& deadline,
-                                           const std::shared_ptr<internal::Node>& node,
-                                           proto::Response* response) const
+proto::Query TopicInfoQuery::buildRequest(proto::QueryHeader* header) const
 {
-  return node->submitQuery(
-    proto::Query::QueryCase::kConsensusGetTopicInfo, makeRequest(client, node), deadline, response);
+  auto consensusGetTopicInfoQuery = std::make_unique<proto::ConsensusGetTopicInfoQuery>();
+  consensusGetTopicInfoQuery->set_allocated_header(header);
+  consensusGetTopicInfoQuery->set_allocated_topicid(mTopicId.toProtobuf().release());
+
+  proto::Query query;
+  query.set_allocated_consensusgettopicinfo(consensusGetTopicInfoQuery.release());
+  return query;
+}
+
+//-----
+proto::ResponseHeader TopicInfoQuery::mapResponseHeader(const proto::Response& response) const
+{
+  return response.consensusgettopicinfo().header();
 }
 
 } // namespace Hedera

--- a/sdk/main/src/TopicInfoQuery.cc
+++ b/sdk/main/src/TopicInfoQuery.cc
@@ -68,6 +68,7 @@ proto::Query TopicInfoQuery::buildRequest(proto::QueryHeader* header) const
 //-----
 proto::ResponseHeader TopicInfoQuery::mapResponseHeader(const proto::Response& response) const
 {
+  Query<TopicInfoQuery, TopicInfo>::saveCostFromHeader(response.consensusgettopicinfo().header());
   return response.consensusgettopicinfo().header();
 }
 

--- a/sdk/main/src/TopicMessageQuery.cc
+++ b/sdk/main/src/TopicMessageQuery.cc
@@ -50,7 +50,7 @@ enum class CallStatus
 std::shared_ptr<internal::MirrorNode> getConnectedMirrorNode(const std::shared_ptr<internal::MirrorNetwork>& network)
 {
   std::shared_ptr<internal::MirrorNode> node = network->getNextMirrorNode();
-  while (!node->connect(std::chrono::system_clock::now() + std::chrono::seconds(2)))
+  while (node->channelFailedToConnect())
   {
     node = network->getNextMirrorNode();
   }
@@ -189,7 +189,7 @@ void startSubscription(
             }
             else
             {
-              // An error occurred. Whether retrying or not, cancel the call and shutdown the queue.
+              // An error occurred. Whether retrying or not, cancel the call and close the queue.
               contexts.back()->TryCancel();
               queues.back()->Shutdown();
 

--- a/sdk/main/src/TopicMessageSubmitTransaction.cc
+++ b/sdk/main/src/TopicMessageSubmitTransaction.cc
@@ -90,7 +90,7 @@ void TopicMessageSubmitTransaction::addToChunk(uint32_t chunk, uint32_t total, p
   body.set_allocated_consensussubmitmessage(build(static_cast<int>(chunk)));
   body.mutable_consensussubmitmessage()->mutable_chunkinfo()->set_allocated_initialtransactionid(
     getTransactionId().toProtobuf().release());
-  body.mutable_consensussubmitmessage()->mutable_chunkinfo()->set_number(static_cast<int32_t>(chunk));
+  body.mutable_consensussubmitmessage()->mutable_chunkinfo()->set_number(static_cast<int32_t>(chunk + 1));
   body.mutable_consensussubmitmessage()->mutable_chunkinfo()->set_total(static_cast<int32_t>(total));
 }
 

--- a/sdk/main/src/TopicMessageSubmitTransaction.cc
+++ b/sdk/main/src/TopicMessageSubmitTransaction.cc
@@ -24,24 +24,24 @@
 #include <grpcpp/client_context.h>
 #include <proto/consensus_submit_message.pb.h>
 #include <proto/transaction.pb.h>
+#include <proto/transaction_body.pb.h>
 #include <stdexcept>
 
 namespace Hedera
 {
 //-----
 TopicMessageSubmitTransaction::TopicMessageSubmitTransaction(const proto::TransactionBody& transactionBody)
+  : ChunkedTransaction<TopicMessageSubmitTransaction>(transactionBody)
 {
-  if (!transactionBody.has_consensussubmitmessage())
-  {
-    throw std::invalid_argument("Transaction body doesn't contain ConsensusSubmitMessage data");
-  }
+  initFromSourceTransactionBody();
+}
 
-  const proto::ConsensusSubmitMessageTransactionBody& body = transactionBody.consensussubmitmessage();
-
-  if (body.has_topicid())
-  {
-    mTopicId = TopicId::fromProtobuf(body.topicid());
-  }
+//-----
+TopicMessageSubmitTransaction::TopicMessageSubmitTransaction(
+  const std::map<TransactionId, std::map<AccountId, proto::Transaction>>& transactions)
+  : ChunkedTransaction<TopicMessageSubmitTransaction>(transactions)
+{
+  initFromSourceTransactionBody();
 }
 
 //-----
@@ -69,28 +69,13 @@ TopicMessageSubmitTransaction& TopicMessageSubmitTransaction::setMessage(std::st
 }
 
 //-----
-void TopicMessageSubmitTransaction::onChunk(const TransactionId& transactionId, int32_t chunk, int32_t total)
-{
-  mInitialTransactionId = transactionId;
-  mChunkNum = chunk;
-  mTotalNumOfChunks = total;
-}
-
-//-----
-proto::Transaction TopicMessageSubmitTransaction::makeRequest(const Client& client,
-                                                              const std::shared_ptr<internal::Node>&) const
-{
-  return signTransaction(generateTransactionBody(&client), client);
-}
-
-//-----
-grpc::Status TopicMessageSubmitTransaction::submitRequest(const Client& client,
-                                                          const std::chrono::system_clock::time_point& deadline,
+grpc::Status TopicMessageSubmitTransaction::submitRequest(const proto::Transaction& request,
                                                           const std::shared_ptr<internal::Node>& node,
+                                                          const std::chrono::system_clock::time_point& deadline,
                                                           proto::TransactionResponse* response) const
 {
   return node->submitTransaction(
-    proto::TransactionBody::DataCase::kConsensusSubmitMessage, makeRequest(client, node), deadline, response);
+    proto::TransactionBody::DataCase::kConsensusSubmitMessage, request, deadline, response);
 }
 
 //-----
@@ -100,7 +85,35 @@ void TopicMessageSubmitTransaction::addToBody(proto::TransactionBody& body) cons
 }
 
 //-----
-proto::ConsensusSubmitMessageTransactionBody* TopicMessageSubmitTransaction::build() const
+void TopicMessageSubmitTransaction::addToChunk(uint32_t chunk, uint32_t total, proto::TransactionBody& body) const
+{
+  body.set_allocated_consensussubmitmessage(build(static_cast<int>(chunk)));
+  body.mutable_consensussubmitmessage()->mutable_chunkinfo()->set_allocated_initialtransactionid(
+    getTransactionId().toProtobuf().release());
+  body.mutable_consensussubmitmessage()->mutable_chunkinfo()->set_number(static_cast<int32_t>(chunk));
+  body.mutable_consensussubmitmessage()->mutable_chunkinfo()->set_total(static_cast<int32_t>(total));
+}
+
+//-----
+void TopicMessageSubmitTransaction::initFromSourceTransactionBody()
+{
+  const proto::TransactionBody transactionBody = getSourceTransactionBody();
+
+  if (!transactionBody.has_consensussubmitmessage())
+  {
+    throw std::invalid_argument("Transaction body doesn't contain ConsensusSubmitMessage data");
+  }
+
+  const proto::ConsensusSubmitMessageTransactionBody& body = transactionBody.consensussubmitmessage();
+
+  if (body.has_topicid())
+  {
+    mTopicId = TopicId::fromProtobuf(body.topicid());
+  }
+}
+
+//-----
+proto::ConsensusSubmitMessageTransactionBody* TopicMessageSubmitTransaction::build(int chunk) const
 {
   auto body = std::make_unique<proto::ConsensusSubmitMessageTransactionBody>();
 
@@ -109,12 +122,8 @@ proto::ConsensusSubmitMessageTransactionBody* TopicMessageSubmitTransaction::bui
     body->set_allocated_topicid(mTopicId.toProtobuf().release());
   }
 
-  body->set_message(internal::Utilities::byteVectorToString(getData()));
-
-  body->mutable_chunkinfo()->set_allocated_initialtransactionid(mInitialTransactionId.toProtobuf().release());
-  body->mutable_chunkinfo()->set_total(mTotalNumOfChunks);
-  body->mutable_chunkinfo()->set_number(mChunkNum + 1);
-
+  body->set_message(internal::Utilities::byteVectorToString(
+    (chunk >= 0) ? getDataForChunk(static_cast<unsigned int>(chunk)) : getData()));
   return body.release();
 }
 

--- a/sdk/main/src/Transaction.cc
+++ b/sdk/main/src/Transaction.cc
@@ -916,6 +916,8 @@ Transaction<SdkRequestType>::getSignaturesInternal(size_t offset) const
       }
     }
   }
+
+  return signatures;
 }
 
 //-----

--- a/sdk/main/src/TransactionId.cc
+++ b/sdk/main/src/TransactionId.cc
@@ -68,6 +68,12 @@ bool TransactionId::operator==(const TransactionId& other) const
 }
 
 //-----
+bool TransactionId::operator!=(const TransactionId& other) const
+{
+  return !operator==(other);
+}
+
+//-----
 std::unique_ptr<proto::TransactionID> TransactionId::toProtobuf() const
 {
   auto proto = std::make_unique<proto::TransactionID>();

--- a/sdk/main/src/TransactionReceiptQuery.cc
+++ b/sdk/main/src/TransactionReceiptQuery.cc
@@ -37,8 +37,6 @@ TransactionReceiptQuery& TransactionReceiptQuery::setTransactionId(const Transac
 }
 
 //-----
-<<<<<<< HEAD
-=======
 TransactionReceiptQuery& TransactionReceiptQuery::setIncludeChildren(bool children)
 {
   mIncludeChildren = children;
@@ -53,24 +51,6 @@ TransactionReceiptQuery& TransactionReceiptQuery::setIncludeDuplicates(bool dupl
 }
 
 //-----
-proto::Query TransactionReceiptQuery::makeRequest(const Client&, const std::shared_ptr<internal::Node>&) const
-{
-  proto::Query query;
-  proto::TransactionGetReceiptQuery* getTransactionReceiptQuery = query.mutable_transactiongetreceipt();
-
-  proto::QueryHeader* header = getTransactionReceiptQuery->mutable_header();
-  header->set_responsetype(proto::ANSWER_ONLY);
-
-  // This is a free query, so no payment required
-  getTransactionReceiptQuery->set_allocated_transactionid(mTransactionId->toProtobuf().release());
-  getTransactionReceiptQuery->set_include_child_receipts(mIncludeChildren);
-  getTransactionReceiptQuery->set_includeduplicates(mIncludeDuplicates);
-
-  return query;
-}
-
-//-----
->>>>>>> main
 TransactionReceipt TransactionReceiptQuery::mapResponse(const proto::Response& response) const
 {
   return TransactionReceipt::fromProtobuf(response.transactiongetreceipt());
@@ -127,6 +107,9 @@ proto::Query TransactionReceiptQuery::buildRequest(proto::QueryHeader* header) c
   {
     transactionGetReceiptQuery->set_allocated_transactionid(mTransactionId->toProtobuf().release());
   }
+
+  transactionGetReceiptQuery->set_includeduplicates(mIncludeDuplicates);
+  transactionGetReceiptQuery->set_include_child_receipts(mIncludeChildren);
 
   proto::Query query;
   query.set_allocated_transactiongetreceipt(transactionGetReceiptQuery.release());

--- a/sdk/main/src/TransactionReceiptQuery.cc
+++ b/sdk/main/src/TransactionReceiptQuery.cc
@@ -128,7 +128,7 @@ proto::Query TransactionReceiptQuery::buildRequest(proto::QueryHeader* header) c
 //-----
 proto::ResponseHeader TransactionReceiptQuery::mapResponseHeader(const proto::Response& response) const
 {
-  Query<TransactionReceiptQuery, TransactionReceipt>::saveCostFromHeader(response.transactiongetreceipt().header());
+  saveCostFromHeader(response.transactiongetreceipt().header());
   return response.transactiongetreceipt().header();
 }
 

--- a/sdk/main/src/TransactionRecordQuery.cc
+++ b/sdk/main/src/TransactionRecordQuery.cc
@@ -118,7 +118,7 @@ proto::Query TransactionRecordQuery::buildRequest(proto::QueryHeader* header) co
 //-----
 proto::ResponseHeader TransactionRecordQuery::mapResponseHeader(const proto::Response& response) const
 {
-  Query<TransactionRecordQuery, TransactionRecord>::saveCostFromHeader(response.transactiongetrecord().header());
+  saveCostFromHeader(response.transactiongetrecord().header());
   return response.transactiongetrecord().header();
 }
 

--- a/sdk/main/src/WrappedTransaction.cc
+++ b/sdk/main/src/WrappedTransaction.cc
@@ -20,6 +20,7 @@
 #include "WrappedTransaction.h"
 #include "exceptions/UninitializedException.h"
 
+#include <memory>
 #include <proto/transaction_body.pb.h>
 
 namespace Hedera
@@ -394,125 +395,245 @@ std::unique_ptr<proto::TransactionBody> WrappedTransaction::toProtobuf() const
   switch (getTransactionType())
   {
     case ACCOUNT_ALLOWANCE_APPROVE_TRANSACTION:
-      return std::make_unique<proto::TransactionBody>(
-        getTransaction<AccountAllowanceApproveTransaction>()->generateTransactionBody(nullptr));
+    {
+      const auto transaction = getTransaction<AccountAllowanceApproveTransaction>();
+      transaction->updateSourceTransactionBody(nullptr);
+      return std::make_unique<proto::TransactionBody>(transaction->getSourceTransactionBody());
+    }
     case ACCOUNT_ALLOWANCE_DELETE_TRANSACTION:
-      return std::make_unique<proto::TransactionBody>(
-        getTransaction<AccountAllowanceDeleteTransaction>()->generateTransactionBody(nullptr));
+    {
+      const auto transaction = getTransaction<AccountAllowanceDeleteTransaction>();
+      transaction->updateSourceTransactionBody(nullptr);
+      return std::make_unique<proto::TransactionBody>(transaction->getSourceTransactionBody());
+    }
     case ACCOUNT_CREATE_TRANSACTION:
-      return std::make_unique<proto::TransactionBody>(
-        getTransaction<AccountCreateTransaction>()->generateTransactionBody(nullptr));
+    {
+      const auto transaction = getTransaction<AccountCreateTransaction>();
+      transaction->updateSourceTransactionBody(nullptr);
+      return std::make_unique<proto::TransactionBody>(transaction->getSourceTransactionBody());
+    }
     case ACCOUNT_DELETE_TRANSACTION:
-      return std::make_unique<proto::TransactionBody>(
-        getTransaction<AccountDeleteTransaction>()->generateTransactionBody(nullptr));
+    {
+      const auto transaction = getTransaction<AccountDeleteTransaction>();
+      transaction->updateSourceTransactionBody(nullptr);
+      return std::make_unique<proto::TransactionBody>(transaction->getSourceTransactionBody());
+    }
     case ACCOUNT_UPDATE_TRANSACTION:
-      return std::make_unique<proto::TransactionBody>(
-        getTransaction<AccountUpdateTransaction>()->generateTransactionBody(nullptr));
+    {
+      const auto transaction = getTransaction<AccountUpdateTransaction>();
+      transaction->updateSourceTransactionBody(nullptr);
+      return std::make_unique<proto::TransactionBody>(transaction->getSourceTransactionBody());
+    }
     case CONTRACT_CREATE_TRANSACTION:
-      return std::make_unique<proto::TransactionBody>(
-        getTransaction<ContractCreateTransaction>()->generateTransactionBody(nullptr));
+    {
+      const auto transaction = getTransaction<ContractCreateTransaction>();
+      transaction->updateSourceTransactionBody(nullptr);
+      return std::make_unique<proto::TransactionBody>(transaction->getSourceTransactionBody());
+    }
     case CONTRACT_DELETE_TRANSACTION:
-      return std::make_unique<proto::TransactionBody>(
-        getTransaction<ContractDeleteTransaction>()->generateTransactionBody(nullptr));
+    {
+      const auto transaction = getTransaction<ContractDeleteTransaction>();
+      transaction->updateSourceTransactionBody(nullptr);
+      return std::make_unique<proto::TransactionBody>(transaction->getSourceTransactionBody());
+    }
     case CONTRACT_EXECUTE_TRANSACTION:
-      return std::make_unique<proto::TransactionBody>(
-        getTransaction<ContractExecuteTransaction>()->generateTransactionBody(nullptr));
+    {
+      const auto transaction = getTransaction<ContractExecuteTransaction>();
+      transaction->updateSourceTransactionBody(nullptr);
+      return std::make_unique<proto::TransactionBody>(transaction->getSourceTransactionBody());
+    }
     case CONTRACT_UPDATE_TRANSACTION:
-      return std::make_unique<proto::TransactionBody>(
-        getTransaction<ContractUpdateTransaction>()->generateTransactionBody(nullptr));
+    {
+      const auto transaction = getTransaction<ContractUpdateTransaction>();
+      transaction->updateSourceTransactionBody(nullptr);
+      return std::make_unique<proto::TransactionBody>(transaction->getSourceTransactionBody());
+    }
     case ETHEREUM_TRANSACTION:
-      return std::make_unique<proto::TransactionBody>(
-        getTransaction<EthereumTransaction>()->generateTransactionBody(nullptr));
+    {
+      const auto transaction = getTransaction<EthereumTransaction>();
+      transaction->updateSourceTransactionBody(nullptr);
+      return std::make_unique<proto::TransactionBody>(transaction->getSourceTransactionBody());
+    }
     case FILE_APPEND_TRANSACTION:
-      return std::make_unique<proto::TransactionBody>(
-        getTransaction<FileAppendTransaction>()->generateTransactionBody(nullptr));
+    {
+      const auto transaction = getTransaction<FileAppendTransaction>();
+      transaction->updateSourceTransactionBody(nullptr);
+      return std::make_unique<proto::TransactionBody>(transaction->getSourceTransactionBody());
+    }
     case FILE_CREATE_TRANSACTION:
-      return std::make_unique<proto::TransactionBody>(
-        getTransaction<FileCreateTransaction>()->generateTransactionBody(nullptr));
+    {
+      const auto transaction = getTransaction<FileCreateTransaction>();
+      transaction->updateSourceTransactionBody(nullptr);
+      return std::make_unique<proto::TransactionBody>(transaction->getSourceTransactionBody());
+    }
     case FILE_DELETE_TRANSACTION:
-      return std::make_unique<proto::TransactionBody>(
-        getTransaction<FileDeleteTransaction>()->generateTransactionBody(nullptr));
+    {
+      const auto transaction = getTransaction<FileDeleteTransaction>();
+      transaction->updateSourceTransactionBody(nullptr);
+      return std::make_unique<proto::TransactionBody>(transaction->getSourceTransactionBody());
+    }
     case FILE_UPDATE_TRANSACTION:
-      return std::make_unique<proto::TransactionBody>(
-        getTransaction<FileUpdateTransaction>()->generateTransactionBody(nullptr));
+    {
+      const auto transaction = getTransaction<FileUpdateTransaction>();
+      transaction->updateSourceTransactionBody(nullptr);
+      return std::make_unique<proto::TransactionBody>(transaction->getSourceTransactionBody());
+    }
     case FREEZE_TRANSACTION:
-      return std::make_unique<proto::TransactionBody>(
-        getTransaction<FreezeTransaction>()->generateTransactionBody(nullptr));
+    {
+      const auto transaction = getTransaction<FreezeTransaction>();
+      transaction->updateSourceTransactionBody(nullptr);
+      return std::make_unique<proto::TransactionBody>(transaction->getSourceTransactionBody());
+    }
     case SCHEDULE_CREATE_TRANSACTION:
-      return std::make_unique<proto::TransactionBody>(
-        getTransaction<ScheduleCreateTransaction>()->generateTransactionBody(nullptr));
+    {
+      const auto transaction = getTransaction<ScheduleCreateTransaction>();
+      transaction->updateSourceTransactionBody(nullptr);
+      return std::make_unique<proto::TransactionBody>(transaction->getSourceTransactionBody());
+    }
     case SCHEDULE_DELETE_TRANSACTION:
-      return std::make_unique<proto::TransactionBody>(
-        getTransaction<ScheduleDeleteTransaction>()->generateTransactionBody(nullptr));
+    {
+      const auto transaction = getTransaction<ScheduleDeleteTransaction>();
+      transaction->updateSourceTransactionBody(nullptr);
+      return std::make_unique<proto::TransactionBody>(transaction->getSourceTransactionBody());
+    }
     case SCHEDULE_SIGN_TRANSACTION:
-      return std::make_unique<proto::TransactionBody>(
-        getTransaction<ScheduleSignTransaction>()->generateTransactionBody(nullptr));
+    {
+      const auto transaction = getTransaction<ScheduleSignTransaction>();
+      transaction->updateSourceTransactionBody(nullptr);
+      return std::make_unique<proto::TransactionBody>(transaction->getSourceTransactionBody());
+    }
     case SYSTEM_DELETE_TRANSACTION:
-      return std::make_unique<proto::TransactionBody>(
-        getTransaction<SystemDeleteTransaction>()->generateTransactionBody(nullptr));
+    {
+      const auto transaction = getTransaction<SystemDeleteTransaction>();
+      transaction->updateSourceTransactionBody(nullptr);
+      return std::make_unique<proto::TransactionBody>(transaction->getSourceTransactionBody());
+    }
     case SYSTEM_UNDELETE_TRANSACTION:
-      return std::make_unique<proto::TransactionBody>(
-        getTransaction<SystemUndeleteTransaction>()->generateTransactionBody(nullptr));
+    {
+      const auto transaction = getTransaction<SystemUndeleteTransaction>();
+      transaction->updateSourceTransactionBody(nullptr);
+      return std::make_unique<proto::TransactionBody>(transaction->getSourceTransactionBody());
+    }
     case TOKEN_ASSOCIATE_TRANSACTION:
-      return std::make_unique<proto::TransactionBody>(
-        getTransaction<TokenAssociateTransaction>()->generateTransactionBody(nullptr));
+    {
+      const auto transaction = getTransaction<TokenAssociateTransaction>();
+      transaction->updateSourceTransactionBody(nullptr);
+      return std::make_unique<proto::TransactionBody>(transaction->getSourceTransactionBody());
+    }
     case TOKEN_BURN_TRANSACTION:
-      return std::make_unique<proto::TransactionBody>(
-        getTransaction<TokenBurnTransaction>()->generateTransactionBody(nullptr));
+    {
+      const auto transaction = getTransaction<TokenBurnTransaction>();
+      transaction->updateSourceTransactionBody(nullptr);
+      return std::make_unique<proto::TransactionBody>(transaction->getSourceTransactionBody());
+    }
     case TOKEN_CREATE_TRANSACTION:
-      return std::make_unique<proto::TransactionBody>(
-        getTransaction<TokenCreateTransaction>()->generateTransactionBody(nullptr));
+    {
+      const auto transaction = getTransaction<TokenCreateTransaction>();
+      transaction->updateSourceTransactionBody(nullptr);
+      return std::make_unique<proto::TransactionBody>(transaction->getSourceTransactionBody());
+    }
     case TOKEN_DELETE_TRANSACTION:
-      return std::make_unique<proto::TransactionBody>(
-        getTransaction<TokenDeleteTransaction>()->generateTransactionBody(nullptr));
+    {
+      const auto transaction = getTransaction<TokenDeleteTransaction>();
+      transaction->updateSourceTransactionBody(nullptr);
+      return std::make_unique<proto::TransactionBody>(transaction->getSourceTransactionBody());
+    }
     case TOKEN_DISSOCIATE_TRANSACTION:
-      return std::make_unique<proto::TransactionBody>(
-        getTransaction<TokenDissociateTransaction>()->generateTransactionBody(nullptr));
+    {
+      const auto transaction = getTransaction<TokenDissociateTransaction>();
+      transaction->updateSourceTransactionBody(nullptr);
+      return std::make_unique<proto::TransactionBody>(transaction->getSourceTransactionBody());
+    }
     case TOKEN_FEE_SCHEDULE_UPDATE_TRANSACTION:
-      return std::make_unique<proto::TransactionBody>(
-        getTransaction<TokenFeeScheduleUpdateTransaction>()->generateTransactionBody(nullptr));
+    {
+      const auto transaction = getTransaction<TokenFeeScheduleUpdateTransaction>();
+      transaction->updateSourceTransactionBody(nullptr);
+      return std::make_unique<proto::TransactionBody>(transaction->getSourceTransactionBody());
+    }
     case TOKEN_FREEZE_TRANSACTION:
-      return std::make_unique<proto::TransactionBody>(
-        getTransaction<TokenFreezeTransaction>()->generateTransactionBody(nullptr));
+    {
+      const auto transaction = getTransaction<TokenFreezeTransaction>();
+      transaction->updateSourceTransactionBody(nullptr);
+      return std::make_unique<proto::TransactionBody>(transaction->getSourceTransactionBody());
+    }
     case TOKEN_GRANT_KYC_TRANSACTION:
-      return std::make_unique<proto::TransactionBody>(
-        getTransaction<TokenGrantKycTransaction>()->generateTransactionBody(nullptr));
+    {
+      const auto transaction = getTransaction<TokenGrantKycTransaction>();
+      transaction->updateSourceTransactionBody(nullptr);
+      return std::make_unique<proto::TransactionBody>(transaction->getSourceTransactionBody());
+    }
     case TOKEN_MINT_TRANSACTION:
-      return std::make_unique<proto::TransactionBody>(
-        getTransaction<TokenMintTransaction>()->generateTransactionBody(nullptr));
+    {
+      const auto transaction = getTransaction<TokenMintTransaction>();
+      transaction->updateSourceTransactionBody(nullptr);
+      return std::make_unique<proto::TransactionBody>(transaction->getSourceTransactionBody());
+    }
     case TOKEN_PAUSE_TRANSACTION:
-      return std::make_unique<proto::TransactionBody>(
-        getTransaction<TokenPauseTransaction>()->generateTransactionBody(nullptr));
+    {
+      const auto transaction = getTransaction<TokenPauseTransaction>();
+      transaction->updateSourceTransactionBody(nullptr);
+      return std::make_unique<proto::TransactionBody>(transaction->getSourceTransactionBody());
+    }
     case TOKEN_REVOKE_KYC_TRANSACTION:
-      return std::make_unique<proto::TransactionBody>(
-        getTransaction<TokenRevokeKycTransaction>()->generateTransactionBody(nullptr));
+    {
+      const auto transaction = getTransaction<TokenRevokeKycTransaction>();
+      transaction->updateSourceTransactionBody(nullptr);
+      return std::make_unique<proto::TransactionBody>(transaction->getSourceTransactionBody());
+    }
     case TOKEN_UNFREEZE_TRANSACTION:
-      return std::make_unique<proto::TransactionBody>(
-        getTransaction<TokenUnfreezeTransaction>()->generateTransactionBody(nullptr));
+    {
+      const auto transaction = getTransaction<TokenUnfreezeTransaction>();
+      transaction->updateSourceTransactionBody(nullptr);
+      return std::make_unique<proto::TransactionBody>(transaction->getSourceTransactionBody());
+    }
     case TOKEN_UNPAUSE_TRANSACTION:
-      return std::make_unique<proto::TransactionBody>(
-        getTransaction<TokenUnpauseTransaction>()->generateTransactionBody(nullptr));
+    {
+      const auto transaction = getTransaction<TokenUnpauseTransaction>();
+      transaction->updateSourceTransactionBody(nullptr);
+      return std::make_unique<proto::TransactionBody>(transaction->getSourceTransactionBody());
+    }
     case TOKEN_UPDATE_TRANSACTION:
-      return std::make_unique<proto::TransactionBody>(
-        getTransaction<TokenUpdateTransaction>()->generateTransactionBody(nullptr));
+    {
+      const auto transaction = getTransaction<TokenUpdateTransaction>();
+      transaction->updateSourceTransactionBody(nullptr);
+      return std::make_unique<proto::TransactionBody>(transaction->getSourceTransactionBody());
+    }
     case TOKEN_WIPE_TRANSACTION:
-      return std::make_unique<proto::TransactionBody>(
-        getTransaction<TokenWipeTransaction>()->generateTransactionBody(nullptr));
+    {
+      const auto transaction = getTransaction<TokenWipeTransaction>();
+      transaction->updateSourceTransactionBody(nullptr);
+      return std::make_unique<proto::TransactionBody>(transaction->getSourceTransactionBody());
+    }
     case TOPIC_CREATE_TRANSACTION:
-      return std::make_unique<proto::TransactionBody>(
-        getTransaction<TopicCreateTransaction>()->generateTransactionBody(nullptr));
+    {
+      const auto transaction = getTransaction<TopicCreateTransaction>();
+      transaction->updateSourceTransactionBody(nullptr);
+      return std::make_unique<proto::TransactionBody>(transaction->getSourceTransactionBody());
+    }
     case TOPIC_DELETE_TRANSACTION:
-      return std::make_unique<proto::TransactionBody>(
-        getTransaction<TopicDeleteTransaction>()->generateTransactionBody(nullptr));
+    {
+      const auto transaction = getTransaction<TopicDeleteTransaction>();
+      transaction->updateSourceTransactionBody(nullptr);
+      return std::make_unique<proto::TransactionBody>(transaction->getSourceTransactionBody());
+    }
     case TOPIC_MESSAGE_SUBMIT_TRANSACTION:
-      return std::make_unique<proto::TransactionBody>(
-        getTransaction<TopicMessageSubmitTransaction>()->generateTransactionBody(nullptr));
+    {
+      const auto transaction = getTransaction<TopicMessageSubmitTransaction>();
+      transaction->updateSourceTransactionBody(nullptr);
+      return std::make_unique<proto::TransactionBody>(transaction->getSourceTransactionBody());
+    }
     case TOPIC_UPDATE_TRANSACTION:
-      return std::make_unique<proto::TransactionBody>(
-        getTransaction<TopicUpdateTransaction>()->generateTransactionBody(nullptr));
+    {
+      const auto transaction = getTransaction<TopicUpdateTransaction>();
+      transaction->updateSourceTransactionBody(nullptr);
+      return std::make_unique<proto::TransactionBody>(transaction->getSourceTransactionBody());
+    }
     case TRANSFER_TRANSACTION:
-      return std::make_unique<proto::TransactionBody>(
-        getTransaction<TransferTransaction>()->generateTransactionBody(nullptr));
+    {
+      const auto transaction = getTransaction<TransferTransaction>();
+      transaction->updateSourceTransactionBody(nullptr);
+      return std::make_unique<proto::TransactionBody>(transaction->getSourceTransactionBody());
+    }
     default:
     {
       throw UninitializedException("WrappedTransaction doesn't contain a Transaction");

--- a/sdk/main/src/impl/BaseNetwork.cc
+++ b/sdk/main/src/impl/BaseNetwork.cc
@@ -229,7 +229,7 @@ std::vector<std::shared_ptr<NodeType>> BaseNetwork<NetworkType, KeyType, NodeTyp
 
 //-----
 template<typename NetworkType, typename KeyType, typename NodeType>
-void BaseNetwork<NetworkType, KeyType, NodeType>::setTransportSecurity(TLSBehavior tls)
+void BaseNetwork<NetworkType, KeyType, NodeType>::setTransportSecurityInternal(TLSBehavior tls)
 {
   mTransportSecurity = tls;
 }

--- a/sdk/main/src/impl/BaseNetwork.cc
+++ b/sdk/main/src/impl/BaseNetwork.cc
@@ -1,0 +1,289 @@
+/*-
+ *
+ * Hedera C++ SDK
+ *
+ * Copyright (C) 2020 - 2023 Hedera Hashgraph, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+#include "impl/BaseNetwork.h"
+#include "AccountId.h"
+#include "impl/BaseNode.h"
+#include "impl/BaseNodeAddress.h"
+#include "impl/MirrorNetwork.h"
+#include "impl/MirrorNode.h"
+#include "impl/Network.h"
+#include "impl/Node.h"
+#include "impl/Utilities.h"
+
+#include <thread>
+
+namespace Hedera::internal
+{
+//-----
+template<typename NetworkType, typename KeyType, typename NodeType>
+NetworkType& BaseNetwork<NetworkType, KeyType, NodeType>::setNetwork(
+  const std::unordered_map<std::string, KeyType>& network)
+{
+  // New containers to hold new network.
+  std::unordered_map<KeyType, std::unordered_set<std::shared_ptr<NodeType>>> newNetwork;
+  std::unordered_set<std::shared_ptr<NodeType>> newNodes;
+
+  // Go through each entry in the new network list and either move the NodeType that already exists for that entry to
+  // the newNodes list, or create a new NodeType for that entry.
+  for (const auto& [address, key] : network)
+  {
+    // Determine if this entry already has a NodeType.
+    bool entryAlreadyExists = false;
+    for (const auto& node : mNodes)
+    {
+      if (node->getAddress().toString() == address && node->getKey() == key)
+      {
+        // Move this node to the newNodes set and go to the next entry.
+        mNodes.erase(node);
+        newNodes.insert(node);
+        newNetwork[key].insert(node);
+        entryAlreadyExists = true;
+        break;
+      }
+    }
+
+    // If the entry was found, go to the next entry.
+    if (entryAlreadyExists)
+    {
+      continue;
+    }
+
+    // If an entry doesn't exist, create one and add it to the nodes lists and network.
+    const std::shared_ptr<NodeType> newNode = createNodeFromNetworkEntry(address, key);
+    newNodes.insert(newNode);
+    newNetwork[key].insert(newNode);
+  }
+
+  // The remaining nodes in mNodes need to be closed and removed.
+  for (const std::shared_ptr<NodeType>& node : mNodes)
+  {
+    node->close();
+    removeNodeFromNetwork(node);
+  }
+
+  // Set the new nodes list and network.
+  mNodes = newNodes;
+  mNetwork = newNetwork;
+  mHealthyNodes.clear();
+
+  return static_cast<NetworkType&>(*this);
+}
+
+//-----
+template<typename NetworkType, typename KeyType, typename NodeType>
+void BaseNetwork<NetworkType, KeyType, NodeType>::increaseBackoff(const std::shared_ptr<NodeType>& node)
+{
+  node->increaseBackoff();
+  mHealthyNodes.erase(node);
+}
+
+//-----
+template<typename NetworkType, typename KeyType, typename NodeType>
+void BaseNetwork<NetworkType, KeyType, NodeType>::decreaseBackoff(const std::shared_ptr<NodeType>& node)
+{
+  node->decreaseBackoff();
+}
+
+//-----
+template<typename NetworkType, typename KeyType, typename NodeType>
+std::vector<std::shared_ptr<NodeType>> BaseNetwork<NetworkType, KeyType, NodeType>::getNodeProxies(const KeyType& key)
+{
+  readmitNodes();
+  return { mNetwork[key].cbegin(), mNetwork[key].cend() };
+}
+
+//-----
+template<typename NetworkType, typename KeyType, typename NodeType>
+void BaseNetwork<NetworkType, KeyType, NodeType>::close()
+{
+  for (const std::shared_ptr<NodeType>& node : mNodes)
+  {
+    node->close();
+  }
+}
+
+//-----
+template<typename NetworkType, typename KeyType, typename NodeType>
+NetworkType& BaseNetwork<NetworkType, KeyType, NodeType>::setMaxNodeAttempts(unsigned int attempts)
+{
+  mMaxNodeAttempts = attempts;
+  return static_cast<NetworkType&>(*this);
+}
+
+//-----
+template<typename NetworkType, typename KeyType, typename NodeType>
+NetworkType& BaseNetwork<NetworkType, KeyType, NodeType>::setMinNodeBackoff(
+  const std::chrono::duration<double>& backoff)
+{
+  mMinNodeBackoff = backoff;
+  return static_cast<NetworkType&>(*this);
+}
+
+//-----
+template<typename NetworkType, typename KeyType, typename NodeType>
+NetworkType& BaseNetwork<NetworkType, KeyType, NodeType>::setMaxNodeBackoff(
+  const std::chrono::duration<double>& backoff)
+{
+  mMaxNodeBackoff = backoff;
+  return static_cast<NetworkType&>(*this);
+}
+
+//-----
+template<typename NetworkType, typename KeyType, typename NodeType>
+NetworkType& BaseNetwork<NetworkType, KeyType, NodeType>::setMinNodeReadmitTime(
+  const std::chrono::duration<double>& time)
+{
+  mMinNodeReadmitTime = time;
+  return static_cast<NetworkType&>(*this);
+}
+
+//-----
+template<typename NetworkType, typename KeyType, typename NodeType>
+NetworkType& BaseNetwork<NetworkType, KeyType, NodeType>::setMaxNodeReadmitTime(
+  const std::chrono::duration<double>& time)
+{
+  mMaxNodeReadmitTime = time;
+  return static_cast<NetworkType&>(*this);
+}
+
+//-----
+template<typename NetworkType, typename KeyType, typename NodeType>
+NetworkType& BaseNetwork<NetworkType, KeyType, NodeType>::setCloseTimeout(const std::chrono::duration<double>& timeout)
+{
+  mCloseTimeout = timeout;
+  return static_cast<NetworkType&>(*this);
+}
+
+//-----
+template<typename NetworkType, typename KeyType, typename NodeType>
+NetworkType& BaseNetwork<NetworkType, KeyType, NodeType>::setLedgerId(const LedgerId& ledgerId)
+{
+  mLedgerId = ledgerId;
+  return static_cast<NetworkType&>(*this);
+}
+
+//-----
+template<typename NetworkType, typename KeyType, typename NodeType>
+std::vector<std::shared_ptr<NodeType>> BaseNetwork<NetworkType, KeyType, NodeType>::getNumberOfMostHealthyNodes(
+  unsigned int count)
+{
+  readmitNodes();
+
+  // First, remove any nodes from the network that have exceeded the maximum number of node attempts.
+  if (mMaxNodeAttempts > 0U)
+  {
+    auto nodeIter = mNodes.begin();
+    while (nodeIter != mNodes.end())
+    {
+      if ((*nodeIter)->getBadGrpcStatusCount() >= mMaxNodeAttempts)
+      {
+        (*nodeIter)->close();
+        removeNodeFromNetwork(*nodeIter);
+      }
+      else
+      {
+        ++nodeIter;
+      }
+    }
+  }
+
+  std::unordered_set<std::shared_ptr<NodeType>> nodes;
+  while (count > nodes.size())
+  {
+    // Readmit nodes each time one is fetched. Since readmitting only happens periodically, calling this each time
+    // should not have a significant impact on performance.
+    readmitNodes();
+
+    // If there are no healthy nodes, wait until one can be readmitted.
+    if (mHealthyNodes.empty())
+    {
+      std::this_thread::sleep_for(mEarliestReadmitTime - std::chrono::system_clock::now());
+      continue;
+    }
+
+    // Add a random node (it won't be added if its repeated).
+    auto iter = mHealthyNodes.cbegin();
+    std::advance(iter, internal::Utilities::getRandomNumber(0U, static_cast<unsigned int>(mHealthyNodes.size()) - 1U));
+    nodes.insert(*iter);
+  }
+
+  return { nodes.cbegin(), nodes.cend() };
+}
+
+//-----
+template<typename NetworkType, typename KeyType, typename NodeType>
+void BaseNetwork<NetworkType, KeyType, NodeType>::setTransportSecurity(TLSBehavior tls)
+{
+  mTransportSecurity = tls;
+}
+
+//-----
+template<typename NetworkType, typename KeyType, typename NodeType>
+void BaseNetwork<NetworkType, KeyType, NodeType>::readmitNodes()
+{
+  const std::chrono::system_clock::time_point now = std::chrono::system_clock::now();
+
+  // Do nothing if the time for node re-admittance hasn't been reached yet.
+  if (now <= mEarliestReadmitTime)
+  {
+    return;
+  }
+
+  // Determine the next earliest readmit time.
+  std::chrono::system_clock::time_point nextEarliestReadmitTime =
+    now + std::chrono::duration_cast<std::chrono::system_clock::duration>(mMaxNodeReadmitTime);
+
+  for (const auto& node : mNodes)
+  {
+    if (node->getReadmitTime() > now && node->getReadmitTime() < nextEarliestReadmitTime)
+    {
+      nextEarliestReadmitTime = node->getReadmitTime();
+    }
+  }
+
+  // Set the next earliest readmit time.
+  mEarliestReadmitTime = nextEarliestReadmitTime;
+
+  // Readmit nodes as healthy if they're passed their readmit time.
+  for (const auto& node : mNodes)
+  {
+    if (mHealthyNodes.find(node) == mHealthyNodes.end() && node->getReadmitTime() <= now)
+    {
+      mHealthyNodes.insert(node);
+    }
+  }
+}
+
+//-----
+template<typename NetworkType, typename KeyType, typename NodeType>
+void BaseNetwork<NetworkType, KeyType, NodeType>::removeNodeFromNetwork(const std::shared_ptr<NodeType>& node)
+{
+  mNetwork[node->getKey()].erase(node);
+  mNodes.erase(node);
+  mHealthyNodes.erase(node);
+}
+
+/**
+ * Explicit template instantiations.
+ */
+template class BaseNetwork<Network, AccountId, Node>;
+template class BaseNetwork<MirrorNetwork, BaseNodeAddress, MirrorNode>;
+
+} // namespace Hedera::internal

--- a/sdk/main/src/impl/BaseNetwork.cc
+++ b/sdk/main/src/impl/BaseNetwork.cc
@@ -83,6 +83,8 @@ NetworkType& BaseNetwork<NetworkType, KeyType, NodeType>::setNetwork(
   mNetwork = newNetwork;
   mHealthyNodes.clear();
 
+  readmitNodes();
+
   return static_cast<NetworkType&>(*this);
 }
 
@@ -111,7 +113,7 @@ std::vector<std::shared_ptr<NodeType>> BaseNetwork<NetworkType, KeyType, NodeTyp
 
 //-----
 template<typename NetworkType, typename KeyType, typename NodeType>
-void BaseNetwork<NetworkType, KeyType, NodeType>::close()
+void BaseNetwork<NetworkType, KeyType, NodeType>::close() const
 {
   for (const std::shared_ptr<NodeType>& node : mNodes)
   {
@@ -184,8 +186,6 @@ template<typename NetworkType, typename KeyType, typename NodeType>
 std::vector<std::shared_ptr<NodeType>> BaseNetwork<NetworkType, KeyType, NodeType>::getNumberOfMostHealthyNodes(
   unsigned int count)
 {
-  readmitNodes();
-
   // First, remove any nodes from the network that have exceeded the maximum number of node attempts.
   if (mMaxNodeAttempts > 0U)
   {

--- a/sdk/main/src/impl/BaseNetwork.cc
+++ b/sdk/main/src/impl/BaseNetwork.cc
@@ -19,7 +19,6 @@
  */
 #include "impl/BaseNetwork.h"
 #include "AccountId.h"
-#include "impl/BaseNode.h"
 #include "impl/BaseNodeAddress.h"
 #include "impl/MirrorNetwork.h"
 #include "impl/MirrorNode.h"
@@ -98,7 +97,7 @@ void BaseNetwork<NetworkType, KeyType, NodeType>::increaseBackoff(const std::sha
 
 //-----
 template<typename NetworkType, typename KeyType, typename NodeType>
-void BaseNetwork<NetworkType, KeyType, NodeType>::decreaseBackoff(const std::shared_ptr<NodeType>& node)
+void BaseNetwork<NetworkType, KeyType, NodeType>::decreaseBackoff(const std::shared_ptr<NodeType>& node) const
 {
   node->decreaseBackoff();
 }

--- a/sdk/main/src/impl/BaseNode.cc
+++ b/sdk/main/src/impl/BaseNode.cc
@@ -86,11 +86,7 @@ bool BaseNode<NodeType, KeyType>::channelFailedToConnect()
   }
 
   const std::chrono::system_clock::time_point timeoutTime = std::chrono::system_clock::now() + GET_STATE_TIMEOUT;
-  while (!mIsConnected && std::chrono::system_clock::now() < timeoutTime)
-  {
-    mIsConnected = getChannel()->GetState(true) == GRPC_CHANNEL_READY;
-    std::this_thread::sleep_for(GET_STATE_INTERVAL);
-  }
+  mIsConnected = getChannel()->WaitForConnected(timeoutTime);
 
   return !mIsConnected;
 }
@@ -161,9 +157,9 @@ std::shared_ptr<grpc::Channel> BaseNode<NodeType, KeyType>::getChannel()
                                          mAddress.isTransportSecurity() ? getTlsChannelCredentials()
                                                                         : grpc::InsecureChannelCredentials(),
                                          channelArguments);
+    initializeStubs(mChannel);
   }
 
-  initializeStubs(mChannel);
   return mChannel;
 }
 

--- a/sdk/main/src/impl/BaseNode.cc
+++ b/sdk/main/src/impl/BaseNode.cc
@@ -132,6 +132,17 @@ BaseNode<NodeType, KeyType>::BaseNode(BaseNodeAddress address)
 
 //-----
 template<typename NodeType, typename KeyType>
+NodeType& BaseNode<NodeType, KeyType>::setAddress(const BaseNodeAddress& address)
+{
+  // Close the connection since the address is changing.
+  close();
+
+  mAddress = address;
+  return static_cast<NodeType&>(*this);
+}
+
+//-----
+template<typename NodeType, typename KeyType>
 std::shared_ptr<grpc::Channel> BaseNode<NodeType, KeyType>::getChannel()
 {
   if (!mChannel)

--- a/sdk/main/src/impl/BaseNode.cc
+++ b/sdk/main/src/impl/BaseNode.cc
@@ -1,0 +1,172 @@
+/*-
+ *
+ * Hedera C++ SDK
+ *
+ * Copyright (C) 2020 - 2023 Hedera Hashgraph, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+#include "impl/BaseNode.h"
+#include "impl/BaseNodeAddress.h"
+#include "impl/HederaCertificateVerifier.h"
+#include "impl/MirrorNode.h"
+#include "impl/Node.h"
+
+#include <grpcpp/channel.h>
+#include <grpcpp/create_channel.h>
+#include <thread>
+#include <utility>
+
+namespace Hedera::internal
+{
+//-----
+template<typename NodeType, typename KeyType>
+void BaseNode<NodeType, KeyType>::close()
+{
+  closeStubs();
+
+  // The connection is closed automatically upon destruction of the channel.
+  mChannel = nullptr;
+}
+
+//-----
+template<typename NodeType, typename KeyType>
+void BaseNode<NodeType, KeyType>::increaseBackoff()
+{
+  ++mBadGrpcStatusCount;
+  mReadmitTime =
+    std::chrono::system_clock::now() + std::chrono::duration_cast<std::chrono::system_clock::duration>(mCurrentBackoff);
+  mCurrentBackoff *= 2.0;
+
+  // Make sure the current backoff doesn't go over the max backoff.
+  if (mCurrentBackoff > mMaxNodeBackoff)
+  {
+    mCurrentBackoff = mMaxNodeBackoff;
+  }
+}
+
+//-----
+template<typename NodeType, typename KeyType>
+void BaseNode<NodeType, KeyType>::decreaseBackoff()
+{
+  mCurrentBackoff /= 2.0;
+
+  // Make sure the current backoff doesn't go below the min backoff.
+  if (mCurrentBackoff < mMinNodeBackoff)
+  {
+    mCurrentBackoff = mMinNodeBackoff;
+  }
+}
+
+//-----
+template<typename NodeType, typename KeyType>
+bool BaseNode<NodeType, KeyType>::isHealthy() const
+{
+  return mReadmitTime < std::chrono::system_clock::now();
+}
+
+//-----
+template<typename NodeType, typename KeyType>
+bool BaseNode<NodeType, KeyType>::channelFailedToConnect()
+{
+  if (mIsConnected)
+  {
+    return false;
+  }
+
+  const std::chrono::system_clock::time_point timeoutTime = std::chrono::system_clock::now() + GET_STATE_TIMEOUT;
+  while (!mIsConnected && std::chrono::system_clock::now() < timeoutTime)
+  {
+    mIsConnected = getChannel()->GetState(true) == GRPC_CHANNEL_READY;
+    std::this_thread::sleep_for(GET_STATE_INTERVAL);
+  }
+
+  return !mIsConnected;
+}
+
+//-----
+template<typename NodeType, typename KeyType>
+std::chrono::duration<double> BaseNode<NodeType, KeyType>::getRemainingTimeForBackoff() const
+{
+  return mReadmitTime - std::chrono::system_clock::now();
+}
+
+//-----
+template<typename NodeType, typename KeyType>
+NodeType& BaseNode<NodeType, KeyType>::setMinNodeBackoff(const std::chrono::duration<double>& backoff)
+{
+  if (mCurrentBackoff == mMinNodeBackoff)
+  {
+    mCurrentBackoff = backoff;
+  }
+
+  mMinNodeBackoff = backoff;
+  return static_cast<NodeType&>(*this);
+}
+
+//-----
+template<typename NodeType, typename KeyType>
+NodeType& BaseNode<NodeType, KeyType>::setMaxNodeBackoff(const std::chrono::duration<double>& backoff)
+{
+  mMaxNodeBackoff = backoff;
+  return static_cast<NodeType&>(*this);
+}
+
+//-----
+template<typename NodeType, typename KeyType>
+BaseNode<NodeType, KeyType>::BaseNode(BaseNodeAddress address)
+  : mAddress(std::move(address))
+{
+}
+
+//-----
+template<typename NodeType, typename KeyType>
+std::shared_ptr<grpc::Channel> BaseNode<NodeType, KeyType>::getChannel()
+{
+  if (!mChannel)
+  {
+    grpc::ChannelArguments channelArguments;
+    channelArguments.SetInt(GRPC_ARG_ENABLE_RETRIES, 0);
+    channelArguments.SetInt(GRPC_ARG_KEEPALIVE_TIMEOUT_MS, 10000);
+    channelArguments.SetInt(GRPC_ARG_KEEPALIVE_PERMIT_WITHOUT_CALLS, 1);
+
+    if (const std::string authority = getAuthority(); !authority.empty())
+    {
+      channelArguments.SetString(GRPC_ARG_DEFAULT_AUTHORITY, authority);
+    }
+
+    mChannel = grpc::CreateCustomChannel(mAddress.toString(),
+                                         mAddress.isTransportSecurity() ? getTlsChannelCredentials()
+                                                                        : grpc::InsecureChannelCredentials(),
+                                         channelArguments);
+  }
+
+  initializeStubs(mChannel);
+  return mChannel;
+}
+
+//-----
+template<typename NodeType, typename KeyType>
+std::shared_ptr<grpc::ChannelCredentials> BaseNode<NodeType, KeyType>::getTlsChannelCredentials() const
+{
+  return grpc::experimental::TlsCredentials(grpc::experimental::TlsChannelCredentialsOptions());
+}
+
+/**
+ * Explicit template instantiations.
+ */
+template class BaseNode<Node, AccountId>;
+template class BaseNode<MirrorNode, BaseNodeAddress>;
+
+} // namespace Hedera::internal

--- a/sdk/main/src/impl/BaseNodeAddress.cc
+++ b/sdk/main/src/impl/BaseNodeAddress.cc
@@ -1,0 +1,87 @@
+/*-
+ *
+ * Hedera C++ SDK
+ *
+ * Copyright (C) 2020 - 2023 Hedera Hashgraph, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+#include "impl/BaseNodeAddress.h"
+
+#include <charconv>
+
+namespace Hedera::internal
+{
+//-----
+BaseNodeAddress::BaseNodeAddress(std::string_view name, std::string_view address, unsigned int port)
+  : mName(name)
+  , mAddress(address)
+  , mPort(port)
+{
+}
+
+//-----
+BaseNodeAddress BaseNodeAddress::fromString(std::string_view address)
+{
+  if (const std::string_view inProcessPrefix = "in-process:"; address.find(inProcessPrefix) == 0ULL)
+  {
+    address.remove_prefix(inProcessPrefix.size());
+    return BaseNodeAddress(address, "", 0U);
+  }
+
+  const size_t colonIndex = address.find(':');
+  if (colonIndex == std::string::npos)
+  {
+    throw std::invalid_argument("Input BaseNodeAddress is malformed");
+  }
+
+  const std::string_view ipAddressV4 = address.substr(0, colonIndex);
+  const std::string_view portStr = address.substr(colonIndex + 1, address.size() - colonIndex - 1);
+  unsigned int port;
+  if (const auto result = std::from_chars(portStr.data(), portStr.data() + portStr.size(), port);
+      result.ptr != portStr.data() + portStr.size() || result.ec != std::errc())
+  {
+    throw std::invalid_argument("Input BaseNodeAddress is malformed");
+  }
+
+  return BaseNodeAddress("", ipAddressV4, port);
+}
+
+//-----
+bool BaseNodeAddress::operator==(const BaseNodeAddress& other) const
+{
+  return (!mName.empty()) ? (mName == other.mName) : ((mAddress == other.mAddress) && (mPort == other.mPort));
+}
+
+//-----
+BaseNodeAddress BaseNodeAddress::toSecure() const
+{
+  return BaseNodeAddress(
+    mName, mAddress, (mPort == PORT_MIRROR_PLAIN || mPort == PORT_MIRROR_TLS) ? PORT_MIRROR_TLS : PORT_NODE_TLS);
+}
+
+//-----
+BaseNodeAddress BaseNodeAddress::toInsecure() const
+{
+  return BaseNodeAddress(
+    mName, mAddress, (mPort == PORT_MIRROR_PLAIN || mPort == PORT_MIRROR_TLS) ? PORT_MIRROR_PLAIN : PORT_NODE_PLAIN);
+}
+
+//-----
+std::string BaseNodeAddress::toString() const
+{
+  return (!mName.empty()) ? mName : mAddress + std::to_string(mPort);
+}
+
+} // namespace Hedera::internal

--- a/sdk/main/src/impl/BaseNodeAddress.cc
+++ b/sdk/main/src/impl/BaseNodeAddress.cc
@@ -81,7 +81,7 @@ BaseNodeAddress BaseNodeAddress::toInsecure() const
 //-----
 std::string BaseNodeAddress::toString() const
 {
-  return (!mName.empty()) ? mName : mAddress + std::to_string(mPort);
+  return (!mName.empty()) ? "in-process:" + mName : mAddress + ':' + std::to_string(mPort);
 }
 
 } // namespace Hedera::internal

--- a/sdk/main/src/impl/BaseNodeAddress.cc
+++ b/sdk/main/src/impl/BaseNodeAddress.cc
@@ -20,6 +20,7 @@
 #include "impl/BaseNodeAddress.h"
 
 #include <charconv>
+#include <stdexcept>
 
 namespace Hedera::internal
 {

--- a/sdk/main/src/impl/HederaCertificateVerifier.cc
+++ b/sdk/main/src/impl/HederaCertificateVerifier.cc
@@ -43,10 +43,11 @@ bool HederaCertificateVerifier::Verify(grpc::experimental::TlsCustomVerification
   {
     *sync_status = grpc::Status(grpc::StatusCode::UNAUTHENTICATED,
                                 "Hash of node certificate chain doesn't match hash contained in address book");
-    return true;
   }
-
-  *sync_status = grpc::Status(grpc::StatusCode::OK, "Certificate chain hash matches expected");
+  else
+  {
+    *sync_status = grpc::Status(grpc::StatusCode::OK, "Certificate chain hash matches expected");
+  }
 
   // always true, since this is called synchronously
   return true;

--- a/sdk/main/src/impl/IPv4Address.cc
+++ b/sdk/main/src/impl/IPv4Address.cc
@@ -20,55 +20,36 @@
 #include "impl/IPv4Address.h"
 #include "impl/Utilities.h"
 
-#include <charconv>
-#include <iostream>
-#include <vector>
+#include <algorithm>
 
 namespace Hedera::internal
 {
-IPv4Address::IPv4Address(std::byte octet1, std::byte octet2, std::byte octet3, std::byte octet4)
-  : mOctet1(octet1)
-  , mOctet2(octet2)
-  , mOctet3(octet3)
-  , mOctet4(octet4)
+//-----
+IPv4Address IPv4Address::fromBytes(const std::vector<std::byte>& bytes)
 {
+  if (bytes.size() != 4)
+  {
+    throw std::invalid_argument("Incorrect byte array size, should be 4 bytes but is " + std::to_string(bytes.size()));
+  }
+
+  IPv4Address iPv4Address;
+  std::copy(bytes.cbegin(), bytes.cend(), iPv4Address.mAddress.begin());
+  return iPv4Address;
 }
 
-IPv4Address IPv4Address::fromString(std::string_view address)
+//-----
+std::vector<std::byte> IPv4Address::toBytes() const
 {
-  // The input string is in byte format, where each byte represents a single IP address octet.
-  if (address.size() == 4)
-  {
-    const std::vector<std::byte> byteVector = Utilities::stringToByteVector(address);
-    return { byteVector.at(0), byteVector.at(1), byteVector.at(2), byteVector.at(3) };
-  }
-
-  try
-  {
-    std::vector<std::byte> byteVector;
-    std::string_view octet;
-    for (int i = 0; i < 3; ++i)
-    {
-      octet = address.substr(0, address.find_first_of('.'));
-      byteVector.push_back(Utilities::stringToByte(octet));
-      address.remove_prefix(octet.size() + 1);
-    }
-
-    byteVector.push_back(Utilities::stringToByte(address));
-    return { byteVector.at(0), byteVector.at(1), byteVector.at(2), byteVector.at(3) };
-  }
-  catch (const std::exception&)
-  {
-    throw std::invalid_argument("Input IPv4Address is malformed");
-  }
+  return { mAddress.at(0), mAddress.at(1), mAddress.at(2), mAddress.at(3) };
 }
 
+//-----
 std::string IPv4Address::toString() const
 {
-  return std::to_string(std::to_integer<unsigned char>(mOctet1)) + '.' +
-         std::to_string(std::to_integer<unsigned char>(mOctet2)) + '.' +
-         std::to_string(std::to_integer<unsigned char>(mOctet3)) + '.' +
-         std::to_string(std::to_integer<unsigned char>(mOctet4));
+  return std::to_string(std::to_integer<unsigned char>(mAddress.at(0))) + '.' +
+         std::to_string(std::to_integer<unsigned char>(mAddress.at(1))) + '.' +
+         std::to_string(std::to_integer<unsigned char>(mAddress.at(2))) + '.' +
+         std::to_string(std::to_integer<unsigned char>(mAddress.at(3)));
 }
 
 } // namespace Hedera::internal

--- a/sdk/main/src/impl/IPv4Address.cc
+++ b/sdk/main/src/impl/IPv4Address.cc
@@ -18,9 +18,8 @@
  *
  */
 #include "impl/IPv4Address.h"
-#include "impl/Utilities.h"
 
-#include <algorithm>
+#include <stdexcept>
 
 namespace Hedera::internal
 {

--- a/sdk/main/src/impl/MirrorNetwork.cc
+++ b/sdk/main/src/impl/MirrorNetwork.cc
@@ -72,7 +72,7 @@ MirrorNetwork& MirrorNetwork::setNetwork(const std::vector<std::string>& network
 std::vector<std::string> MirrorNetwork::getNetwork() const
 {
   std::vector<std::string> network;
-  for (const auto& [address, nodes] : BaseNetwork<MirrorNetwork, BaseNodeAddress, MirrorNode>::getNetwork())
+  for (const auto& [address, nodes] : BaseNetwork<MirrorNetwork, BaseNodeAddress, MirrorNode>::getNetworkInternal())
   {
     network.push_back(address.toString());
   }
@@ -83,12 +83,14 @@ std::vector<std::string> MirrorNetwork::getNetwork() const
 //-----
 std::shared_ptr<MirrorNode> MirrorNetwork::getNextMirrorNode() const
 {
-  if (mNodes.empty())
+  if (getNodes().empty())
   {
     return nullptr;
   }
 
-  return mNodes.at(Utilities::getRandomNumber(0U, static_cast<unsigned int>(mNodes.size()) - 1U));
+  auto nodeIter = getNodes().cbegin();
+  std::advance(nodeIter, Utilities::getRandomNumber(0U, static_cast<unsigned int>(getNodes().size()) - 1U));
+  return *nodeIter;
 }
 
 //-----

--- a/sdk/main/src/impl/Network.cc
+++ b/sdk/main/src/impl/Network.cc
@@ -151,10 +151,9 @@ Network Network::getNetworkForLedgerId(const LedgerId& ledgerId)
   {
     for (const auto& endpoint : nodeAddress.getEndpoints())
     {
-      if (endpoint.getPort() == BaseNodeAddress::PORT_NODE_TLS)
+      if (endpoint.getPort() == BaseNodeAddress::PORT_NODE_PLAIN)
       {
         network[endpoint.toString()] = accountId;
-        break;
       }
     }
   }
@@ -178,7 +177,7 @@ std::unordered_map<AccountId, NodeAddress> Network::getAddressBookForLedgerId(co
   std::unordered_map<AccountId, NodeAddress> addresses;
   for (const auto& nodeAddress : addressBook.getNodeAddresses())
   {
-    addresses.try_emplace(nodeAddress.getAccountId(), nodeAddress);
+    addresses[nodeAddress.getAccountId()] = nodeAddress;
   }
 
   return addresses;

--- a/sdk/main/src/impl/Network.cc
+++ b/sdk/main/src/impl/Network.cc
@@ -72,6 +72,13 @@ Network& Network::setVerifyCertificates(bool verify)
 }
 
 //-----
+Network& Network::setMaxNodesPerRequest(unsigned int max)
+{
+  mMaxNodesPerRequest = max;
+  return *this;
+}
+
+//-----
 Network& Network::setTransportSecurity(TLSBehavior tls)
 {
   if (isTransportSecurity() != tls)
@@ -108,8 +115,8 @@ std::vector<AccountId> Network::getNodeAccountIdsForExecute()
 {
   std::vector<AccountId> accountIds;
   for (const std::shared_ptr<Node>& node : getNumberOfMostHealthyNodes(
-         mMaxNodesPerRequest > 0 ? std::min(mMaxNodesPerRequest, static_cast<unsigned int>(getNodes().size()))
-                                 : static_cast<unsigned int>(floor(static_cast<double>(getNodes().size()) / 3.0))))
+         mMaxNodesPerRequest > 0U ? std::min(mMaxNodesPerRequest, static_cast<unsigned int>(getNodes().size()))
+                                  : static_cast<unsigned int>(std::ceil(static_cast<double>(getNodes().size()) / 3.0))))
   {
     accountIds.push_back(node->getAccountId());
   }

--- a/sdk/main/src/impl/Node.cc
+++ b/sdk/main/src/impl/Node.cc
@@ -267,7 +267,6 @@ void Node::initializeStubs(const std::shared_ptr<grpc::Channel>& channel)
 //-----
 void Node::closeStubs()
 {
-<<<<<<< HEAD
   mConsensusStub = nullptr;
   mCryptoStub = nullptr;
   mFileStub = nullptr;
@@ -275,79 +274,6 @@ void Node::closeStubs()
   mScheduleStub = nullptr;
   mSmartContractStub = nullptr;
   mTokenStub = nullptr;
-=======
-  const std::vector<std::shared_ptr<Endpoint>> endpoints = mAddress->getEndpoints();
-
-  std::shared_ptr<grpc::ChannelCredentials> channelCredentials = nullptr;
-
-  grpc::ChannelArguments channelArguments;
-  channelArguments.SetInt(GRPC_ARG_ENABLE_RETRIES, 0);
-
-  for (const auto& endpoint : endpoints)
-  {
-    switch (mTLSBehavior)
-    {
-      case TLSBehavior::REQUIRE:
-      {
-        if (NodeAddress::isTlsPort(endpoint->getPort()))
-        {
-          channelArguments.SetInt(GRPC_ARG_KEEPALIVE_TIMEOUT_MS, 10000);
-          channelArguments.SetInt(GRPC_ARG_KEEPALIVE_PERMIT_WITHOUT_CALLS, 1);
-          channelCredentials = mTlsChannelCredentials;
-        }
-
-        break;
-      }
-
-      case TLSBehavior::DISABLE:
-      {
-        if (NodeAddress::isNonTlsPort(endpoint->getPort()))
-        {
-          channelCredentials = grpc::InsecureChannelCredentials();
-        }
-
-        break;
-      }
-
-      default:
-      {
-        continue;
-      }
-    }
-
-    if (channelCredentials)
-    {
-      shutdown();
-
-      mChannel = grpc::CreateCustomChannel(endpoint->toString(), channelCredentials, channelArguments);
-
-      if (mChannel->WaitForConnected(deadline))
-      {
-        mConsensusStub = proto::ConsensusService::NewStub(mChannel);
-        mCryptoStub = proto::CryptoService::NewStub(mChannel);
-        mFileStub = proto::FileService::NewStub(mChannel);
-        mFreezeStub = proto::FreezeService::NewStub(mChannel);
-        mNetworkStub = proto::NetworkService::NewStub(mChannel);
-        mScheduleStub = proto::ScheduleService::NewStub(mChannel);
-        mSmartContractStub = proto::SmartContractService::NewStub(mChannel);
-        mTokenStub = proto::TokenService::NewStub(mChannel);
-        mIsInitialized = true;
-
-        return true;
-      }
-      else
-      {
-        mChannel = nullptr;
-      }
-    }
-    else
-    {
-      channelCredentials = nullptr;
-    }
-  }
-
-  return false;
->>>>>>> main
 }
 
 } // namespace Hedera::internal

--- a/sdk/main/src/impl/Node.cc
+++ b/sdk/main/src/impl/Node.cc
@@ -191,15 +191,15 @@ grpc::Status Node::submitTransaction(proto::TransactionBody::DataCase funcEnum,
 }
 
 //-----
-std::shared_ptr<Node> Node::toInsecure() const
+Node& Node::toInsecure()
 {
-  return std::make_shared<Node>(Node(*this, getAddress().toInsecure()));
+  return BaseNode<Node, AccountId>::setAddress(getAddress().toInsecure());
 }
 
 //-----
-std::shared_ptr<Node> Node::toSecure() const
+Node& Node::toSecure()
 {
-  return std::make_shared<Node>(Node(*this, getAddress().toSecure()));
+  return BaseNode<Node, AccountId>::setAddress(getAddress().toSecure());
 }
 
 //-----

--- a/sdk/main/src/impl/Node.cc
+++ b/sdk/main/src/impl/Node.cc
@@ -258,6 +258,7 @@ void Node::initializeStubs(const std::shared_ptr<grpc::Channel>& channel)
   if (!mCryptoStub)        mCryptoStub = proto::CryptoService::NewStub(channel);
   if (!mFileStub)          mFileStub = proto::FileService::NewStub(channel);
   if (!mFreezeStub)        mFreezeStub = proto::FreezeService::NewStub(channel);
+  if (!mNetworkStub)       mNetworkStub = proto::NetworkService::NewStub(channel);
   if (!mScheduleStub)      mScheduleStub = proto::ScheduleService::NewStub(channel);
   if (!mSmartContractStub) mSmartContractStub = proto::SmartContractService::NewStub(channel);
   if (!mTokenStub)         mTokenStub = proto::TokenService::NewStub(channel);
@@ -271,6 +272,7 @@ void Node::closeStubs()
   mCryptoStub = nullptr;
   mFileStub = nullptr;
   mFreezeStub = nullptr;
+  mNetworkStub = nullptr;
   mScheduleStub = nullptr;
   mSmartContractStub = nullptr;
   mTokenStub = nullptr;

--- a/sdk/main/src/impl/NodeAddress.cc
+++ b/sdk/main/src/impl/NodeAddress.cc
@@ -33,16 +33,16 @@ namespace Hedera::internal
 NodeAddress NodeAddress::fromProtobuf(const proto::NodeAddress& protoNodeAddress)
 {
   NodeAddress outputNodeAddress;
+  outputNodeAddress.mRSAPublicKey = protoNodeAddress.rsa_pubkey();
+  outputNodeAddress.mNodeId = protoNodeAddress.nodeid();
+  outputNodeAddress.mNodeAccountId = AccountId::fromProtobuf(protoNodeAddress.nodeaccountid());
+  outputNodeAddress.mNodeCertHash = Utilities::stringToByteVector(protoNodeAddress.nodecerthash());
 
   for (int i = 0; i < protoNodeAddress.serviceendpoint_size(); ++i)
   {
     outputNodeAddress.mEndpoints.push_back(Endpoint::fromProtobuf(protoNodeAddress.serviceendpoint(i)));
   }
 
-  outputNodeAddress.mRSAPublicKey = protoNodeAddress.rsa_pubkey();
-  outputNodeAddress.mNodeId = protoNodeAddress.nodeid();
-  outputNodeAddress.mNodeAccountId = AccountId::fromProtobuf(protoNodeAddress.nodeaccountid());
-  outputNodeAddress.mNodeCertHash = Utilities::stringToByteVector(protoNodeAddress.nodecerthash());
   outputNodeAddress.mDescription = protoNodeAddress.description();
 
   return outputNodeAddress;
@@ -56,12 +56,13 @@ std::unique_ptr<proto::NodeAddress> NodeAddress::toProtobuf() const
   protoNodeAddress->set_nodeid(mNodeId);
   protoNodeAddress->set_allocated_nodeaccountid(mNodeAccountId.toProtobuf().release());
   protoNodeAddress->set_nodecerthash(Utilities::byteVectorToString(mNodeCertHash));
-  protoNodeAddress->set_description(mDescription);
 
   for (const auto& endpoint : mEndpoints)
   {
     *protoNodeAddress->add_serviceendpoint() = *endpoint.toProtobuf();
   }
+
+  protoNodeAddress->set_description(mDescription);
 
   return protoNodeAddress;
 }
@@ -112,7 +113,7 @@ std::string NodeAddress::toString() const
 }
 
 //-----
-NodeAddress& NodeAddress::setRSAPublicKey(std::string_view publicKey)
+NodeAddress& NodeAddress::setPublicKey(std::string_view publicKey)
 {
   mRSAPublicKey = publicKey;
   return *this;
@@ -126,16 +127,23 @@ NodeAddress& NodeAddress::setNodeId(const int64_t& nodeId)
 }
 
 //-----
-NodeAddress& NodeAddress::setNodeAccountId(const AccountId& accountId)
+NodeAddress& NodeAddress::setAccountId(const AccountId& accountId)
 {
   mNodeAccountId = accountId;
   return *this;
 }
 
 //-----
-NodeAddress& NodeAddress::setNodeCertHash(std::string_view certHash)
+NodeAddress& NodeAddress::setCertHash(std::string_view certHash)
 {
   mNodeCertHash = Utilities::stringToByteVector(certHash);
+  return *this;
+}
+
+//-----
+NodeAddress& NodeAddress::setCertHash(std::vector<std::byte> certHash)
+{
+  mNodeCertHash = std::move(certHash);
   return *this;
 }
 

--- a/sdk/main/src/impl/Utilities.cc
+++ b/sdk/main/src/impl/Utilities.cc
@@ -22,6 +22,7 @@
 #include <algorithm>
 #include <charconv>
 #include <iostream>
+#include <random>
 
 namespace Hedera::internal::Utilities
 {
@@ -90,6 +91,16 @@ std::string byteVectorToString(const std::vector<std::byte>& bytes)
   std::transform(
     bytes.cbegin(), bytes.cend(), std::back_inserter(str), [](std::byte byte) { return static_cast<char>(byte); });
   return str;
+}
+
+//-----
+unsigned int getRandomNumber(unsigned int lowerBound, unsigned int upperBound)
+{
+  static std::random_device rand;
+  static std::mt19937 eng(rand());
+
+  std::uniform_int_distribution dis(lowerBound, upperBound);
+  return dis(eng);
 }
 
 } // namespace Hedera::internal::Utilities

--- a/sdk/tests/integration/ContractNonceInfoIntegrationTest.cc
+++ b/sdk/tests/integration/ContractNonceInfoIntegrationTest.cc
@@ -23,7 +23,6 @@
 #include "ContractDeleteTransaction.h"
 #include "ContractFunctionResult.h"
 #include "ContractId.h"
-#include "ContractInfo.h"
 #include "ED25519PrivateKey.h"
 #include "FileCreateTransaction.h"
 #include "FileDeleteTransaction.h"
@@ -35,7 +34,6 @@
 #include "exceptions/ReceiptStatusException.h"
 #include "impl/Utilities.h"
 
-#include <chrono>
 #include <gtest/gtest.h>
 
 using namespace Hedera;
@@ -64,7 +62,6 @@ TEST_F(ContractNonceInfoIntegrationTest, ContractADeploysContractBInConstructor)
   const std::unique_ptr<PrivateKey> operatorKey = ED25519PrivateKey::fromString(
     "302e020100300506032b65700422042091132178e72057a1d7528025956fe39b0b847f200ab59b2fdd367017f3087137");
   const std::string memo = "[e2e::ContractADeploysContractBInConstructor]";
-  const std::chrono::duration<double> autoRenewPeriod = std::chrono::hours(2016);
   FileId fileId;
   ASSERT_NO_THROW(fileId =
                     FileCreateTransaction()
@@ -88,12 +85,11 @@ TEST_F(ContractNonceInfoIntegrationTest, ContractADeploysContractBInConstructor)
   ContractId contractA = contractFunctionResult.mContractId;
   std::vector<ContractNonceInfo> contractNonces;
 
-  for (auto it = contractFunctionResult.mContractNonces.begin(); it != contractFunctionResult.mContractNonces.end();
-       ++it)
+  for (const auto& mContractNonce : contractFunctionResult.mContractNonces)
   {
-    if (!((*it).mContractId == contractA))
+    if (!(mContractNonce.mContractId == contractA))
     {
-      contractNonces.push_back(*it);
+      contractNonces.push_back(mContractNonce);
     }
   }
 
@@ -102,16 +98,15 @@ TEST_F(ContractNonceInfoIntegrationTest, ContractADeploysContractBInConstructor)
   ContractNonceInfo contractANonceInfo;
   ContractNonceInfo contractBNonceInfo;
 
-  for (auto it = contractFunctionResult.mContractNonces.begin(); it != contractFunctionResult.mContractNonces.end();
-       ++it)
+  for (const auto& mContractNonce : contractFunctionResult.mContractNonces)
   {
-    if ((*it).mContractId == contractA)
+    if (mContractNonce.mContractId == contractA)
     {
-      contractANonceInfo = *it;
+      contractANonceInfo = mContractNonce;
     }
-    else if ((*it).mContractId == contractB)
+    else if (mContractNonce.mContractId == contractB)
     {
-      contractBNonceInfo = *it;
+      contractBNonceInfo = mContractNonce;
     }
   }
 

--- a/sdk/tests/integration/FileAppendTransactionIntegrationTests.cc
+++ b/sdk/tests/integration/FileAppendTransactionIntegrationTests.cc
@@ -239,11 +239,6 @@ TEST_F(FileAppendTransactionIntegrationTest, CanAppendLargeContents)
     txResponses = FileAppendTransaction().setFileId(fileId).setContents(appendedContents).executeAll(getTestClient()));
 
   // Then
-  for (const auto& response : txResponses)
-  {
-    EXPECT_NO_THROW(const TransactionReceipt txReceipt = response.getReceipt(getTestClient()));
-  }
-
   FileContents fileContents;
   ASSERT_NO_THROW(fileContents = FileContentsQuery().setFileId(fileId).execute(getTestClient()));
   EXPECT_EQ(fileContents, internal::Utilities::concatenateVectors({ origContents, appendedContents }));

--- a/sdk/tests/integration/TopicMessageSubmitTransactionIntegrationTests.cc
+++ b/sdk/tests/integration/TopicMessageSubmitTransactionIntegrationTests.cc
@@ -325,7 +325,7 @@ TEST_F(TopicMessageSubmitTransactionIntegrationTests, CannotSubmitTopicMessageWi
   for (const auto& resp : txResponses)
   {
     EXPECT_EQ(resp.getValidateStatus(), true);
-    EXPECT_THROW(resp.getReceipt(getTestClient()).mStatus == Status::INVALID_TOPIC_ID, ReceiptStatusException);
+    EXPECT_THROW(const TransactionReceipt txReceipt = resp.getReceipt(getTestClient()), ReceiptStatusException);
   }
 
   TopicInfo topicInfo2;

--- a/sdk/tests/unit/AccountAllowanceApproveTransactionTest.cc
+++ b/sdk/tests/unit/AccountAllowanceApproveTransactionTest.cc
@@ -36,9 +36,6 @@ using namespace Hedera;
 class AccountAllowanceApproveTransactionTest : public ::testing::Test
 {
 protected:
-  void SetUp() override { mClient.setOperator(AccountId(1ULL), ECDSAsecp256k1PrivateKey::generatePrivateKey().get()); }
-
-  [[nodiscard]] inline const Client& getTestClient() const { return mClient; }
   [[nodiscard]] inline const AccountId& getTestOwnerAccountId() const { return mOwnerAccountId; }
   [[nodiscard]] inline const AccountId& getTestSpenderAccountId() const { return mSpenderAccountId; }
   [[nodiscard]] inline const Hbar& getTestAmountHbar() const { return mAmountHbar; }
@@ -51,7 +48,6 @@ protected:
   }
 
 private:
-  Client mClient;
   const AccountId mOwnerAccountId = AccountId(2ULL);
   const AccountId mSpenderAccountId = AccountId(3ULL);
   const Hbar mAmountHbar = Hbar(4LL);
@@ -153,8 +149,10 @@ TEST_F(AccountAllowanceApproveTransactionTest, ApproveHbarAllowance)
 TEST_F(AccountAllowanceApproveTransactionTest, ApproveHbarAllowanceFrozen)
 {
   // Given
-  AccountAllowanceApproveTransaction transaction;
-  ASSERT_NO_THROW(transaction.freezeWith(&getTestClient()));
+  AccountAllowanceApproveTransaction transaction = AccountAllowanceApproveTransaction()
+                                                     .setNodeAccountIds({ AccountId(1ULL) })
+                                                     .setTransactionId(TransactionId::generate(AccountId(1ULL)));
+  ASSERT_NO_THROW(transaction.freeze());
 
   // When / Then
   EXPECT_THROW(
@@ -196,8 +194,10 @@ TEST_F(AccountAllowanceApproveTransactionTest, ApproveTokenAllowance)
 TEST_F(AccountAllowanceApproveTransactionTest, ApproveTokenAllowanceFrozen)
 {
   // Given
-  AccountAllowanceApproveTransaction transaction;
-  ASSERT_NO_THROW(transaction.freezeWith(&getTestClient()));
+  AccountAllowanceApproveTransaction transaction = AccountAllowanceApproveTransaction()
+                                                     .setNodeAccountIds({ AccountId(1ULL) })
+                                                     .setTransactionId(TransactionId::generate(AccountId(1ULL)));
+  ASSERT_NO_THROW(transaction.freeze());
 
   // When / Then
   EXPECT_THROW(
@@ -247,8 +247,10 @@ TEST_F(AccountAllowanceApproveTransactionTest, ApproveNftAllowance)
 TEST_F(AccountAllowanceApproveTransactionTest, ApproveNftAllowanceFrozen)
 {
   // Given
-  AccountAllowanceApproveTransaction transaction;
-  ASSERT_NO_THROW(transaction.freezeWith(&getTestClient()));
+  AccountAllowanceApproveTransaction transaction = AccountAllowanceApproveTransaction()
+                                                     .setNodeAccountIds({ AccountId(1ULL) })
+                                                     .setTransactionId(TransactionId::generate(AccountId(1ULL)));
+  ASSERT_NO_THROW(transaction.freeze());
 
   // When / Then
   EXPECT_THROW(transaction.approveTokenNftAllowance(
@@ -281,8 +283,10 @@ TEST_F(AccountAllowanceApproveTransactionTest, ApproveNftAllowanceAllSerials)
 TEST_F(AccountAllowanceApproveTransactionTest, ApproveNftAllowanceAllSerialsFrozen)
 {
   // Given
-  AccountAllowanceApproveTransaction transaction;
-  ASSERT_NO_THROW(transaction.freezeWith(&getTestClient()));
+  AccountAllowanceApproveTransaction transaction = AccountAllowanceApproveTransaction()
+                                                     .setNodeAccountIds({ AccountId(1ULL) })
+                                                     .setTransactionId(TransactionId::generate(AccountId(1ULL)));
+  ASSERT_NO_THROW(transaction.freeze());
 
   // When / Then
   EXPECT_THROW(
@@ -315,8 +319,10 @@ TEST_F(AccountAllowanceApproveTransactionTest, DeleteNftAllowanceAllSerials)
 TEST_F(AccountAllowanceApproveTransactionTest, DeleteNftAllowanceAllSerialsFrozen)
 {
   // Given
-  AccountAllowanceApproveTransaction transaction;
-  ASSERT_NO_THROW(transaction.freezeWith(&getTestClient()));
+  AccountAllowanceApproveTransaction transaction = AccountAllowanceApproveTransaction()
+                                                     .setNodeAccountIds({ AccountId(1ULL) })
+                                                     .setTransactionId(TransactionId::generate(AccountId(1ULL)));
+  ASSERT_NO_THROW(transaction.freeze());
 
   // When / Then
   EXPECT_THROW(

--- a/sdk/tests/unit/AccountAllowanceDeleteTransactionTest.cc
+++ b/sdk/tests/unit/AccountAllowanceDeleteTransactionTest.cc
@@ -35,15 +35,11 @@ using namespace Hedera;
 class AccountAllowanceDeleteTransactionTest : public ::testing::Test
 {
 protected:
-  void SetUp() override { mClient.setOperator(AccountId(1ULL), ECDSAsecp256k1PrivateKey::generatePrivateKey().get()); }
-
-  [[nodiscard]] inline const Client& getTestClient() const { return mClient; }
   [[nodiscard]] inline const TokenId& getTestTokenId() const { return mTokenId; }
   [[nodiscard]] inline const AccountId& getTestOwnerAccountId() const { return mOwnerAccountId; }
   [[nodiscard]] inline const std::vector<uint64_t>& getTestSerialNumbers() const { return mSerialNumbers; }
 
 private:
-  Client mClient;
   const AccountId mOwnerAccountId = AccountId(2ULL);
   const TokenId mTokenId = TokenId(3ULL);
   const std::vector<uint64_t> mSerialNumbers = { 4ULL, 5ULL, 6ULL };
@@ -145,8 +141,10 @@ TEST_F(AccountAllowanceDeleteTransactionTest, DeleteNftAllowancesDifferentTokenI
 TEST_F(AccountAllowanceDeleteTransactionTest, DeleteNftAllowancesFrozen)
 {
   // Given
-  AccountAllowanceDeleteTransaction transaction;
-  transaction.freezeWith(&getTestClient());
+  AccountAllowanceDeleteTransaction transaction = AccountAllowanceDeleteTransaction()
+                                                    .setNodeAccountIds({ AccountId(1ULL) })
+                                                    .setTransactionId(TransactionId::generate(AccountId(1ULL)));
+  ASSERT_NO_THROW(transaction.freeze());
 
   // When / Then
   EXPECT_THROW(transaction.deleteAllTokenNftAllowances(NftId(getTestTokenId(), 10ULL), getTestOwnerAccountId()),

--- a/sdk/tests/unit/AccountCreateTransactionTest.cc
+++ b/sdk/tests/unit/AccountCreateTransactionTest.cc
@@ -36,12 +36,6 @@ using namespace Hedera;
 class AccountCreateTransactionTest : public ::testing::Test
 {
 protected:
-  void SetUp() override
-  {
-    mClient.setOperator(getTestAccountId(), ECDSAsecp256k1PrivateKey::generatePrivateKey().get());
-  }
-
-  [[nodiscard]] inline const Client& getTestClient() const { return mClient; }
   [[nodiscard]] inline const std::shared_ptr<PublicKey>& getTestPublicKey() const { return mPublicKey; }
   [[nodiscard]] inline const Hbar& getTestInitialBalance() const { return mInitialBalance; }
   [[nodiscard]] inline bool getTestReceiverSignatureRequired() const { return mReceiverSignatureRequired; }
@@ -54,7 +48,6 @@ protected:
   [[nodiscard]] inline const EvmAddress& getTestEvmAddress() const { return mEvmAddress; }
 
 private:
-  Client mClient;
   const std::shared_ptr<PublicKey> mPublicKey = ED25519PrivateKey::generatePrivateKey()->getPublicKey();
   const Hbar mInitialBalance = Hbar(1LL);
   const bool mReceiverSignatureRequired = true;
@@ -153,8 +146,10 @@ TEST_F(AccountCreateTransactionTest, SetKey)
 TEST_F(AccountCreateTransactionTest, SetKeyFrozen)
 {
   // Given
-  AccountCreateTransaction transaction;
-  ASSERT_NO_THROW(transaction.freezeWith(&getTestClient()));
+  AccountCreateTransaction transaction = AccountCreateTransaction()
+                                           .setNodeAccountIds({ AccountId(1ULL) })
+                                           .setTransactionId(TransactionId::generate(AccountId(1ULL)));
+  ASSERT_NO_THROW(transaction.freeze());
 
   // When / Then
   EXPECT_THROW(transaction.setKey(getTestPublicKey().get()), IllegalStateException);
@@ -177,8 +172,10 @@ TEST_F(AccountCreateTransactionTest, SetInitialBalance)
 TEST_F(AccountCreateTransactionTest, SetInitialBalanceFrozen)
 {
   // Given
-  AccountCreateTransaction transaction;
-  ASSERT_NO_THROW(transaction.freezeWith(&getTestClient()));
+  AccountCreateTransaction transaction = AccountCreateTransaction()
+                                           .setNodeAccountIds({ AccountId(1ULL) })
+                                           .setTransactionId(TransactionId::generate(AccountId(1ULL)));
+  ASSERT_NO_THROW(transaction.freeze());
 
   // When / Then
   EXPECT_THROW(transaction.setInitialBalance(getTestInitialBalance()), IllegalStateException);
@@ -201,8 +198,10 @@ TEST_F(AccountCreateTransactionTest, SetReceiverSignatureRequired)
 TEST_F(AccountCreateTransactionTest, SetReceiverSignatureRequiredFrozen)
 {
   // Given
-  AccountCreateTransaction transaction;
-  ASSERT_NO_THROW(transaction.freezeWith(&getTestClient()));
+  AccountCreateTransaction transaction = AccountCreateTransaction()
+                                           .setNodeAccountIds({ AccountId(1ULL) })
+                                           .setTransactionId(TransactionId::generate(AccountId(1ULL)));
+  ASSERT_NO_THROW(transaction.freeze());
 
   // When / Then
   EXPECT_THROW(transaction.setReceiverSignatureRequired(getTestReceiverSignatureRequired()), IllegalStateException);
@@ -225,8 +224,10 @@ TEST_F(AccountCreateTransactionTest, SetAutoRenewPeriod)
 TEST_F(AccountCreateTransactionTest, SetAutoRenewPeriodFrozen)
 {
   // Given
-  AccountCreateTransaction transaction;
-  ASSERT_NO_THROW(transaction.freezeWith(&getTestClient()));
+  AccountCreateTransaction transaction = AccountCreateTransaction()
+                                           .setNodeAccountIds({ AccountId(1ULL) })
+                                           .setTransactionId(TransactionId::generate(AccountId(1ULL)));
+  ASSERT_NO_THROW(transaction.freeze());
 
   // When / Then
   EXPECT_THROW(transaction.setAutoRenewPeriod(getTestAutoRenewPeriod()), IllegalStateException);
@@ -259,8 +260,10 @@ TEST_F(AccountCreateTransactionTest, SetAccountMemoTooLarge)
 TEST_F(AccountCreateTransactionTest, SetAccountMemoFrozen)
 {
   // Given
-  AccountCreateTransaction transaction;
-  ASSERT_NO_THROW(transaction.freezeWith(&getTestClient()));
+  AccountCreateTransaction transaction = AccountCreateTransaction()
+                                           .setNodeAccountIds({ AccountId(1ULL) })
+                                           .setTransactionId(TransactionId::generate(AccountId(1ULL)));
+  ASSERT_NO_THROW(transaction.freeze());
 
   // When / Then
   EXPECT_THROW(transaction.setAccountMemo(getTestAccountMemo()), IllegalStateException);
@@ -293,8 +296,10 @@ TEST_F(AccountCreateTransactionTest, SetMaxAutomaticTokenAssociationsTooMany)
 TEST_F(AccountCreateTransactionTest, SetMaxAutomaticTokenAssociationsFrozen)
 {
   // Given
-  AccountCreateTransaction transaction;
-  ASSERT_NO_THROW(transaction.freezeWith(&getTestClient()));
+  AccountCreateTransaction transaction = AccountCreateTransaction()
+                                           .setNodeAccountIds({ AccountId(1ULL) })
+                                           .setTransactionId(TransactionId::generate(AccountId(1ULL)));
+  ASSERT_NO_THROW(transaction.freeze());
 
   // When / Then
   EXPECT_THROW(transaction.setMaxAutomaticTokenAssociations(getTestMaximumTokenAssociations()), IllegalStateException);
@@ -317,8 +322,10 @@ TEST_F(AccountCreateTransactionTest, SetStakedAccountId)
 TEST_F(AccountCreateTransactionTest, SetStakedAccountIdFrozen)
 {
   // Given
-  AccountCreateTransaction transaction;
-  ASSERT_NO_THROW(transaction.freezeWith(&getTestClient()));
+  AccountCreateTransaction transaction = AccountCreateTransaction()
+                                           .setNodeAccountIds({ AccountId(1ULL) })
+                                           .setTransactionId(TransactionId::generate(AccountId(1ULL)));
+  ASSERT_NO_THROW(transaction.freeze());
 
   // When / Then
   EXPECT_THROW(transaction.setStakedAccountId(getTestAccountId()), IllegalStateException);
@@ -341,8 +348,10 @@ TEST_F(AccountCreateTransactionTest, SetStakedNodeId)
 TEST_F(AccountCreateTransactionTest, SetStakedNodeIdFrozen)
 {
   // Given
-  AccountCreateTransaction transaction;
-  ASSERT_NO_THROW(transaction.freezeWith(&getTestClient()));
+  AccountCreateTransaction transaction = AccountCreateTransaction()
+                                           .setNodeAccountIds({ AccountId(1ULL) })
+                                           .setTransactionId(TransactionId::generate(AccountId(1ULL)));
+  ASSERT_NO_THROW(transaction.freeze());
 
   // When / Then
   EXPECT_THROW(transaction.setStakedNodeId(getTestNodeId()), IllegalStateException);
@@ -365,8 +374,10 @@ TEST_F(AccountCreateTransactionTest, SetStakingRewardPolicy)
 TEST_F(AccountCreateTransactionTest, SetStakingRewardPolicyFrozen)
 {
   // Given
-  AccountCreateTransaction transaction;
-  ASSERT_NO_THROW(transaction.freezeWith(&getTestClient()));
+  AccountCreateTransaction transaction = AccountCreateTransaction()
+                                           .setNodeAccountIds({ AccountId(1ULL) })
+                                           .setTransactionId(TransactionId::generate(AccountId(1ULL)));
+  ASSERT_NO_THROW(transaction.freeze());
 
   // When / Then
   EXPECT_THROW(transaction.setDeclineStakingReward(getTestDeclineStakingReward()), IllegalStateException);
@@ -384,17 +395,16 @@ TEST_F(AccountCreateTransactionTest, SetAlias)
   // Then
   ASSERT_TRUE(transaction.getAlias().has_value());
   EXPECT_EQ(transaction.getAlias()->toBytes(), getTestEvmAddress().toBytes());
-
-  transaction.freezeWith(&getTestClient());
-  EXPECT_THROW(transaction.setAlias(getTestEvmAddress()), IllegalStateException);
 }
 
 //-----
 TEST_F(AccountCreateTransactionTest, SetAliasFrozen)
 {
   // Given
-  AccountCreateTransaction transaction;
-  ASSERT_NO_THROW(transaction.freezeWith(&getTestClient()));
+  AccountCreateTransaction transaction = AccountCreateTransaction()
+                                           .setNodeAccountIds({ AccountId(1ULL) })
+                                           .setTransactionId(TransactionId::generate(AccountId(1ULL)));
+  ASSERT_NO_THROW(transaction.freeze());
 
   // When
   EXPECT_THROW(transaction.setAlias(getTestEvmAddress()), IllegalStateException);

--- a/sdk/tests/unit/AccountDeleteTransactionTest.cc
+++ b/sdk/tests/unit/AccountDeleteTransactionTest.cc
@@ -30,14 +30,10 @@ using namespace Hedera;
 class AccountDeleteTransactionTest : public ::testing::Test
 {
 protected:
-  void SetUp() override { mClient.setOperator(AccountId(), ECDSAsecp256k1PrivateKey::generatePrivateKey().get()); }
-
-  [[nodiscard]] inline const Client& getTestClient() const { return mClient; }
   [[nodiscard]] inline const AccountId& getTestDeleteAccountId() const { return mDeleteAccountId; }
   [[nodiscard]] inline const AccountId& getTestTransferAccountId() const { return mTransferAccountId; }
 
 private:
-  Client mClient;
   const AccountId mDeleteAccountId = AccountId(1ULL);
   const AccountId mTransferAccountId = AccountId(2ULL);
 };
@@ -89,8 +85,10 @@ TEST_F(AccountDeleteTransactionTest, SetDeleteAccountId)
 TEST_F(AccountDeleteTransactionTest, SetDeleteAccountIdFrozen)
 {
   // Given
-  AccountDeleteTransaction transaction;
-  ASSERT_NO_THROW(transaction.freezeWith(&getTestClient()));
+  AccountDeleteTransaction transaction = AccountDeleteTransaction()
+                                           .setNodeAccountIds({ AccountId(1ULL) })
+                                           .setTransactionId(TransactionId::generate(AccountId(1ULL)));
+  ASSERT_NO_THROW(transaction.freeze());
 
   // When / Then
   EXPECT_THROW(transaction.setDeleteAccountId(getTestDeleteAccountId()), IllegalStateException);
@@ -113,8 +111,10 @@ TEST_F(AccountDeleteTransactionTest, SetTransferAccountId)
 TEST_F(AccountDeleteTransactionTest, SetTransferAccountIdFrozen)
 {
   // Given
-  AccountDeleteTransaction transaction;
-  ASSERT_NO_THROW(transaction.freezeWith(&getTestClient()));
+  AccountDeleteTransaction transaction = AccountDeleteTransaction()
+                                           .setNodeAccountIds({ AccountId(1ULL) })
+                                           .setTransactionId(TransactionId::generate(AccountId(1ULL)));
+  ASSERT_NO_THROW(transaction.freeze());
 
   // When / Then
   EXPECT_THROW(transaction.setTransferAccountId(getTestTransferAccountId()), IllegalStateException);

--- a/sdk/tests/unit/AccountUpdateTransactionTest.cc
+++ b/sdk/tests/unit/AccountUpdateTransactionTest.cc
@@ -34,12 +34,6 @@ using namespace Hedera;
 class AccountUpdateTransactionTest : public ::testing::Test
 {
 protected:
-  void SetUp() override
-  {
-    mClient.setOperator(getTestAccountId(), ECDSAsecp256k1PrivateKey::generatePrivateKey().get());
-  }
-
-  [[nodiscard]] inline const Client& getTestClient() const { return mClient; }
   [[nodiscard]] inline const AccountId& getTestAccountId() const { return mAccountId; }
   [[nodiscard]] inline const std::shared_ptr<PublicKey>& getTestPublicKey() const { return mPublicKey; }
   [[nodiscard]] inline bool getTestReceiverSignatureRequired() const { return mReceiverSignatureRequired; }
@@ -55,7 +49,6 @@ protected:
   [[nodiscard]] inline bool getTestDeclineStakingReward() const { return mDeclineStakingReward; }
 
 private:
-  Client mClient;
   const AccountId mAccountId = AccountId(1ULL);
   const std::shared_ptr<PublicKey> mPublicKey = ECDSAsecp256k1PrivateKey::generatePrivateKey()->getPublicKey();
   const bool mReceiverSignatureRequired = true;
@@ -158,8 +151,10 @@ TEST_F(AccountUpdateTransactionTest, SetAccountId)
 TEST_F(AccountUpdateTransactionTest, SetAccountIdFrozen)
 {
   // Given
-  AccountUpdateTransaction transaction;
-  ASSERT_NO_THROW(transaction.freezeWith(&getTestClient()));
+  AccountUpdateTransaction transaction = AccountUpdateTransaction()
+                                           .setNodeAccountIds({ AccountId(1ULL) })
+                                           .setTransactionId(TransactionId::generate(AccountId(1ULL)));
+  ASSERT_NO_THROW(transaction.freeze());
 
   // When / Then
   EXPECT_THROW(transaction.setAccountId(getTestAccountId()), IllegalStateException);
@@ -182,8 +177,10 @@ TEST_F(AccountUpdateTransactionTest, SetKey)
 TEST_F(AccountUpdateTransactionTest, SetKeyFrozen)
 {
   // Given
-  AccountUpdateTransaction transaction;
-  ASSERT_NO_THROW(transaction.freezeWith(&getTestClient()));
+  AccountUpdateTransaction transaction = AccountUpdateTransaction()
+                                           .setNodeAccountIds({ AccountId(1ULL) })
+                                           .setTransactionId(TransactionId::generate(AccountId(1ULL)));
+  ASSERT_NO_THROW(transaction.freeze());
 
   // When / Then
   EXPECT_THROW(transaction.setKey(getTestPublicKey().get()), IllegalStateException);
@@ -206,8 +203,10 @@ TEST_F(AccountUpdateTransactionTest, SetReceiverSignatureRequired)
 TEST_F(AccountUpdateTransactionTest, SetReceiverSignatureRequiredFrozen)
 {
   // Given
-  AccountUpdateTransaction transaction;
-  ASSERT_NO_THROW(transaction.freezeWith(&getTestClient()));
+  AccountUpdateTransaction transaction = AccountUpdateTransaction()
+                                           .setNodeAccountIds({ AccountId(1ULL) })
+                                           .setTransactionId(TransactionId::generate(AccountId(1ULL)));
+  ASSERT_NO_THROW(transaction.freeze());
 
   // When / Then
   EXPECT_THROW(transaction.setReceiverSignatureRequired(getTestReceiverSignatureRequired()), IllegalStateException);
@@ -230,8 +229,10 @@ TEST_F(AccountUpdateTransactionTest, SetAutoRenewPeriod)
 TEST_F(AccountUpdateTransactionTest, SetAutoRenewPeriodFrozen)
 {
   // Given
-  AccountUpdateTransaction transaction;
-  ASSERT_NO_THROW(transaction.freezeWith(&getTestClient()));
+  AccountUpdateTransaction transaction = AccountUpdateTransaction()
+                                           .setNodeAccountIds({ AccountId(1ULL) })
+                                           .setTransactionId(TransactionId::generate(AccountId(1ULL)));
+  ASSERT_NO_THROW(transaction.freeze());
 
   // When / Then
   EXPECT_THROW(transaction.setAutoRenewPeriod(getTestAutoRenewPeriod()), IllegalStateException);
@@ -254,8 +255,10 @@ TEST_F(AccountUpdateTransactionTest, SetExpirationTime)
 TEST_F(AccountUpdateTransactionTest, SetExpirationTimeFrozen)
 {
   // Given
-  AccountUpdateTransaction transaction;
-  ASSERT_NO_THROW(transaction.freezeWith(&getTestClient()));
+  AccountUpdateTransaction transaction = AccountUpdateTransaction()
+                                           .setNodeAccountIds({ AccountId(1ULL) })
+                                           .setTransactionId(TransactionId::generate(AccountId(1ULL)));
+  ASSERT_NO_THROW(transaction.freeze());
 
   // When / Then
   EXPECT_THROW(transaction.setExpirationTime(getTestExpirationTime()), IllegalStateException);
@@ -288,8 +291,10 @@ TEST_F(AccountUpdateTransactionTest, SetAccountMemoTooLarge)
 TEST_F(AccountUpdateTransactionTest, SetAccountMemoFrozen)
 {
   // Given
-  AccountUpdateTransaction transaction;
-  ASSERT_NO_THROW(transaction.freezeWith(&getTestClient()));
+  AccountUpdateTransaction transaction = AccountUpdateTransaction()
+                                           .setNodeAccountIds({ AccountId(1ULL) })
+                                           .setTransactionId(TransactionId::generate(AccountId(1ULL)));
+  ASSERT_NO_THROW(transaction.freeze());
 
   // When / Then
   EXPECT_THROW(transaction.setAccountMemo(getTestAccountMemo()), IllegalStateException);
@@ -322,8 +327,10 @@ TEST_F(AccountUpdateTransactionTest, SetMaxAutomaticTokenAssociationsTooMany)
 TEST_F(AccountUpdateTransactionTest, SetMaxAutomaticTokenAssociationsFrozen)
 {
   // Given
-  AccountUpdateTransaction transaction;
-  ASSERT_NO_THROW(transaction.freezeWith(&getTestClient()));
+  AccountUpdateTransaction transaction = AccountUpdateTransaction()
+                                           .setNodeAccountIds({ AccountId(1ULL) })
+                                           .setTransactionId(TransactionId::generate(AccountId(1ULL)));
+  ASSERT_NO_THROW(transaction.freeze());
 
   // When / Then
   EXPECT_THROW(transaction.setMaxAutomaticTokenAssociations(getTestMaximumTokenAssociations()), IllegalStateException);
@@ -346,8 +353,10 @@ TEST_F(AccountUpdateTransactionTest, SetStakedAccountId)
 TEST_F(AccountUpdateTransactionTest, SetStakedAccountIdFrozen)
 {
   // Given
-  AccountUpdateTransaction transaction;
-  ASSERT_NO_THROW(transaction.freezeWith(&getTestClient()));
+  AccountUpdateTransaction transaction = AccountUpdateTransaction()
+                                           .setNodeAccountIds({ AccountId(1ULL) })
+                                           .setTransactionId(TransactionId::generate(AccountId(1ULL)));
+  ASSERT_NO_THROW(transaction.freeze());
 
   // When / Then
   EXPECT_THROW(transaction.setStakedAccountId(getTestStakedAccountId()), IllegalStateException);
@@ -370,8 +379,10 @@ TEST_F(AccountUpdateTransactionTest, SetStakedNodeId)
 TEST_F(AccountUpdateTransactionTest, SetStakedNodeIdFrozen)
 {
   // Given
-  AccountUpdateTransaction transaction;
-  ASSERT_NO_THROW(transaction.freezeWith(&getTestClient()));
+  AccountUpdateTransaction transaction = AccountUpdateTransaction()
+                                           .setNodeAccountIds({ AccountId(1ULL) })
+                                           .setTransactionId(TransactionId::generate(AccountId(1ULL)));
+  ASSERT_NO_THROW(transaction.freeze());
 
   // When / Then
   EXPECT_THROW(transaction.setStakedNodeId(getTestStakedNodeId()), IllegalStateException);
@@ -394,8 +405,10 @@ TEST_F(AccountUpdateTransactionTest, SetStakingRewardPolicy)
 TEST_F(AccountUpdateTransactionTest, SetStakingRewardPolicyFrozen)
 {
   // Given
-  AccountUpdateTransaction transaction;
-  ASSERT_NO_THROW(transaction.freezeWith(&getTestClient()));
+  AccountUpdateTransaction transaction = AccountUpdateTransaction()
+                                           .setNodeAccountIds({ AccountId(1ULL) })
+                                           .setTransactionId(TransactionId::generate(AccountId(1ULL)));
+  ASSERT_NO_THROW(transaction.freeze());
 
   // When / Then
   EXPECT_THROW(transaction.setDeclineStakingReward(getTestDeclineStakingReward()), IllegalStateException);

--- a/sdk/tests/unit/ChunkedTransactionTest.cc
+++ b/sdk/tests/unit/ChunkedTransactionTest.cc
@@ -32,14 +32,10 @@ using namespace Hedera;
 class ChunkedTransactionTest : public ::testing::Test
 {
 protected:
-  void SetUp() override { mClient.setOperator(AccountId(), ED25519PrivateKey::generatePrivateKey().get()); }
-
-  [[nodiscard]] inline const Client& getTestClient() const { return mClient; }
   [[nodiscard]] inline unsigned int getTestMaxChunks() const { return mTestMaxChunks; }
   [[nodiscard]] inline unsigned int getTestChunkSize() const { return mTestChunkSize; }
 
 private:
-  Client mClient;
   const unsigned int mTestMaxChunks = 1U;
   const unsigned int mTestChunkSize = 2U;
 };
@@ -61,8 +57,10 @@ TEST_F(ChunkedTransactionTest, GetSetMaxChunks)
 TEST_F(ChunkedTransactionTest, GetSetMaxChunksFrozen)
 {
   // Given
-  FileAppendTransaction transaction;
-  transaction.freezeWith(&getTestClient());
+  FileAppendTransaction transaction = FileAppendTransaction()
+                                        .setNodeAccountIds({ AccountId(1ULL) })
+                                        .setTransactionId(TransactionId::generate(AccountId(1ULL)));
+  ASSERT_NO_THROW(transaction.freeze());
 
   // When / Then
   EXPECT_THROW(transaction.setMaxChunks(getTestMaxChunks()), IllegalStateException);
@@ -85,8 +83,10 @@ TEST_F(ChunkedTransactionTest, GetSetChunkSize)
 TEST_F(ChunkedTransactionTest, GetSetChunkSizeFrozen)
 {
   // Given
-  FileAppendTransaction transaction;
-  transaction.freezeWith(&getTestClient());
+  FileAppendTransaction transaction = FileAppendTransaction()
+                                        .setNodeAccountIds({ AccountId(1ULL) })
+                                        .setTransactionId(TransactionId::generate(AccountId(1ULL)));
+  ASSERT_NO_THROW(transaction.freeze());
 
   // When / Then
   EXPECT_THROW(transaction.setChunkSize(getTestChunkSize()), IllegalStateException);

--- a/sdk/tests/unit/ClientTest.cc
+++ b/sdk/tests/unit/ClientTest.cc
@@ -80,25 +80,6 @@ TEST_F(ClientTest, SetOperator)
 }
 
 //-----
-TEST_F(ClientTest, SignWithOperator)
-{
-  const std::vector<std::byte> bytesToSign = { std::byte(0x1), std::byte(0x2), std::byte(0x3) };
-
-  Client client;
-  EXPECT_THROW(auto bytes = client.sign(bytesToSign), UninitializedException);
-
-  client.setOperator(getTestAccountId(), getTestPrivateKey().get());
-  EXPECT_TRUE(getTestPrivateKey()->getPublicKey()->verifySignature(client.sign(bytesToSign), bytesToSign));
-}
-
-//-----
-TEST_F(ClientTest, GetNodes)
-{
-  Client client;
-  EXPECT_THROW(auto nodes = client.getNodesWithAccountIds({ getTestAccountId() }), UninitializedException);
-}
-
-//-----
 TEST_F(ClientTest, SetDefaultMaxTransactionFee)
 {
   Client client;

--- a/sdk/tests/unit/ContractCreateTransactionTest.cc
+++ b/sdk/tests/unit/ContractCreateTransactionTest.cc
@@ -37,9 +37,6 @@ using namespace Hedera;
 class ContractCreateTransactionTest : public ::testing::Test
 {
 protected:
-  void SetUp() override { mClient.setOperator(AccountId(), ED25519PrivateKey::generatePrivateKey().get()); }
-
-  [[nodiscard]] inline const Client& getTestClient() const { return mClient; }
   [[nodiscard]] inline const FileId& getTestFileId() const { return mTestFileId; }
   [[nodiscard]] inline const std::vector<std::byte>& getTestBytecode() const { return mTestBytecode; }
   [[nodiscard]] inline const std::shared_ptr<PublicKey>& getTestAdminKey() const { return mTestAdminKey; }
@@ -61,7 +58,6 @@ protected:
   [[nodiscard]] inline bool getTestDeclineStakingReward() const { return mTestDeclineStakingReward; }
 
 private:
-  Client mClient;
   const FileId mTestFileId = FileId(1ULL);
   const std::vector<std::byte> mTestBytecode = { std::byte(0x02), std::byte(0x03), std::byte(0x04) };
   const std::shared_ptr<PublicKey> mTestAdminKey = PublicKey::fromStringDer(
@@ -138,8 +134,10 @@ TEST_F(ContractCreateTransactionTest, GetSetFileId)
 TEST_F(ContractCreateTransactionTest, GetSetFileIdFrozen)
 {
   // Given
-  ContractCreateTransaction transaction;
-  ASSERT_NO_THROW(transaction.freezeWith(&getTestClient()));
+  ContractCreateTransaction transaction = ContractCreateTransaction()
+                                            .setNodeAccountIds({ AccountId(1ULL) })
+                                            .setTransactionId(TransactionId::generate(AccountId(1ULL)));
+  ASSERT_NO_THROW(transaction.freeze());
 
   // When / Then
   EXPECT_THROW(transaction.setBytecodeFileId(getTestFileId()), IllegalStateException);
@@ -162,8 +160,10 @@ TEST_F(ContractCreateTransactionTest, GetSetInitCode)
 TEST_F(ContractCreateTransactionTest, GetSetInitCodeFrozen)
 {
   // Given
-  ContractCreateTransaction transaction;
-  ASSERT_NO_THROW(transaction.freezeWith(&getTestClient()));
+  ContractCreateTransaction transaction = ContractCreateTransaction()
+                                            .setNodeAccountIds({ AccountId(1ULL) })
+                                            .setTransactionId(TransactionId::generate(AccountId(1ULL)));
+  ASSERT_NO_THROW(transaction.freeze());
 
   // When / Then
   EXPECT_THROW(transaction.setBytecode(getTestBytecode()), IllegalStateException);
@@ -186,8 +186,10 @@ TEST_F(ContractCreateTransactionTest, GetSetAdminKey)
 TEST_F(ContractCreateTransactionTest, GetSetAdminKeyFrozen)
 {
   // Given
-  ContractCreateTransaction transaction;
-  ASSERT_NO_THROW(transaction.freezeWith(&getTestClient()));
+  ContractCreateTransaction transaction = ContractCreateTransaction()
+                                            .setNodeAccountIds({ AccountId(1ULL) })
+                                            .setTransactionId(TransactionId::generate(AccountId(1ULL)));
+  ASSERT_NO_THROW(transaction.freeze());
 
   // When / Then
   EXPECT_THROW(transaction.setAdminKey(getTestAdminKey().get()), IllegalStateException);
@@ -210,8 +212,10 @@ TEST_F(ContractCreateTransactionTest, GetSetGas)
 TEST_F(ContractCreateTransactionTest, GetSetGasFrozen)
 {
   // Given
-  ContractCreateTransaction transaction;
-  ASSERT_NO_THROW(transaction.freezeWith(&getTestClient()));
+  ContractCreateTransaction transaction = ContractCreateTransaction()
+                                            .setNodeAccountIds({ AccountId(1ULL) })
+                                            .setTransactionId(TransactionId::generate(AccountId(1ULL)));
+  ASSERT_NO_THROW(transaction.freeze());
 
   // When / Then
   EXPECT_THROW(transaction.setGas(getTestGas()), IllegalStateException);
@@ -234,8 +238,10 @@ TEST_F(ContractCreateTransactionTest, GetSetInitialBalance)
 TEST_F(ContractCreateTransactionTest, GetSetInitialBalanceFrozen)
 {
   // Given
-  ContractCreateTransaction transaction;
-  ASSERT_NO_THROW(transaction.freezeWith(&getTestClient()));
+  ContractCreateTransaction transaction = ContractCreateTransaction()
+                                            .setNodeAccountIds({ AccountId(1ULL) })
+                                            .setTransactionId(TransactionId::generate(AccountId(1ULL)));
+  ASSERT_NO_THROW(transaction.freeze());
 
   // When / Then
   EXPECT_THROW(transaction.setInitialBalance(getTestInitialBalance()), IllegalStateException);
@@ -258,8 +264,10 @@ TEST_F(ContractCreateTransactionTest, GetSetAutoRenewPeriod)
 TEST_F(ContractCreateTransactionTest, GetSetAutoRenewPeriodFrozen)
 {
   // Given
-  ContractCreateTransaction transaction;
-  ASSERT_NO_THROW(transaction.freezeWith(&getTestClient()));
+  ContractCreateTransaction transaction = ContractCreateTransaction()
+                                            .setNodeAccountIds({ AccountId(1ULL) })
+                                            .setTransactionId(TransactionId::generate(AccountId(1ULL)));
+  ASSERT_NO_THROW(transaction.freeze());
 
   // When / Then
   EXPECT_THROW(transaction.setAutoRenewPeriod(getTestAutoRenewPeriod()), IllegalStateException);
@@ -282,8 +290,10 @@ TEST_F(ContractCreateTransactionTest, GetSetConstructorParameters)
 TEST_F(ContractCreateTransactionTest, GetSetConstructorParametersFrozen)
 {
   // Given
-  ContractCreateTransaction transaction;
-  ASSERT_NO_THROW(transaction.freezeWith(&getTestClient()));
+  ContractCreateTransaction transaction = ContractCreateTransaction()
+                                            .setNodeAccountIds({ AccountId(1ULL) })
+                                            .setTransactionId(TransactionId::generate(AccountId(1ULL)));
+  ASSERT_NO_THROW(transaction.freeze());
 
   // When / Then
   EXPECT_THROW(transaction.setConstructorParameters(getTestConstructorParameters()), IllegalStateException);
@@ -306,8 +316,10 @@ TEST_F(ContractCreateTransactionTest, GetSetMemo)
 TEST_F(ContractCreateTransactionTest, GetSetMemoFrozen)
 {
   // Given
-  ContractCreateTransaction transaction;
-  ASSERT_NO_THROW(transaction.freezeWith(&getTestClient()));
+  ContractCreateTransaction transaction = ContractCreateTransaction()
+                                            .setNodeAccountIds({ AccountId(1ULL) })
+                                            .setTransactionId(TransactionId::generate(AccountId(1ULL)));
+  ASSERT_NO_THROW(transaction.freeze());
 
   // When / Then
   EXPECT_THROW(transaction.setMemo(getTestMemo()), IllegalStateException);
@@ -330,8 +342,10 @@ TEST_F(ContractCreateTransactionTest, GetSetMaxAutomaticTokenAssociations)
 TEST_F(ContractCreateTransactionTest, GetSetMaxAutomaticTokenAssociationsFrozen)
 {
   // Given
-  ContractCreateTransaction transaction;
-  ASSERT_NO_THROW(transaction.freezeWith(&getTestClient()));
+  ContractCreateTransaction transaction = ContractCreateTransaction()
+                                            .setNodeAccountIds({ AccountId(1ULL) })
+                                            .setTransactionId(TransactionId::generate(AccountId(1ULL)));
+  ASSERT_NO_THROW(transaction.freeze());
 
   // When / Then
   EXPECT_THROW(transaction.setMaxAutomaticTokenAssociations(getTestMaximumTokenAssociations()), IllegalStateException);
@@ -354,8 +368,10 @@ TEST_F(ContractCreateTransactionTest, GetSetAutoRenewAccountId)
 TEST_F(ContractCreateTransactionTest, GetSetAutoRenewAccountIdFrozen)
 {
   // Given
-  ContractCreateTransaction transaction;
-  ASSERT_NO_THROW(transaction.freezeWith(&getTestClient()));
+  ContractCreateTransaction transaction = ContractCreateTransaction()
+                                            .setNodeAccountIds({ AccountId(1ULL) })
+                                            .setTransactionId(TransactionId::generate(AccountId(1ULL)));
+  ASSERT_NO_THROW(transaction.freeze());
 
   // When / Then
   EXPECT_THROW(transaction.setAutoRenewAccountId(getTestAutoRenewAccountId()), IllegalStateException);
@@ -378,8 +394,10 @@ TEST_F(ContractCreateTransactionTest, GetSetStakedAccountId)
 TEST_F(ContractCreateTransactionTest, GetSetStakedAccountIdFrozen)
 {
   // Given
-  ContractCreateTransaction transaction;
-  ASSERT_NO_THROW(transaction.freezeWith(&getTestClient()));
+  ContractCreateTransaction transaction = ContractCreateTransaction()
+                                            .setNodeAccountIds({ AccountId(1ULL) })
+                                            .setTransactionId(TransactionId::generate(AccountId(1ULL)));
+  ASSERT_NO_THROW(transaction.freeze());
 
   // When / Then
   EXPECT_THROW(transaction.setStakedAccountId(getTestStakedAccountId()), IllegalStateException);
@@ -402,8 +420,10 @@ TEST_F(ContractCreateTransactionTest, GetSetStakedNodeId)
 TEST_F(ContractCreateTransactionTest, GetSetStakedNodeIdFrozen)
 {
   // Given
-  ContractCreateTransaction transaction;
-  ASSERT_NO_THROW(transaction.freezeWith(&getTestClient()));
+  ContractCreateTransaction transaction = ContractCreateTransaction()
+                                            .setNodeAccountIds({ AccountId(1ULL) })
+                                            .setTransactionId(TransactionId::generate(AccountId(1ULL)));
+  ASSERT_NO_THROW(transaction.freeze());
 
   // When / Then
   EXPECT_THROW(transaction.setStakedNodeId(getTestStakedNodeId()), IllegalStateException);
@@ -426,8 +446,10 @@ TEST_F(ContractCreateTransactionTest, GetSetDeclineReward)
 TEST_F(ContractCreateTransactionTest, GetSetDeclineRewardFrozen)
 {
   // Given
-  ContractCreateTransaction transaction;
-  ASSERT_NO_THROW(transaction.freezeWith(&getTestClient()));
+  ContractCreateTransaction transaction = ContractCreateTransaction()
+                                            .setNodeAccountIds({ AccountId(1ULL) })
+                                            .setTransactionId(TransactionId::generate(AccountId(1ULL)));
+  ASSERT_NO_THROW(transaction.freeze());
 
   // When / Then
   EXPECT_THROW(transaction.setDeclineStakingReward(getTestDeclineStakingReward()), IllegalStateException);

--- a/sdk/tests/unit/ContractDeleteTransactionTest.cc
+++ b/sdk/tests/unit/ContractDeleteTransactionTest.cc
@@ -34,15 +34,11 @@ using namespace Hedera;
 class ContractDeleteTransactionTest : public ::testing::Test
 {
 protected:
-  void SetUp() override { mClient.setOperator(AccountId(), ECDSAsecp256k1PrivateKey::generatePrivateKey().get()); }
-
-  [[nodiscard]] inline const Client& getTestClient() const { return mClient; }
   [[nodiscard]] inline const ContractId& getTestContractId() const { return mTestContractId; }
   [[nodiscard]] inline const AccountId& getTestTransferAccountId() const { return mTestTransferAccountId; }
   [[nodiscard]] inline const ContractId& getTestTransferContractId() const { return mTestTransferContractId; }
 
 private:
-  Client mClient;
   const ContractId mTestContractId = ContractId(1ULL);
   const AccountId mTestTransferAccountId = AccountId(2ULL);
   const ContractId mTestTransferContractId = ContractId(3ULL);
@@ -99,8 +95,10 @@ TEST_F(ContractDeleteTransactionTest, GetSetContractId)
 TEST_F(ContractDeleteTransactionTest, GetSetContractIdFrozen)
 {
   // Given
-  ContractDeleteTransaction transaction;
-  ASSERT_NO_THROW(transaction.freezeWith(&getTestClient()));
+  ContractDeleteTransaction transaction = ContractDeleteTransaction()
+                                            .setNodeAccountIds({ AccountId(1ULL) })
+                                            .setTransactionId(TransactionId::generate(AccountId(1ULL)));
+  ASSERT_NO_THROW(transaction.freeze());
 
   // When / Then
   EXPECT_THROW(transaction.setContractId(getTestContractId()), IllegalStateException);
@@ -123,8 +121,10 @@ TEST_F(ContractDeleteTransactionTest, GetSetTransferAccountId)
 TEST_F(ContractDeleteTransactionTest, GetSetTransferAccountIdFrozen)
 {
   // Given
-  ContractDeleteTransaction transaction;
-  ASSERT_NO_THROW(transaction.freezeWith(&getTestClient()));
+  ContractDeleteTransaction transaction = ContractDeleteTransaction()
+                                            .setNodeAccountIds({ AccountId(1ULL) })
+                                            .setTransactionId(TransactionId::generate(AccountId(1ULL)));
+  ASSERT_NO_THROW(transaction.freeze());
 
   // When / Then
   EXPECT_THROW(transaction.setTransferAccountId(getTestTransferAccountId()), IllegalStateException);
@@ -147,8 +147,10 @@ TEST_F(ContractDeleteTransactionTest, GetSetTransferContractId)
 TEST_F(ContractDeleteTransactionTest, GetSetTransferContractIdFrozen)
 {
   // Given
-  ContractDeleteTransaction transaction;
-  ASSERT_NO_THROW(transaction.freezeWith(&getTestClient()));
+  ContractDeleteTransaction transaction = ContractDeleteTransaction()
+                                            .setNodeAccountIds({ AccountId(1ULL) })
+                                            .setTransactionId(TransactionId::generate(AccountId(1ULL)));
+  ASSERT_NO_THROW(transaction.freeze());
 
   // When / Then
   EXPECT_THROW(transaction.setTransferContractId(getTestTransferContractId()), IllegalStateException);

--- a/sdk/tests/unit/ContractExecuteTransactionTest.cc
+++ b/sdk/tests/unit/ContractExecuteTransactionTest.cc
@@ -36,9 +36,6 @@ using namespace Hedera;
 class ContractExecuteTransactionTest : public ::testing::Test
 {
 protected:
-  void SetUp() override { mClient.setOperator(AccountId(), ED25519PrivateKey::generatePrivateKey().get()); }
-
-  [[nodiscard]] inline const Client& getTestClient() const { return mClient; }
   [[nodiscard]] inline const ContractId& getTestContractId() const { return mTestContractId; }
   [[nodiscard]] inline const uint64_t& getTestGas() const { return mTestGas; }
   [[nodiscard]] inline const Hbar& getTestPayableAmount() const { return mTestPayableAmount; }
@@ -48,7 +45,6 @@ protected:
   }
 
 private:
-  Client mClient;
   const ContractId mTestContractId = ContractId(1ULL);
   const uint64_t mTestGas = 2ULL;
   const Hbar mTestPayableAmount = Hbar(3LL);
@@ -95,8 +91,10 @@ TEST_F(ContractExecuteTransactionTest, GetSetContractId)
 TEST_F(ContractExecuteTransactionTest, GetSetContractIdFrozen)
 {
   // Given
-  ContractExecuteTransaction transaction;
-  ASSERT_NO_THROW(transaction.freezeWith(&getTestClient()));
+  ContractExecuteTransaction transaction = ContractExecuteTransaction()
+                                             .setNodeAccountIds({ AccountId(1ULL) })
+                                             .setTransactionId(TransactionId::generate(AccountId(1ULL)));
+  ASSERT_NO_THROW(transaction.freeze());
 
   // When / Then
   EXPECT_THROW(transaction.setContractId(getTestContractId()), IllegalStateException);
@@ -119,8 +117,10 @@ TEST_F(ContractExecuteTransactionTest, GetSetGas)
 TEST_F(ContractExecuteTransactionTest, GetSetGasFrozen)
 {
   // Given
-  ContractExecuteTransaction transaction;
-  ASSERT_NO_THROW(transaction.freezeWith(&getTestClient()));
+  ContractExecuteTransaction transaction = ContractExecuteTransaction()
+                                             .setNodeAccountIds({ AccountId(1ULL) })
+                                             .setTransactionId(TransactionId::generate(AccountId(1ULL)));
+  ASSERT_NO_THROW(transaction.freeze());
 
   // When / Then
   EXPECT_THROW(transaction.setGas(getTestGas()), IllegalStateException);
@@ -143,8 +143,10 @@ TEST_F(ContractExecuteTransactionTest, GetSetPayableAmount)
 TEST_F(ContractExecuteTransactionTest, GetSetPayableAmountFrozen)
 {
   // Given
-  ContractExecuteTransaction transaction;
-  ASSERT_NO_THROW(transaction.freezeWith(&getTestClient()));
+  ContractExecuteTransaction transaction = ContractExecuteTransaction()
+                                             .setNodeAccountIds({ AccountId(1ULL) })
+                                             .setTransactionId(TransactionId::generate(AccountId(1ULL)));
+  ASSERT_NO_THROW(transaction.freeze());
 
   // When / Then
   EXPECT_THROW(transaction.setPayableAmount(getTestPayableAmount()), IllegalStateException);
@@ -167,8 +169,10 @@ TEST_F(ContractExecuteTransactionTest, GetSetFunctionParameters)
 TEST_F(ContractExecuteTransactionTest, GetSetFunctionParametersFrozen)
 {
   // Given
-  ContractExecuteTransaction transaction;
-  ASSERT_NO_THROW(transaction.freezeWith(&getTestClient()));
+  ContractExecuteTransaction transaction = ContractExecuteTransaction()
+                                             .setNodeAccountIds({ AccountId(1ULL) })
+                                             .setTransactionId(TransactionId::generate(AccountId(1ULL)));
+  ASSERT_NO_THROW(transaction.freeze());
 
   // When / Then
   EXPECT_THROW(transaction.setFunctionParameters(getTestFunctionParameters()), IllegalStateException);
@@ -191,8 +195,10 @@ TEST_F(ContractExecuteTransactionTest, GetSetFunctionName)
 TEST_F(ContractExecuteTransactionTest, GetSetFunctionNameFrozen)
 {
   // Given
-  ContractExecuteTransaction transaction;
-  ASSERT_NO_THROW(transaction.freezeWith(&getTestClient()));
+  ContractExecuteTransaction transaction = ContractExecuteTransaction()
+                                             .setNodeAccountIds({ AccountId(1ULL) })
+                                             .setTransactionId(TransactionId::generate(AccountId(1ULL)));
+  ASSERT_NO_THROW(transaction.freeze());
 
   // When / Then
   EXPECT_THROW(transaction.setFunction("functionName"), IllegalStateException);

--- a/sdk/tests/unit/ContractUpdateTransactionTest.cc
+++ b/sdk/tests/unit/ContractUpdateTransactionTest.cc
@@ -35,9 +35,6 @@ using namespace Hedera;
 class ContractUpdateTransactionTest : public ::testing::Test
 {
 protected:
-  void SetUp() override { mClient.setOperator(AccountId(), ECDSAsecp256k1PrivateKey::generatePrivateKey().get()); }
-
-  [[nodiscard]] inline const Client& getTestClient() const { return mClient; }
   [[nodiscard]] inline const ContractId& getTestContractId() const { return mTestContractId; }
   [[nodiscard]] inline const std::chrono::system_clock::time_point& getTestExpirationTime() const
   {
@@ -59,7 +56,6 @@ protected:
   [[nodiscard]] inline bool getTestDeclineStakingReward() const { return mTestDeclineStakingReward; }
 
 private:
-  Client mClient;
   const ContractId mTestContractId = ContractId(1ULL);
   const std::chrono::system_clock::time_point mTestExpirationTime = std::chrono::system_clock::now();
   const std::shared_ptr<PublicKey> mTestAdminKey = ECDSAsecp256k1PrivateKey::generatePrivateKey()->getPublicKey();
@@ -140,8 +136,10 @@ TEST_F(ContractUpdateTransactionTest, GetSetContractId)
 TEST_F(ContractUpdateTransactionTest, SetContractIdFrozen)
 {
   // Given
-  ContractUpdateTransaction transaction;
-  ASSERT_NO_THROW(transaction.freezeWith(&getTestClient()));
+  ContractUpdateTransaction transaction = ContractUpdateTransaction()
+                                            .setNodeAccountIds({ AccountId(1ULL) })
+                                            .setTransactionId(TransactionId::generate(AccountId(1ULL)));
+  ASSERT_NO_THROW(transaction.freeze());
 
   // When / Then
   EXPECT_THROW(transaction.setContractId(getTestContractId()), IllegalStateException);
@@ -164,8 +162,10 @@ TEST_F(ContractUpdateTransactionTest, GetSetExpirationTime)
 TEST_F(ContractUpdateTransactionTest, SetExpirationTimeFrozen)
 {
   // Given
-  ContractUpdateTransaction transaction;
-  ASSERT_NO_THROW(transaction.freezeWith(&getTestClient()));
+  ContractUpdateTransaction transaction = ContractUpdateTransaction()
+                                            .setNodeAccountIds({ AccountId(1ULL) })
+                                            .setTransactionId(TransactionId::generate(AccountId(1ULL)));
+  ASSERT_NO_THROW(transaction.freeze());
 
   // When / Then
   EXPECT_THROW(transaction.setExpirationTime(getTestExpirationTime()), IllegalStateException);
@@ -188,8 +188,10 @@ TEST_F(ContractUpdateTransactionTest, GetSetAdminKey)
 TEST_F(ContractUpdateTransactionTest, SetAdminKeyFrozen)
 {
   // Given
-  ContractUpdateTransaction transaction;
-  ASSERT_NO_THROW(transaction.freezeWith(&getTestClient()));
+  ContractUpdateTransaction transaction = ContractUpdateTransaction()
+                                            .setNodeAccountIds({ AccountId(1ULL) })
+                                            .setTransactionId(TransactionId::generate(AccountId(1ULL)));
+  ASSERT_NO_THROW(transaction.freeze());
 
   // When / Then
   EXPECT_THROW(transaction.setAdminKey(getTestAdminKey().get()), IllegalStateException);
@@ -212,8 +214,10 @@ TEST_F(ContractUpdateTransactionTest, GetSetAutoRenewPeriod)
 TEST_F(ContractUpdateTransactionTest, SetAutoRenewPeriodFrozen)
 {
   // Given
-  ContractUpdateTransaction transaction;
-  ASSERT_NO_THROW(transaction.freezeWith(&getTestClient()));
+  ContractUpdateTransaction transaction = ContractUpdateTransaction()
+                                            .setNodeAccountIds({ AccountId(1ULL) })
+                                            .setTransactionId(TransactionId::generate(AccountId(1ULL)));
+  ASSERT_NO_THROW(transaction.freeze());
 
   // When / Then
   EXPECT_THROW(transaction.setAutoRenewPeriod(getTestAutoRenewPeriod()), IllegalStateException);
@@ -246,8 +250,10 @@ TEST_F(ContractUpdateTransactionTest, SetContractMemoTooLarge)
 TEST_F(ContractUpdateTransactionTest, SetContractMemoFrozen)
 {
   // Given
-  ContractUpdateTransaction transaction;
-  ASSERT_NO_THROW(transaction.freezeWith(&getTestClient()));
+  ContractUpdateTransaction transaction = ContractUpdateTransaction()
+                                            .setNodeAccountIds({ AccountId(1ULL) })
+                                            .setTransactionId(TransactionId::generate(AccountId(1ULL)));
+  ASSERT_NO_THROW(transaction.freeze());
 
   // When / Then
   EXPECT_THROW(transaction.setContractMemo(getTestContractMemo()), IllegalStateException);
@@ -280,8 +286,10 @@ TEST_F(ContractUpdateTransactionTest, SetMaxAutomaticTokenAssociationsTooMany)
 TEST_F(ContractUpdateTransactionTest, GetSetMaxAutomaticTokenAssociationsFrozen)
 {
   // Given
-  ContractUpdateTransaction transaction;
-  ASSERT_NO_THROW(transaction.freezeWith(&getTestClient()));
+  ContractUpdateTransaction transaction = ContractUpdateTransaction()
+                                            .setNodeAccountIds({ AccountId(1ULL) })
+                                            .setTransactionId(TransactionId::generate(AccountId(1ULL)));
+  ASSERT_NO_THROW(transaction.freeze());
 
   // When / Then
   EXPECT_THROW(transaction.setMaxAutomaticTokenAssociations(getTestMaximumAutomaticTokenAssociations()),
@@ -305,8 +313,10 @@ TEST_F(ContractUpdateTransactionTest, GetSetAutoRenewAccountId)
 TEST_F(ContractUpdateTransactionTest, SetAutoRenewAccountIdFrozen)
 {
   // Given
-  ContractUpdateTransaction transaction;
-  ASSERT_NO_THROW(transaction.freezeWith(&getTestClient()));
+  ContractUpdateTransaction transaction = ContractUpdateTransaction()
+                                            .setNodeAccountIds({ AccountId(1ULL) })
+                                            .setTransactionId(TransactionId::generate(AccountId(1ULL)));
+  ASSERT_NO_THROW(transaction.freeze());
 
   // When / Then
   EXPECT_THROW(transaction.setAutoRenewAccountId(getTestAutoRenewAccountId()), IllegalStateException);
@@ -329,8 +339,10 @@ TEST_F(ContractUpdateTransactionTest, GetSetStakedAccountId)
 TEST_F(ContractUpdateTransactionTest, SetStakedAccountIdFrozen)
 {
   // Given
-  ContractUpdateTransaction transaction;
-  ASSERT_NO_THROW(transaction.freezeWith(&getTestClient()));
+  ContractUpdateTransaction transaction = ContractUpdateTransaction()
+                                            .setNodeAccountIds({ AccountId(1ULL) })
+                                            .setTransactionId(TransactionId::generate(AccountId(1ULL)));
+  ASSERT_NO_THROW(transaction.freeze());
 
   // When / Then
   EXPECT_THROW(transaction.setStakedAccountId(getTestStakedAccountId()), IllegalStateException);
@@ -353,8 +365,10 @@ TEST_F(ContractUpdateTransactionTest, GetSetStakedNodeId)
 TEST_F(ContractUpdateTransactionTest, SetStakedNodeIdFrozen)
 {
   // Given
-  ContractUpdateTransaction transaction;
-  ASSERT_NO_THROW(transaction.freezeWith(&getTestClient()));
+  ContractUpdateTransaction transaction = ContractUpdateTransaction()
+                                            .setNodeAccountIds({ AccountId(1ULL) })
+                                            .setTransactionId(TransactionId::generate(AccountId(1ULL)));
+  ASSERT_NO_THROW(transaction.freeze());
 
   // When / Then
   EXPECT_THROW(transaction.setStakedNodeId(getTestStakedNodeId()), IllegalStateException);
@@ -377,8 +391,10 @@ TEST_F(ContractUpdateTransactionTest, GetSetStakingRewardPolicy)
 TEST_F(ContractUpdateTransactionTest, SetStakingRewardPolicyFrozen)
 {
   // Given
-  ContractUpdateTransaction transaction;
-  ASSERT_NO_THROW(transaction.freezeWith(&getTestClient()));
+  ContractUpdateTransaction transaction = ContractUpdateTransaction()
+                                            .setNodeAccountIds({ AccountId(1ULL) })
+                                            .setTransactionId(TransactionId::generate(AccountId(1ULL)));
+  ASSERT_NO_THROW(transaction.freeze());
 
   // When / Then
   EXPECT_THROW(transaction.setDeclineStakingReward(getTestDeclineStakingReward()), IllegalStateException);

--- a/sdk/tests/unit/EthereumTransactionTest.cc
+++ b/sdk/tests/unit/EthereumTransactionTest.cc
@@ -37,15 +37,11 @@ using namespace Hedera;
 class EthereumTransactionTest : public ::testing::Test
 {
 protected:
-  void SetUp() override { mClient.setOperator(AccountId(), ECDSAsecp256k1PrivateKey::generatePrivateKey().get()); }
-
-  [[nodiscard]] inline const Client& getTestClient() const { return mClient; }
   [[nodiscard]] inline const std::vector<std::byte>& getTestEthereumData() const { return mTestEthereumData; }
   [[nodiscard]] inline const FileId& getTestCallDataFileId() const { return mTestCallDataFileId; }
   [[nodiscard]] inline const Hbar& getTestMaxGasAllowance() const { return mTestMaxGasAllowance; }
 
 private:
-  Client mClient;
   const std::vector<std::byte> mTestEthereumData = { std::byte(0x01), std::byte(0x02), std::byte(0x03) };
   const FileId mTestCallDataFileId = FileId(4ULL);
   const Hbar mTestMaxGasAllowance = Hbar(5LL);
@@ -90,8 +86,10 @@ TEST_F(EthereumTransactionTest, GetSetEthereumData)
 TEST_F(EthereumTransactionTest, GetSetEthereumDataFrozen)
 {
   // Given
-  EthereumTransaction transaction;
-  ASSERT_NO_THROW(transaction.freezeWith(&getTestClient()));
+  EthereumTransaction transaction = EthereumTransaction()
+                                      .setNodeAccountIds({ AccountId(1ULL) })
+                                      .setTransactionId(TransactionId::generate(AccountId(1ULL)));
+  ASSERT_NO_THROW(transaction.freeze());
 
   // When / Then
   EXPECT_THROW(transaction.setEthereumData(getTestEthereumData()), IllegalStateException);
@@ -114,8 +112,10 @@ TEST_F(EthereumTransactionTest, GetSetCallDataFileId)
 TEST_F(EthereumTransactionTest, GetSetCallDataFileIdFrozen)
 {
   // Given
-  EthereumTransaction transaction;
-  ASSERT_NO_THROW(transaction.freezeWith(&getTestClient()));
+  EthereumTransaction transaction = EthereumTransaction()
+                                      .setNodeAccountIds({ AccountId(1ULL) })
+                                      .setTransactionId(TransactionId::generate(AccountId(1ULL)));
+  ASSERT_NO_THROW(transaction.freeze());
 
   // When / Then
   EXPECT_THROW(transaction.setCallDataFileId(getTestCallDataFileId()), IllegalStateException);
@@ -138,8 +138,10 @@ TEST_F(EthereumTransactionTest, GetSetMaxGasAllowance)
 TEST_F(EthereumTransactionTest, GetSetMaxGasAllowanceFrozen)
 {
   // Given
-  EthereumTransaction transaction;
-  ASSERT_NO_THROW(transaction.freezeWith(&getTestClient()));
+  EthereumTransaction transaction = EthereumTransaction()
+                                      .setNodeAccountIds({ AccountId(1ULL) })
+                                      .setTransactionId(TransactionId::generate(AccountId(1ULL)));
+  ASSERT_NO_THROW(transaction.freeze());
 
   // When / Then
   EXPECT_THROW(transaction.setMaxGasAllowance(getTestMaxGasAllowance()), IllegalStateException);

--- a/sdk/tests/unit/FileAppendTransactionTest.cc
+++ b/sdk/tests/unit/FileAppendTransactionTest.cc
@@ -37,15 +37,10 @@ using namespace Hedera;
 class FileAppendTransactionTest : public ::testing::Test
 {
 protected:
-  void SetUp() override { mClient.setOperator(AccountId(), ED25519PrivateKey::generatePrivateKey().get()); }
-
-  [[nodiscard]] inline const Client& getTestClient() const { return mClient; }
   [[nodiscard]] inline const FileId& getTestFileId() const { return mTestFileId; }
   [[nodiscard]] inline const std::vector<std::byte>& getTestContents() const { return mTestContents; }
 
 private:
-  Client mClient;
-
   const FileId mTestFileId = FileId(1ULL);
   const std::vector<std::byte> mTestContents = { std::byte(0x02), std::byte(0x03), std::byte(0x04) };
 };
@@ -86,8 +81,10 @@ TEST_F(FileAppendTransactionTest, GetSetFileId)
 TEST_F(FileAppendTransactionTest, GetSetFileIdFrozen)
 {
   // Given
-  FileAppendTransaction transaction;
-  transaction.freezeWith(&getTestClient());
+  FileAppendTransaction transaction = FileAppendTransaction()
+                                        .setNodeAccountIds({ AccountId(1ULL) })
+                                        .setTransactionId(TransactionId::generate(AccountId(1ULL)));
+  ASSERT_NO_THROW(transaction.freeze());
 
   // When / Then
   EXPECT_THROW(transaction.setFileId(getTestFileId()), IllegalStateException);
@@ -113,8 +110,10 @@ TEST_F(FileAppendTransactionTest, GetSetContents)
 TEST_F(FileAppendTransactionTest, GetSetContentsFrozen)
 {
   // Given
-  FileAppendTransaction transaction;
-  transaction.freezeWith(&getTestClient());
+  FileAppendTransaction transaction = FileAppendTransaction()
+                                        .setNodeAccountIds({ AccountId(1ULL) })
+                                        .setTransactionId(TransactionId::generate(AccountId(1ULL)));
+  ASSERT_NO_THROW(transaction.freeze());
 
   // When / Then
   EXPECT_THROW(transaction.setContents(getTestContents()), IllegalStateException);

--- a/sdk/tests/unit/FileCreateTransactionTest.cc
+++ b/sdk/tests/unit/FileCreateTransactionTest.cc
@@ -39,9 +39,6 @@ using namespace Hedera;
 class FileCreateTransactionTest : public ::testing::Test
 {
 protected:
-  void SetUp() override { mClient.setOperator(AccountId(), ED25519PrivateKey::generatePrivateKey().get()); }
-
-  [[nodiscard]] inline const Client& getTestClient() const { return mClient; }
   [[nodiscard]] inline const std::chrono::system_clock::time_point& getTestExpirationTime() const
   {
     return mTestExpirationTime;
@@ -52,7 +49,6 @@ protected:
   [[nodiscard]] inline const std::string& getTestMemo() const { return mTestMemo; }
 
 private:
-  Client mClient;
   const std::unique_ptr<ED25519PrivateKey> mPrivateKey1 = ED25519PrivateKey::fromString(
     "302e020100300506032b657004220420db484b828e64b2d8f12ce3c0a0e93a0b8cce7af1bb8f39c97732394482538e10");
   const std::unique_ptr<ED25519PrivateKey> mPrivateKey2 = ED25519PrivateKey::fromString(
@@ -107,8 +103,10 @@ TEST_F(FileCreateTransactionTest, GetSetExpirationTime)
 TEST_F(FileCreateTransactionTest, GetSetExpirationTimeFrozen)
 {
   // Given
-  FileCreateTransaction transaction;
-  transaction.freezeWith(&getTestClient());
+  FileCreateTransaction transaction = FileCreateTransaction()
+                                        .setNodeAccountIds({ AccountId(1ULL) })
+                                        .setTransactionId(TransactionId::generate(AccountId(1ULL)));
+  ASSERT_NO_THROW(transaction.freeze());
 
   // When / Then
   EXPECT_THROW(transaction.setExpirationTime(getTestExpirationTime()), IllegalStateException);
@@ -135,8 +133,10 @@ TEST_F(FileCreateTransactionTest, GetSetKeys)
 TEST_F(FileCreateTransactionTest, GetSetKeysFrozen)
 {
   // Given
-  FileCreateTransaction transaction;
-  transaction.freezeWith(&getTestClient());
+  FileCreateTransaction transaction = FileCreateTransaction()
+                                        .setNodeAccountIds({ AccountId(1ULL) })
+                                        .setTransactionId(TransactionId::generate(AccountId(1ULL)));
+  ASSERT_NO_THROW(transaction.freeze());
 
   // When / Then
   EXPECT_THROW(transaction.setKeys(getTestKeyList()), IllegalStateException);
@@ -160,8 +160,10 @@ TEST_F(FileCreateTransactionTest, GetSetContents)
 TEST_F(FileCreateTransactionTest, GetSetContentsFrozen)
 {
   // Given
-  FileCreateTransaction transaction;
-  transaction.freezeWith(&getTestClient());
+  FileCreateTransaction transaction = FileCreateTransaction()
+                                        .setNodeAccountIds({ AccountId(1ULL) })
+                                        .setTransactionId(TransactionId::generate(AccountId(1ULL)));
+  ASSERT_NO_THROW(transaction.freeze());
 
   // When / Then
   EXPECT_THROW(transaction.setContents(getTestContents()), IllegalStateException);
@@ -184,8 +186,10 @@ TEST_F(FileCreateTransactionTest, GetSetMemo)
 TEST_F(FileCreateTransactionTest, GetSetMemoFrozen)
 {
   // Given
-  FileCreateTransaction transaction;
-  transaction.freezeWith(&getTestClient());
+  FileCreateTransaction transaction = FileCreateTransaction()
+                                        .setNodeAccountIds({ AccountId(1ULL) })
+                                        .setTransactionId(TransactionId::generate(AccountId(1ULL)));
+  ASSERT_NO_THROW(transaction.freeze());
 
   // When / Then
   EXPECT_THROW(transaction.setFileMemo(getTestMemo()), IllegalStateException);

--- a/sdk/tests/unit/FileDeleteTransactionTest.cc
+++ b/sdk/tests/unit/FileDeleteTransactionTest.cc
@@ -31,13 +31,9 @@ using namespace Hedera;
 class FileDeleteTransactionTest : public ::testing::Test
 {
 protected:
-  void SetUp() override { mClient.setOperator(AccountId(), ED25519PrivateKey::generatePrivateKey().get()); }
-
-  [[nodiscard]] inline const Client& getTestClient() const { return mClient; }
   [[nodiscard]] inline const FileId& getTestFileId() const { return mTestFileId; }
 
 private:
-  Client mClient;
   const FileId mTestFileId = FileId(1ULL);
 };
 
@@ -75,8 +71,10 @@ TEST_F(FileDeleteTransactionTest, GetSetFileId)
 TEST_F(FileDeleteTransactionTest, GetSetFileIdFrozen)
 {
   // Given
-  FileDeleteTransaction transaction;
-  ASSERT_NO_THROW(transaction.freezeWith(&getTestClient()));
+  FileDeleteTransaction transaction = FileDeleteTransaction()
+                                        .setNodeAccountIds({ AccountId(1ULL) })
+                                        .setTransactionId(TransactionId::generate(AccountId(1ULL)));
+  ASSERT_NO_THROW(transaction.freeze());
 
   // When / Then
   EXPECT_THROW(transaction.setFileId(getTestFileId()), IllegalStateException);

--- a/sdk/tests/unit/FileUpdateTransactionTest.cc
+++ b/sdk/tests/unit/FileUpdateTransactionTest.cc
@@ -39,9 +39,6 @@ using namespace Hedera;
 class FileUpdateTransactionTest : public ::testing::Test
 {
 protected:
-  void SetUp() override { mClient.setOperator(AccountId(), ED25519PrivateKey::generatePrivateKey().get()); }
-
-  [[nodiscard]] inline const Client& getTestClient() const { return mClient; }
   [[nodiscard]] inline const FileId& getTestFileId() const { return mTestFileId; }
   [[nodiscard]] inline const std::chrono::system_clock::time_point& getTestExpirationTime() const
   {
@@ -53,7 +50,6 @@ protected:
   [[nodiscard]] inline const std::string& getTestMemo() const { return mTestMemo; }
 
 private:
-  Client mClient;
   const std::unique_ptr<ED25519PrivateKey> mPrivateKey1 = ED25519PrivateKey::fromString(
     "302e020100300506032b657004220420db484b828e64b2d8f12ce3c0a0e93a0b8cce7af1bb8f39c97732394482538e10");
   const std::unique_ptr<ED25519PrivateKey> mPrivateKey2 = ED25519PrivateKey::fromString(
@@ -118,8 +114,10 @@ TEST_F(FileUpdateTransactionTest, GetSetFileId)
 TEST_F(FileUpdateTransactionTest, GetSetFileIdFrozen)
 {
   // Given
-  FileUpdateTransaction transaction;
-  transaction.freezeWith(&getTestClient());
+  FileUpdateTransaction transaction = FileUpdateTransaction()
+                                        .setNodeAccountIds({ AccountId(1ULL) })
+                                        .setTransactionId(TransactionId::generate(AccountId(1ULL)));
+  ASSERT_NO_THROW(transaction.freeze());
 
   // When / Then
   EXPECT_THROW(transaction.setFileId(getTestFileId()), IllegalStateException);
@@ -143,8 +141,10 @@ TEST_F(FileUpdateTransactionTest, GetSetExpirationTime)
 TEST_F(FileUpdateTransactionTest, GetSetExpirationTimeFrozen)
 {
   // Given
-  FileUpdateTransaction transaction;
-  transaction.freezeWith(&getTestClient());
+  FileUpdateTransaction transaction = FileUpdateTransaction()
+                                        .setNodeAccountIds({ AccountId(1ULL) })
+                                        .setTransactionId(TransactionId::generate(AccountId(1ULL)));
+  ASSERT_NO_THROW(transaction.freeze());
 
   // When / Then
   EXPECT_THROW(transaction.setExpirationTime(getTestExpirationTime()), IllegalStateException);
@@ -174,8 +174,10 @@ TEST_F(FileUpdateTransactionTest, GetSetKeys)
 TEST_F(FileUpdateTransactionTest, GetSetKeysFrozen)
 {
   // Given
-  FileUpdateTransaction transaction;
-  transaction.freezeWith(&getTestClient());
+  FileUpdateTransaction transaction = FileUpdateTransaction()
+                                        .setNodeAccountIds({ AccountId(1ULL) })
+                                        .setTransactionId(TransactionId::generate(AccountId(1ULL)));
+  ASSERT_NO_THROW(transaction.freeze());
 
   // When / Then
   EXPECT_THROW(transaction.setKeys(getTestKeyList()), IllegalStateException);
@@ -204,8 +206,10 @@ TEST_F(FileUpdateTransactionTest, GetSetContents)
 TEST_F(FileUpdateTransactionTest, GetSetContentsFrozen)
 {
   // Given
-  FileUpdateTransaction transaction;
-  transaction.freezeWith(&getTestClient());
+  FileUpdateTransaction transaction = FileUpdateTransaction()
+                                        .setNodeAccountIds({ AccountId(1ULL) })
+                                        .setTransactionId(TransactionId::generate(AccountId(1ULL)));
+  ASSERT_NO_THROW(transaction.freeze());
 
   // When / Then
   EXPECT_THROW(transaction.setContents(getTestContents()), IllegalStateException);
@@ -231,8 +235,10 @@ TEST_F(FileUpdateTransactionTest, GetSetMemo)
 TEST_F(FileUpdateTransactionTest, GetSetMemoFrozen)
 {
   // Given
-  FileUpdateTransaction transaction;
-  transaction.freezeWith(&getTestClient());
+  FileUpdateTransaction transaction = FileUpdateTransaction()
+                                        .setNodeAccountIds({ AccountId(1ULL) })
+                                        .setTransactionId(TransactionId::generate(AccountId(1ULL)));
+  ASSERT_NO_THROW(transaction.freeze());
 
   // When / Then
   EXPECT_THROW(transaction.setFileMemo(getTestMemo()), IllegalStateException);

--- a/sdk/tests/unit/FreezeTransactionUnitTests.cc
+++ b/sdk/tests/unit/FreezeTransactionUnitTests.cc
@@ -39,17 +39,12 @@ using namespace Hedera;
 class FreezeTransactionTest : public ::testing::Test
 {
 protected:
-  void SetUp() override { mClient.setOperator(AccountId(), ED25519PrivateKey::generatePrivateKey().get()); }
-
-  [[nodiscard]] inline const Client& getTestClient() const { return mClient; }
   [[nodiscard]] inline const FileId& getTestFileId() const { return mTestFileId; }
   [[nodiscard]] inline const std::vector<std::byte>& getTestFileHash() const { return mTestFileHash; }
   [[nodiscard]] inline const std::chrono::system_clock::time_point& getTestStartTime() const { return mTestStartTime; }
   [[nodiscard]] inline const FreezeType& getTestFreezeType() const { return mTestFreezeType; }
 
 private:
-  Client mClient;
-
   const FileId mTestFileId = FileId(1ULL, 2ULL, 3ULL);
   const std::vector<std::byte> mTestFileHash = { std::byte(0x04), std::byte(0x05), std::byte(0x06) };
   const std::chrono::system_clock::time_point mTestStartTime = std::chrono::system_clock::now();
@@ -99,8 +94,10 @@ TEST_F(FreezeTransactionTest, GetSetFileId)
 TEST_F(FreezeTransactionTest, GetSetFileIdFrozen)
 {
   // Given
-  FreezeTransaction transaction;
-  ASSERT_NO_THROW(transaction.freezeWith(&getTestClient()));
+  FreezeTransaction transaction = FreezeTransaction()
+                                    .setNodeAccountIds({ AccountId(1ULL) })
+                                    .setTransactionId(TransactionId::generate(AccountId(1ULL)));
+  ASSERT_NO_THROW(transaction.freeze());
 
   // When / Then
   EXPECT_THROW(transaction.setFileId(getTestFileId()), IllegalStateException);
@@ -123,8 +120,10 @@ TEST_F(FreezeTransactionTest, GetSetFileHash)
 TEST_F(FreezeTransactionTest, GetSetFileHashFrozen)
 {
   // Given
-  FreezeTransaction transaction;
-  ASSERT_NO_THROW(transaction.freezeWith(&getTestClient()));
+  FreezeTransaction transaction = FreezeTransaction()
+                                    .setNodeAccountIds({ AccountId(1ULL) })
+                                    .setTransactionId(TransactionId::generate(AccountId(1ULL)));
+  ASSERT_NO_THROW(transaction.freeze());
 
   // When / Then
   EXPECT_THROW(transaction.setFileHash(getTestFileHash()), IllegalStateException);
@@ -148,8 +147,10 @@ TEST_F(FreezeTransactionTest, GetSetStartTime)
 TEST_F(FreezeTransactionTest, GetSetStartTimeFrozen)
 {
   // Given
-  FreezeTransaction transaction;
-  ASSERT_NO_THROW(transaction.freezeWith(&getTestClient()));
+  FreezeTransaction transaction = FreezeTransaction()
+                                    .setNodeAccountIds({ AccountId(1ULL) })
+                                    .setTransactionId(TransactionId::generate(AccountId(1ULL)));
+  ASSERT_NO_THROW(transaction.freeze());
 
   // When / Then
   EXPECT_THROW(transaction.setStartTime(getTestStartTime()), IllegalStateException);
@@ -172,8 +173,10 @@ TEST_F(FreezeTransactionTest, GetSetFreezeType)
 TEST_F(FreezeTransactionTest, GetSetFreezeTypeFrozen)
 {
   // Given
-  FreezeTransaction transaction;
-  ASSERT_NO_THROW(transaction.freezeWith(&getTestClient()));
+  FreezeTransaction transaction = FreezeTransaction()
+                                    .setNodeAccountIds({ AccountId(1ULL) })
+                                    .setTransactionId(TransactionId::generate(AccountId(1ULL)));
+  ASSERT_NO_THROW(transaction.freeze());
 
   // When / Then
   EXPECT_THROW(transaction.setFreezeType(getTestFreezeType()), IllegalStateException);

--- a/sdk/tests/unit/NodeAddressTest.cc
+++ b/sdk/tests/unit/NodeAddressTest.cc
@@ -157,7 +157,7 @@ TEST_F(NodeAddressTest, GetSetCertHash)
 
   // When
   nodeAddressWithStr.setCertHash(Utilities::byteVectorToString(getTestCertHash()));
-  nodeAddressWithStr.setCertHash(getTestCertHash());
+  nodeAddressWithBytes.setCertHash(getTestCertHash());
 
   // Then
   EXPECT_EQ(nodeAddressWithStr.getCertHash(), getTestCertHash());

--- a/sdk/tests/unit/NodeAddressTest.cc
+++ b/sdk/tests/unit/NodeAddressTest.cc
@@ -18,11 +18,7 @@
  *
  */
 #include "impl/NodeAddress.h"
-<<<<<<< HEAD
 #include "AccountId.h"
-#include "exceptions/IllegalStateException.h"
-=======
->>>>>>> main
 #include "impl/Endpoint.h"
 #include "impl/IPv4Address.h"
 #include "impl/Utilities.h"
@@ -79,26 +75,12 @@ TEST_F(NodeAddressTest, FromProtobuf)
   const NodeAddress nodeAddress = NodeAddress::fromProtobuf(protoNodeAddress);
 
   // Then
-<<<<<<< HEAD
   EXPECT_EQ(nodeAddress.getEndpoints().size(), getTestEndpoints().size());
   EXPECT_EQ(nodeAddress.getPublicKey(), getTestPublicKey());
   EXPECT_EQ(nodeAddress.getNodeId(), getTestNodeId());
   EXPECT_EQ(nodeAddress.getAccountId(), getTestAccountId());
   EXPECT_EQ(nodeAddress.getCertHash(), getTestCertHash());
   EXPECT_EQ(nodeAddress.getDescription(), getTestDescription());
-=======
-  EXPECT_TRUE(nodeAddress.isTlsPort(testPortTLS));
-  EXPECT_FALSE(nodeAddress.isNonTlsPort(testPortTLS));
-  EXPECT_EQ(nodeAddress.getNodeId(), -1);
-  EXPECT_EQ(nodeAddress.getNodeAccountId().mShardNum, 0ULL);
-  EXPECT_EQ(nodeAddress.getNodeAccountId().mRealmNum, 0ULL);
-  EXPECT_FALSE(nodeAddress.getNodeAccountId().mAccountNum.has_value());
-  EXPECT_EQ(nodeAddress.getNodeAccountId().mPublicKeyAlias, nullptr);
-  EXPECT_FALSE(nodeAddress.getNodeAccountId().mEvmAddressAlias.has_value());
-  EXPECT_TRUE(nodeAddress.getNodeCertHash().empty());
-  EXPECT_TRUE(nodeAddress.getDescription().empty());
-  EXPECT_TRUE(nodeAddress.getEndpoints().empty());
->>>>>>> main
 }
 
 //-----
@@ -120,9 +102,9 @@ TEST_F(NodeAddressTest, ToProtobuf)
   EXPECT_EQ(protoNodeAddress->serviceendpoint_size(), getTestEndpoints().size());
   EXPECT_EQ(protoNodeAddress->rsa_pubkey(), getTestPublicKey());
   EXPECT_EQ(protoNodeAddress->nodeid(), getTestNodeId());
-  EXPECT_EQ(protoNodeAddress->nodeaccountid().shardnum(), getTestAccountId().getShardNum());
-  EXPECT_EQ(protoNodeAddress->nodeaccountid().realmnum(), getTestAccountId().getRealmNum());
-  EXPECT_EQ(protoNodeAddress->nodeaccountid().accountnum(), getTestAccountId().getAccountNum().value());
+  EXPECT_EQ(protoNodeAddress->nodeaccountid().shardnum(), getTestAccountId().mShardNum);
+  EXPECT_EQ(protoNodeAddress->nodeaccountid().realmnum(), getTestAccountId().mRealmNum);
+  EXPECT_EQ(protoNodeAddress->nodeaccountid().accountnum(), getTestAccountId().mAccountNum.value());
   EXPECT_EQ(protoNodeAddress->nodecerthash(), Utilities::byteVectorToString(getTestCertHash()));
   EXPECT_EQ(protoNodeAddress->description(), getTestDescription());
 }
@@ -137,23 +119,7 @@ TEST_F(NodeAddressTest, GetSetPublicKey)
   nodeAddress.setPublicKey(getTestPublicKey());
 
   // Then
-<<<<<<< HEAD
   EXPECT_EQ(nodeAddress.getPublicKey(), getTestPublicKey());
-=======
-  EXPECT_EQ(nodeAddress.getDefaultIpAddress().toString(), testIpAddressV4);
-  EXPECT_EQ(nodeAddress.getDefaultPort(), getTestPortTLS());
-  EXPECT_EQ(nodeAddress.getNodeId(), testNodeId);
-  EXPECT_EQ(nodeAddress.getPublicKey(), testRSAPublicKey);
-  EXPECT_EQ(nodeAddress.getNodeAccountId().mShardNum, 0ULL);
-  EXPECT_EQ(nodeAddress.getNodeAccountId().mRealmNum, 0ULL);
-  EXPECT_FALSE(nodeAddress.getNodeAccountId().mAccountNum.has_value());
-  EXPECT_EQ(nodeAddress.getNodeAccountId().mPublicKeyAlias, nullptr);
-  EXPECT_FALSE(nodeAddress.getNodeAccountId().mEvmAddressAlias.has_value());
-  EXPECT_TRUE(nodeAddress.getNodeCertHash().empty());
-  EXPECT_FALSE(nodeAddress.getDescription().empty());
-  EXPECT_EQ(nodeAddress.getDescription(), testDescription);
-  EXPECT_FALSE(nodeAddress.getEndpoints().empty());
->>>>>>> main
 }
 
 //-----
@@ -166,22 +132,7 @@ TEST_F(NodeAddressTest, GetSetNodeId)
   nodeAddress.setNodeId(getTestNodeId());
 
   // Then
-<<<<<<< HEAD
   EXPECT_EQ(nodeAddress.getNodeId(), getTestNodeId());
-=======
-  EXPECT_EQ(nodeAddress.getDefaultIpAddress().toString(), testIpAddressV4);
-  EXPECT_EQ(nodeAddress.getDefaultPort(), testPort);
-  EXPECT_EQ(nodeAddress.getNodeId(), -1);
-  EXPECT_FALSE(nodeAddress.getNodeAccountId().mEvmAddressAlias.has_value());
-  EXPECT_EQ(nodeAddress.getNodeAccountId().mShardNum, 0ULL);
-  EXPECT_EQ(nodeAddress.getNodeAccountId().mRealmNum, 0ULL);
-  EXPECT_FALSE(nodeAddress.getNodeAccountId().mAccountNum.has_value());
-  EXPECT_EQ(nodeAddress.getNodeAccountId().mPublicKeyAlias, nullptr);
-  EXPECT_FALSE(nodeAddress.getNodeAccountId().mEvmAddressAlias.has_value());
-  EXPECT_TRUE(nodeAddress.getNodeCertHash().empty());
-  EXPECT_TRUE(nodeAddress.getDescription().empty());
-  EXPECT_FALSE(nodeAddress.getEndpoints().empty());
->>>>>>> main
 }
 
 //-----

--- a/sdk/tests/unit/ScheduleCreateTransactionUnitTests.cc
+++ b/sdk/tests/unit/ScheduleCreateTransactionUnitTests.cc
@@ -35,15 +35,12 @@ class ScheduleCreateTransactionTests : public ::testing::Test
 protected:
   void SetUp() override
   {
-    mClient.setOperator(AccountId(), ECDSAsecp256k1PrivateKey::generatePrivateKey().get());
-
     mTestSchedulableTransactionBody.set_memo("test memo");
     mTestSchedulableTransactionBody.set_transactionfee(1ULL);
     mTestSchedulableTransactionBody.set_allocated_cryptoapproveallowance(
       new proto::CryptoApproveAllowanceTransactionBody);
   }
 
-  [[nodiscard]] inline const Client& getTestClient() const { return mClient; }
   [[nodiscard]] inline const proto::SchedulableTransactionBody& getTestSchedulableTransactionBody() const
   {
     return mTestSchedulableTransactionBody;
@@ -58,7 +55,6 @@ protected:
   [[nodiscard]] inline bool getTestWaitForExpiry() const { return mTestWaitForExpiry; }
 
 private:
-  Client mClient;
   proto::SchedulableTransactionBody mTestSchedulableTransactionBody;
   const std::string mTestMemo = "my test memo";
   const std::shared_ptr<PublicKey> mTestAdminKey = ECDSAsecp256k1PrivateKey::generatePrivateKey()->getPublicKey();
@@ -113,8 +109,10 @@ TEST_F(ScheduleCreateTransactionTests, GetSetScheduledTransaction)
 TEST_F(ScheduleCreateTransactionTests, GetSetScheduledTransactionFrozen)
 {
   // Given
-  ScheduleCreateTransaction transaction;
-  ASSERT_NO_THROW(transaction.freezeWith(&getTestClient()));
+  ScheduleCreateTransaction transaction = ScheduleCreateTransaction()
+                                            .setNodeAccountIds({ AccountId(1ULL) })
+                                            .setTransactionId(TransactionId::generate(AccountId(1ULL)));
+  ASSERT_NO_THROW(transaction.freeze());
 
   // When / Then
   EXPECT_THROW(transaction.setScheduledTransaction(WrappedTransaction(AccountAllowanceApproveTransaction())),
@@ -138,8 +136,10 @@ TEST_F(ScheduleCreateTransactionTests, GetSetMemo)
 TEST_F(ScheduleCreateTransactionTests, GetSetMemoFrozen)
 {
   // Given
-  ScheduleCreateTransaction transaction;
-  ASSERT_NO_THROW(transaction.freezeWith(&getTestClient()));
+  ScheduleCreateTransaction transaction = ScheduleCreateTransaction()
+                                            .setNodeAccountIds({ AccountId(1ULL) })
+                                            .setTransactionId(TransactionId::generate(AccountId(1ULL)));
+  ASSERT_NO_THROW(transaction.freeze());
 
   // When / Then
   EXPECT_THROW(transaction.setScheduleMemo(getTestMemo()), IllegalStateException);
@@ -162,8 +162,10 @@ TEST_F(ScheduleCreateTransactionTests, GetSetAdminKey)
 TEST_F(ScheduleCreateTransactionTests, GetSetAdminKeyFrozen)
 {
   // Given
-  ScheduleCreateTransaction transaction;
-  ASSERT_NO_THROW(transaction.freezeWith(&getTestClient()));
+  ScheduleCreateTransaction transaction = ScheduleCreateTransaction()
+                                            .setNodeAccountIds({ AccountId(1ULL) })
+                                            .setTransactionId(TransactionId::generate(AccountId(1ULL)));
+  ASSERT_NO_THROW(transaction.freeze());
 
   // When / Then
   EXPECT_THROW(transaction.setAdminKey(getTestAdminKey()), IllegalStateException);
@@ -186,8 +188,10 @@ TEST_F(ScheduleCreateTransactionTests, GetSetPayerAccountId)
 TEST_F(ScheduleCreateTransactionTests, GetSetPayerAccountIdFrozen)
 {
   // Given
-  ScheduleCreateTransaction transaction;
-  ASSERT_NO_THROW(transaction.freezeWith(&getTestClient()));
+  ScheduleCreateTransaction transaction = ScheduleCreateTransaction()
+                                            .setNodeAccountIds({ AccountId(1ULL) })
+                                            .setTransactionId(TransactionId::generate(AccountId(1ULL)));
+  ASSERT_NO_THROW(transaction.freeze());
 
   // When / Then
   EXPECT_THROW(transaction.setPayerAccountId(getTestPayerAccountId()), IllegalStateException);
@@ -210,8 +214,10 @@ TEST_F(ScheduleCreateTransactionTests, GetSetExpirationTime)
 TEST_F(ScheduleCreateTransactionTests, GetSetExpirationTimeFrozen)
 {
   // Given
-  ScheduleCreateTransaction transaction;
-  ASSERT_NO_THROW(transaction.freezeWith(&getTestClient()));
+  ScheduleCreateTransaction transaction = ScheduleCreateTransaction()
+                                            .setNodeAccountIds({ AccountId(1ULL) })
+                                            .setTransactionId(TransactionId::generate(AccountId(1ULL)));
+  ASSERT_NO_THROW(transaction.freeze());
 
   // When / Then
   EXPECT_THROW(transaction.setExpirationTime(getTestExpirationTime()), IllegalStateException);
@@ -234,8 +240,10 @@ TEST_F(ScheduleCreateTransactionTests, GetSetWaitForExpiry)
 TEST_F(ScheduleCreateTransactionTests, GetSetWaitForExpiryFrozen)
 {
   // Given
-  ScheduleCreateTransaction transaction;
-  ASSERT_NO_THROW(transaction.freezeWith(&getTestClient()));
+  ScheduleCreateTransaction transaction = ScheduleCreateTransaction()
+                                            .setNodeAccountIds({ AccountId(1ULL) })
+                                            .setTransactionId(TransactionId::generate(AccountId(1ULL)));
+  ASSERT_NO_THROW(transaction.freeze());
 
   // When / Then
   EXPECT_THROW(transaction.setWaitForExpiry(getTestWaitForExpiry()), IllegalStateException);

--- a/sdk/tests/unit/ScheduleDeleteTransactionUnitTests.cc
+++ b/sdk/tests/unit/ScheduleDeleteTransactionUnitTests.cc
@@ -30,13 +30,9 @@ using namespace Hedera;
 class ScheduleDeleteTransactionTest : public ::testing::Test
 {
 protected:
-  void SetUp() override { mClient.setOperator(AccountId(), ECDSAsecp256k1PrivateKey::generatePrivateKey().get()); }
-
-  [[nodiscard]] inline const Client& getTestClient() const { return mClient; }
   [[nodiscard]] inline const ScheduleId& getTestScheduleId() const { return mTestScheduleId; }
 
 private:
-  Client mClient;
   const ScheduleId mTestScheduleId = ScheduleId(1ULL);
 };
 
@@ -84,8 +80,10 @@ TEST_F(ScheduleDeleteTransactionTest, GetSetScheduleId)
 TEST_F(ScheduleDeleteTransactionTest, GetSetScheduleIdFrozen)
 {
   // Given
-  ScheduleDeleteTransaction transaction;
-  ASSERT_NO_THROW(transaction.freezeWith(&getTestClient()));
+  ScheduleDeleteTransaction transaction = ScheduleDeleteTransaction()
+                                            .setNodeAccountIds({ AccountId(1ULL) })
+                                            .setTransactionId(TransactionId::generate(AccountId(1ULL)));
+  ASSERT_NO_THROW(transaction.freeze());
 
   // When / Then
   EXPECT_THROW(transaction.setScheduleId(getTestScheduleId()), IllegalStateException);

--- a/sdk/tests/unit/ScheduleSignTransactionUnitTests.cc
+++ b/sdk/tests/unit/ScheduleSignTransactionUnitTests.cc
@@ -30,13 +30,9 @@ using namespace Hedera;
 class ScheduleSignTransactionTest : public ::testing::Test
 {
 protected:
-  void SetUp() override { mClient.setOperator(AccountId(), ECDSAsecp256k1PrivateKey::generatePrivateKey().get()); }
-
-  [[nodiscard]] inline const Client& getTestClient() const { return mClient; }
   [[nodiscard]] inline const ScheduleId& getTestScheduleId() const { return mTestScheduleId; }
 
 private:
-  Client mClient;
   const ScheduleId mTestScheduleId = ScheduleId(1ULL);
 };
 
@@ -84,8 +80,10 @@ TEST_F(ScheduleSignTransactionTest, GetSetScheduleId)
 TEST_F(ScheduleSignTransactionTest, GetSetScheduleIdFrozen)
 {
   // Given
-  ScheduleSignTransaction transaction;
-  ASSERT_NO_THROW(transaction.freezeWith(&getTestClient()));
+  ScheduleSignTransaction transaction = ScheduleSignTransaction()
+                                          .setNodeAccountIds({ AccountId(1ULL) })
+                                          .setTransactionId(TransactionId::generate(AccountId(1ULL)));
+  ASSERT_NO_THROW(transaction.freeze());
 
   // When / Then
   EXPECT_THROW(transaction.setScheduleId(getTestScheduleId()), IllegalStateException);
@@ -109,8 +107,10 @@ TEST_F(ScheduleSignTransactionTest, ClearScheduleId)
 TEST_F(ScheduleSignTransactionTest, ClearScheduleIdFrozen)
 {
   // Given
-  ScheduleSignTransaction transaction;
-  ASSERT_NO_THROW(transaction.freezeWith(&getTestClient()));
+  ScheduleSignTransaction transaction = ScheduleSignTransaction()
+                                          .setNodeAccountIds({ AccountId(1ULL) })
+                                          .setTransactionId(TransactionId::generate(AccountId(1ULL)));
+  ASSERT_NO_THROW(transaction.freeze());
 
   // When / Then
   EXPECT_THROW(transaction.clearScheduleId(), IllegalStateException);

--- a/sdk/tests/unit/SystemDeleteTransactionUnitTests.cc
+++ b/sdk/tests/unit/SystemDeleteTransactionUnitTests.cc
@@ -31,9 +31,6 @@ using namespace Hedera;
 class SystemDeleteTransactionTest : public ::testing::Test
 {
 protected:
-  void SetUp() override { mClient.setOperator(AccountId(), ECDSAsecp256k1PrivateKey::generatePrivateKey().get()); }
-
-  [[nodiscard]] inline const Client& getTestClient() const { return mClient; }
   [[nodiscard]] inline const FileId& getTestFileId() const { return mTestFileId; }
   [[nodiscard]] inline const ContractId& getTestContractId() const { return mTestContractId; }
   [[nodiscard]] inline const std::chrono::system_clock::time_point& getTestExpirationTime() const
@@ -42,7 +39,6 @@ protected:
   }
 
 private:
-  Client mClient;
   const FileId mTestFileId = FileId(1ULL, 2ULL, 3ULL);
   const ContractId mTestContractId = ContractId(4ULL, 5ULL, 6ULL);
   const std::chrono::system_clock::time_point mTestExpirationTime = std::chrono::system_clock::now();
@@ -102,8 +98,10 @@ TEST_F(SystemDeleteTransactionTest, GetSetFileId)
 TEST_F(SystemDeleteTransactionTest, GetSetFileIdFrozen)
 {
   // Given
-  SystemDeleteTransaction transaction;
-  ASSERT_NO_THROW(transaction.freezeWith(&getTestClient()));
+  SystemDeleteTransaction transaction = SystemDeleteTransaction()
+                                          .setNodeAccountIds({ AccountId(1ULL) })
+                                          .setTransactionId(TransactionId::generate(AccountId(1ULL)));
+  ASSERT_NO_THROW(transaction.freeze());
 
   // When / Then
   EXPECT_THROW(transaction.setFileId(getTestFileId()), IllegalStateException);
@@ -127,8 +125,10 @@ TEST_F(SystemDeleteTransactionTest, GetSetContractId)
 TEST_F(SystemDeleteTransactionTest, GetSetContractIdFrozen)
 {
   // Given
-  SystemDeleteTransaction transaction;
-  ASSERT_NO_THROW(transaction.freezeWith(&getTestClient()));
+  SystemDeleteTransaction transaction = SystemDeleteTransaction()
+                                          .setNodeAccountIds({ AccountId(1ULL) })
+                                          .setTransactionId(TransactionId::generate(AccountId(1ULL)));
+  ASSERT_NO_THROW(transaction.freeze());
 
   // When / Then
   EXPECT_THROW(transaction.setContractId(getTestContractId()), IllegalStateException);
@@ -151,8 +151,10 @@ TEST_F(SystemDeleteTransactionTest, GetSetExpirationTime)
 TEST_F(SystemDeleteTransactionTest, GetSetExpirationTimeFrozen)
 {
   // Given
-  SystemDeleteTransaction transaction;
-  ASSERT_NO_THROW(transaction.freezeWith(&getTestClient()));
+  SystemDeleteTransaction transaction = SystemDeleteTransaction()
+                                          .setNodeAccountIds({ AccountId(1ULL) })
+                                          .setTransactionId(TransactionId::generate(AccountId(1ULL)));
+  ASSERT_NO_THROW(transaction.freeze());
 
   // When / Then
   EXPECT_THROW(transaction.setExpirationTime(getTestExpirationTime()), IllegalStateException);

--- a/sdk/tests/unit/SystemUndeleteTransactionUnitTests.cc
+++ b/sdk/tests/unit/SystemUndeleteTransactionUnitTests.cc
@@ -30,14 +30,10 @@ using namespace Hedera;
 class SystemUndeleteTransactionTest : public ::testing::Test
 {
 protected:
-  void SetUp() override { mClient.setOperator(AccountId(), ECDSAsecp256k1PrivateKey::generatePrivateKey().get()); }
-
-  [[nodiscard]] inline const Client& getTestClient() const { return mClient; }
   [[nodiscard]] inline const FileId& getTestFileId() const { return mTestFileId; }
   [[nodiscard]] inline const ContractId& getTestContractId() const { return mTestContractId; }
 
 private:
-  Client mClient;
   const FileId mTestFileId = FileId(1ULL, 2ULL, 3ULL);
   const ContractId mTestContractId = ContractId(4ULL, 5ULL, 6ULL);
 };
@@ -90,8 +86,10 @@ TEST_F(SystemUndeleteTransactionTest, GetSetFileId)
 TEST_F(SystemUndeleteTransactionTest, GetSetFileIdFrozen)
 {
   // Given
-  SystemUndeleteTransaction transaction;
-  ASSERT_NO_THROW(transaction.freezeWith(&getTestClient()));
+  SystemUndeleteTransaction transaction = SystemUndeleteTransaction()
+                                            .setNodeAccountIds({ AccountId(1ULL) })
+                                            .setTransactionId(TransactionId::generate(AccountId(1ULL)));
+  ASSERT_NO_THROW(transaction.freeze());
 
   // When / Then
   EXPECT_THROW(transaction.setFileId(getTestFileId()), IllegalStateException);
@@ -115,8 +113,10 @@ TEST_F(SystemUndeleteTransactionTest, GetSetContractId)
 TEST_F(SystemUndeleteTransactionTest, GetSetContractIdFrozen)
 {
   // Given
-  SystemUndeleteTransaction transaction;
-  ASSERT_NO_THROW(transaction.freezeWith(&getTestClient()));
+  SystemUndeleteTransaction transaction = SystemUndeleteTransaction()
+                                            .setNodeAccountIds({ AccountId(1ULL) })
+                                            .setTransactionId(TransactionId::generate(AccountId(1ULL)));
+  ASSERT_NO_THROW(transaction.freeze());
 
   // When / Then
   EXPECT_THROW(transaction.setContractId(getTestContractId()), IllegalStateException);

--- a/sdk/tests/unit/TokenAssociateTransactionUnitTests.cc
+++ b/sdk/tests/unit/TokenAssociateTransactionUnitTests.cc
@@ -31,14 +31,10 @@ using namespace Hedera;
 class TokenAssociateTransactionTest : public ::testing::Test
 {
 protected:
-  void SetUp() override { mClient.setOperator(AccountId(), ECDSAsecp256k1PrivateKey::generatePrivateKey().get()); }
-
-  [[nodiscard]] inline const Client& getTestClient() const { return mClient; }
   [[nodiscard]] inline const AccountId& getTestAccountId() const { return mTestAccountId; }
   [[nodiscard]] inline const std::vector<TokenId>& getTestTokenIds() const { return mTestTokenIds; }
 
 private:
-  Client mClient;
   const AccountId mTestAccountId = AccountId(1ULL, 2ULL, 3ULL);
   const std::vector<TokenId> mTestTokenIds = { TokenId(4ULL, 5ULL, 6ULL),
                                                TokenId(7ULL, 8ULL, 9ULL),
@@ -85,8 +81,10 @@ TEST_F(TokenAssociateTransactionTest, GetSetAccountId)
 TEST_F(TokenAssociateTransactionTest, GetSetAccountIdFrozen)
 {
   // Given
-  TokenAssociateTransaction transaction;
-  ASSERT_NO_THROW(transaction.freezeWith(&getTestClient()));
+  TokenAssociateTransaction transaction = TokenAssociateTransaction()
+                                            .setNodeAccountIds({ AccountId(1ULL) })
+                                            .setTransactionId(TransactionId::generate(AccountId(1ULL)));
+  ASSERT_NO_THROW(transaction.freeze());
 
   // When / Then
   EXPECT_THROW(transaction.setAccountId(getTestAccountId()), IllegalStateException);
@@ -109,8 +107,10 @@ TEST_F(TokenAssociateTransactionTest, GetSetTokenIds)
 TEST_F(TokenAssociateTransactionTest, GetSetTokenIdFrozen)
 {
   // Given
-  TokenAssociateTransaction transaction;
-  ASSERT_NO_THROW(transaction.freezeWith(&getTestClient()));
+  TokenAssociateTransaction transaction = TokenAssociateTransaction()
+                                            .setNodeAccountIds({ AccountId(1ULL) })
+                                            .setTransactionId(TransactionId::generate(AccountId(1ULL)));
+  ASSERT_NO_THROW(transaction.freeze());
 
   // When / Then
   EXPECT_THROW(transaction.setTokenIds(getTestTokenIds()), IllegalStateException);

--- a/sdk/tests/unit/TokenBurnTransactionUnitTests.cc
+++ b/sdk/tests/unit/TokenBurnTransactionUnitTests.cc
@@ -30,15 +30,11 @@ using namespace Hedera;
 class TokenBurnTransactionTest : public ::testing::Test
 {
 protected:
-  void SetUp() override { mClient.setOperator(AccountId(), ECDSAsecp256k1PrivateKey::generatePrivateKey().get()); }
-
-  [[nodiscard]] inline const Client& getTestClient() const { return mClient; }
   [[nodiscard]] inline const TokenId& getTestTokenId() const { return mTestTokenId; }
   [[nodiscard]] inline const uint64_t& getTestAmount() const { return mTestAmount; }
   [[nodiscard]] inline const std::vector<uint64_t>& getTestSerialNumbers() const { return mTestSerialNumbers; }
 
 private:
-  Client mClient;
   const TokenId mTestTokenId = TokenId(1ULL, 2ULL, 3ULL);
   const uint64_t mTestAmount = 4ULL;
   const std::vector<uint64_t> mTestSerialNumbers = { 5ULL, 6ULL, 7ULL };
@@ -86,8 +82,10 @@ TEST_F(TokenBurnTransactionTest, GetSetTokenId)
 TEST_F(TokenBurnTransactionTest, GetSetTokenIdFrozen)
 {
   // Given
-  TokenBurnTransaction transaction;
-  ASSERT_NO_THROW(transaction.freezeWith(&getTestClient()));
+  TokenBurnTransaction transaction = TokenBurnTransaction()
+                                       .setNodeAccountIds({ AccountId(1ULL) })
+                                       .setTransactionId(TransactionId::generate(AccountId(1ULL)));
+  ASSERT_NO_THROW(transaction.freeze());
 
   // When / Then
   EXPECT_THROW(transaction.setTokenId(getTestTokenId()), IllegalStateException);
@@ -110,8 +108,10 @@ TEST_F(TokenBurnTransactionTest, GetSetAmount)
 TEST_F(TokenBurnTransactionTest, GetSetAmountFrozen)
 {
   // Given
-  TokenBurnTransaction transaction;
-  ASSERT_NO_THROW(transaction.freezeWith(&getTestClient()));
+  TokenBurnTransaction transaction = TokenBurnTransaction()
+                                       .setNodeAccountIds({ AccountId(1ULL) })
+                                       .setTransactionId(TransactionId::generate(AccountId(1ULL)));
+  ASSERT_NO_THROW(transaction.freeze());
 
   // When / Then
   EXPECT_THROW(transaction.setAmount(getTestAmount()), IllegalStateException);
@@ -134,8 +134,10 @@ TEST_F(TokenBurnTransactionTest, GetSetSerialNumbers)
 TEST_F(TokenBurnTransactionTest, GetSetSerialNumbersFrozen)
 {
   // Given
-  TokenBurnTransaction transaction;
-  ASSERT_NO_THROW(transaction.freezeWith(&getTestClient()));
+  TokenBurnTransaction transaction = TokenBurnTransaction()
+                                       .setNodeAccountIds({ AccountId(1ULL) })
+                                       .setTransactionId(TransactionId::generate(AccountId(1ULL)));
+  ASSERT_NO_THROW(transaction.freeze());
 
   // When / Then
   EXPECT_THROW(transaction.setSerialNumbers(getTestSerialNumbers()), IllegalStateException);

--- a/sdk/tests/unit/TokenCreateTransactionTest.cc
+++ b/sdk/tests/unit/TokenCreateTransactionTest.cc
@@ -44,9 +44,6 @@ using namespace Hedera;
 class TokenCreateTransactionTest : public ::testing::Test
 {
 protected:
-  void SetUp() override { mClient.setOperator(AccountId(), ECDSAsecp256k1PrivateKey::generatePrivateKey().get()); }
-
-  [[nodiscard]] inline const Client& getTestClient() const { return mClient; }
   [[nodiscard]] inline const std::string& getTestTokenName() const { return mTestTokenName; }
   [[nodiscard]] inline const std::string& getTestTokenSymbol() const { return mTestTokenSymbol; }
   [[nodiscard]] inline uint32_t getTestDecimals() const { return mTestDecimals; }
@@ -79,7 +76,6 @@ protected:
   [[nodiscard]] inline const std::shared_ptr<PublicKey>& getTestPauseKey() const { return mTestPauseKey; }
 
 private:
-  Client mClient;
   const std::string mTestTokenName = "test name";
   const std::string mTestTokenSymbol = "test symbol";
   const uint32_t mTestDecimals = 1U;
@@ -196,8 +192,10 @@ TEST_F(TokenCreateTransactionTest, GetSetName)
 TEST_F(TokenCreateTransactionTest, GetSetNameFrozen)
 {
   // Given
-  TokenCreateTransaction transaction;
-  ASSERT_NO_THROW(transaction.freezeWith(&getTestClient()));
+  TokenCreateTransaction transaction = TokenCreateTransaction()
+                                         .setNodeAccountIds({ AccountId(1ULL) })
+                                         .setTransactionId(TransactionId::generate(AccountId(1ULL)));
+  ASSERT_NO_THROW(transaction.freeze());
 
   // When / Then
   EXPECT_THROW(transaction.setTokenName(getTestTokenName()), IllegalStateException);
@@ -220,8 +218,10 @@ TEST_F(TokenCreateTransactionTest, GetSetSymbol)
 TEST_F(TokenCreateTransactionTest, GetSetSymbolFrozen)
 {
   // Given
-  TokenCreateTransaction transaction;
-  ASSERT_NO_THROW(transaction.freezeWith(&getTestClient()));
+  TokenCreateTransaction transaction = TokenCreateTransaction()
+                                         .setNodeAccountIds({ AccountId(1ULL) })
+                                         .setTransactionId(TransactionId::generate(AccountId(1ULL)));
+  ASSERT_NO_THROW(transaction.freeze());
 
   // When / Then
   EXPECT_THROW(transaction.setTokenSymbol(getTestTokenSymbol()), IllegalStateException);
@@ -244,8 +244,10 @@ TEST_F(TokenCreateTransactionTest, GetSetDecimals)
 TEST_F(TokenCreateTransactionTest, GetSetDecimalsFrozen)
 {
   // Given
-  TokenCreateTransaction transaction;
-  ASSERT_NO_THROW(transaction.freezeWith(&getTestClient()));
+  TokenCreateTransaction transaction = TokenCreateTransaction()
+                                         .setNodeAccountIds({ AccountId(1ULL) })
+                                         .setTransactionId(TransactionId::generate(AccountId(1ULL)));
+  ASSERT_NO_THROW(transaction.freeze());
 
   // When / Then
   EXPECT_THROW(transaction.setDecimals(getTestDecimals()), IllegalStateException);
@@ -268,8 +270,10 @@ TEST_F(TokenCreateTransactionTest, GetSetInitialSupply)
 TEST_F(TokenCreateTransactionTest, GetSetInitialSupplyFrozen)
 {
   // Given
-  TokenCreateTransaction transaction;
-  ASSERT_NO_THROW(transaction.freezeWith(&getTestClient()));
+  TokenCreateTransaction transaction = TokenCreateTransaction()
+                                         .setNodeAccountIds({ AccountId(1ULL) })
+                                         .setTransactionId(TransactionId::generate(AccountId(1ULL)));
+  ASSERT_NO_THROW(transaction.freeze());
 
   // When / Then
   EXPECT_THROW(transaction.setInitialSupply(getTestInitialSupply()), IllegalStateException);
@@ -292,8 +296,10 @@ TEST_F(TokenCreateTransactionTest, GetSetTreasuryAccountId)
 TEST_F(TokenCreateTransactionTest, GetSetTreasuryAccountIdFrozen)
 {
   // Given
-  TokenCreateTransaction transaction;
-  ASSERT_NO_THROW(transaction.freezeWith(&getTestClient()));
+  TokenCreateTransaction transaction = TokenCreateTransaction()
+                                         .setNodeAccountIds({ AccountId(1ULL) })
+                                         .setTransactionId(TransactionId::generate(AccountId(1ULL)));
+  ASSERT_NO_THROW(transaction.freeze());
 
   // When / Then
   EXPECT_THROW(transaction.setTreasuryAccountId(getTestTreasuryAccountId()), IllegalStateException);
@@ -316,8 +322,10 @@ TEST_F(TokenCreateTransactionTest, GetSetAdminKey)
 TEST_F(TokenCreateTransactionTest, GetSetAdminKeyFrozen)
 {
   // Given
-  TokenCreateTransaction transaction;
-  ASSERT_NO_THROW(transaction.freezeWith(&getTestClient()));
+  TokenCreateTransaction transaction = TokenCreateTransaction()
+                                         .setNodeAccountIds({ AccountId(1ULL) })
+                                         .setTransactionId(TransactionId::generate(AccountId(1ULL)));
+  ASSERT_NO_THROW(transaction.freeze());
 
   // When / Then
   EXPECT_THROW(transaction.setAdminKey(getTestAdminKey()), IllegalStateException);
@@ -340,8 +348,10 @@ TEST_F(TokenCreateTransactionTest, GetSetKycKey)
 TEST_F(TokenCreateTransactionTest, GetSetKycKeyFrozen)
 {
   // Given
-  TokenCreateTransaction transaction;
-  ASSERT_NO_THROW(transaction.freezeWith(&getTestClient()));
+  TokenCreateTransaction transaction = TokenCreateTransaction()
+                                         .setNodeAccountIds({ AccountId(1ULL) })
+                                         .setTransactionId(TransactionId::generate(AccountId(1ULL)));
+  ASSERT_NO_THROW(transaction.freeze());
 
   // When / Then
   EXPECT_THROW(transaction.setKycKey(getTestKycKey()), IllegalStateException);
@@ -364,8 +374,10 @@ TEST_F(TokenCreateTransactionTest, GetSetFreezeKey)
 TEST_F(TokenCreateTransactionTest, GetSetFreezeKeyFrozen)
 {
   // Given
-  TokenCreateTransaction transaction;
-  ASSERT_NO_THROW(transaction.freezeWith(&getTestClient()));
+  TokenCreateTransaction transaction = TokenCreateTransaction()
+                                         .setNodeAccountIds({ AccountId(1ULL) })
+                                         .setTransactionId(TransactionId::generate(AccountId(1ULL)));
+  ASSERT_NO_THROW(transaction.freeze());
 
   // When / Then
   EXPECT_THROW(transaction.setFreezeKey(getTestFreezeKey()), IllegalStateException);
@@ -388,8 +400,10 @@ TEST_F(TokenCreateTransactionTest, GetSetWipeKey)
 TEST_F(TokenCreateTransactionTest, GetSetWipeKeyFrozen)
 {
   // Given
-  TokenCreateTransaction transaction;
-  ASSERT_NO_THROW(transaction.freezeWith(&getTestClient()));
+  TokenCreateTransaction transaction = TokenCreateTransaction()
+                                         .setNodeAccountIds({ AccountId(1ULL) })
+                                         .setTransactionId(TransactionId::generate(AccountId(1ULL)));
+  ASSERT_NO_THROW(transaction.freeze());
 
   // When / Then
   EXPECT_THROW(transaction.setWipeKey(getTestWipeKey()), IllegalStateException);
@@ -412,8 +426,10 @@ TEST_F(TokenCreateTransactionTest, GetSetSupplyKey)
 TEST_F(TokenCreateTransactionTest, GetSetSupplyKeyFrozen)
 {
   // Given
-  TokenCreateTransaction transaction;
-  ASSERT_NO_THROW(transaction.freezeWith(&getTestClient()));
+  TokenCreateTransaction transaction = TokenCreateTransaction()
+                                         .setNodeAccountIds({ AccountId(1ULL) })
+                                         .setTransactionId(TransactionId::generate(AccountId(1ULL)));
+  ASSERT_NO_THROW(transaction.freeze());
 
   // When / Then
   EXPECT_THROW(transaction.setSupplyKey(getTestSupplyKey()), IllegalStateException);
@@ -436,8 +452,10 @@ TEST_F(TokenCreateTransactionTest, GetSetFreezeDefault)
 TEST_F(TokenCreateTransactionTest, GetSetFreezeDefaultFrozen)
 {
   // Given
-  TokenCreateTransaction transaction;
-  ASSERT_NO_THROW(transaction.freezeWith(&getTestClient()));
+  TokenCreateTransaction transaction = TokenCreateTransaction()
+                                         .setNodeAccountIds({ AccountId(1ULL) })
+                                         .setTransactionId(TransactionId::generate(AccountId(1ULL)));
+  ASSERT_NO_THROW(transaction.freeze());
 
   // When / Then
   EXPECT_THROW(transaction.setFreezeDefault(getTestFreezeDefault()), IllegalStateException);
@@ -460,8 +478,10 @@ TEST_F(TokenCreateTransactionTest, GetSetExpirationTime)
 TEST_F(TokenCreateTransactionTest, GetSetExpirationTimeFrozen)
 {
   // Given
-  TokenCreateTransaction transaction;
-  ASSERT_NO_THROW(transaction.freezeWith(&getTestClient()));
+  TokenCreateTransaction transaction = TokenCreateTransaction()
+                                         .setNodeAccountIds({ AccountId(1ULL) })
+                                         .setTransactionId(TransactionId::generate(AccountId(1ULL)));
+  ASSERT_NO_THROW(transaction.freeze());
 
   // When / Then
   EXPECT_THROW(transaction.setExpirationTime(getTestExpirationTime()), IllegalStateException);
@@ -484,8 +504,10 @@ TEST_F(TokenCreateTransactionTest, GetSetAutoRenewAccountId)
 TEST_F(TokenCreateTransactionTest, GetSetAutoRenewAccountIdFrozen)
 {
   // Given
-  TokenCreateTransaction transaction;
-  ASSERT_NO_THROW(transaction.freezeWith(&getTestClient()));
+  TokenCreateTransaction transaction = TokenCreateTransaction()
+                                         .setNodeAccountIds({ AccountId(1ULL) })
+                                         .setTransactionId(TransactionId::generate(AccountId(1ULL)));
+  ASSERT_NO_THROW(transaction.freeze());
 
   // When / Then
   EXPECT_THROW(transaction.setAutoRenewAccountId(getTestAutoRenewAccountId()), IllegalStateException);
@@ -508,8 +530,10 @@ TEST_F(TokenCreateTransactionTest, GetSetAutoRenewPeriod)
 TEST_F(TokenCreateTransactionTest, GetSetAutoRenewPeriodFrozen)
 {
   // Given
-  TokenCreateTransaction transaction;
-  ASSERT_NO_THROW(transaction.freezeWith(&getTestClient()));
+  TokenCreateTransaction transaction = TokenCreateTransaction()
+                                         .setNodeAccountIds({ AccountId(1ULL) })
+                                         .setTransactionId(TransactionId::generate(AccountId(1ULL)));
+  ASSERT_NO_THROW(transaction.freeze());
 
   // When / Then
   EXPECT_THROW(transaction.setAutoRenewPeriod(getTestAutoRenewPeriod()), IllegalStateException);
@@ -532,8 +556,10 @@ TEST_F(TokenCreateTransactionTest, GetSetMemo)
 TEST_F(TokenCreateTransactionTest, GetSetMemoFrozen)
 {
   // Given
-  TokenCreateTransaction transaction;
-  ASSERT_NO_THROW(transaction.freezeWith(&getTestClient()));
+  TokenCreateTransaction transaction = TokenCreateTransaction()
+                                         .setNodeAccountIds({ AccountId(1ULL) })
+                                         .setTransactionId(TransactionId::generate(AccountId(1ULL)));
+  ASSERT_NO_THROW(transaction.freeze());
 
   // When / Then
   EXPECT_THROW(transaction.setTokenMemo(getTestTokenMemo()), IllegalStateException);
@@ -556,8 +582,10 @@ TEST_F(TokenCreateTransactionTest, GetSetTokenType)
 TEST_F(TokenCreateTransactionTest, GetSetTokenTypeFrozen)
 {
   // Given
-  TokenCreateTransaction transaction;
-  ASSERT_NO_THROW(transaction.freezeWith(&getTestClient()));
+  TokenCreateTransaction transaction = TokenCreateTransaction()
+                                         .setNodeAccountIds({ AccountId(1ULL) })
+                                         .setTransactionId(TransactionId::generate(AccountId(1ULL)));
+  ASSERT_NO_THROW(transaction.freeze());
 
   // When / Then
   EXPECT_THROW(transaction.setTokenType(getTestTokenType()), IllegalStateException);
@@ -580,8 +608,10 @@ TEST_F(TokenCreateTransactionTest, GetSetSupplyType)
 TEST_F(TokenCreateTransactionTest, GetSetSupplyTypeFrozen)
 {
   // Given
-  TokenCreateTransaction transaction;
-  ASSERT_NO_THROW(transaction.freezeWith(&getTestClient()));
+  TokenCreateTransaction transaction = TokenCreateTransaction()
+                                         .setNodeAccountIds({ AccountId(1ULL) })
+                                         .setTransactionId(TransactionId::generate(AccountId(1ULL)));
+  ASSERT_NO_THROW(transaction.freeze());
 
   // When / Then
   EXPECT_THROW(transaction.setSupplyType(getTestTokenSupplyType()), IllegalStateException);
@@ -604,8 +634,10 @@ TEST_F(TokenCreateTransactionTest, GetSetMaxSupply)
 TEST_F(TokenCreateTransactionTest, GetSetMaxSupplyFrozen)
 {
   // Given
-  TokenCreateTransaction transaction;
-  ASSERT_NO_THROW(transaction.freezeWith(&getTestClient()));
+  TokenCreateTransaction transaction = TokenCreateTransaction()
+                                         .setNodeAccountIds({ AccountId(1ULL) })
+                                         .setTransactionId(TransactionId::generate(AccountId(1ULL)));
+  ASSERT_NO_THROW(transaction.freeze());
 
   // When / Then
   EXPECT_THROW(transaction.setMaxSupply(getTestMaxSupply()), IllegalStateException);
@@ -628,8 +660,10 @@ TEST_F(TokenCreateTransactionTest, GetSetFeeScheduleKey)
 TEST_F(TokenCreateTransactionTest, GetSetFeeScheduleKeyFrozen)
 {
   // Given
-  TokenCreateTransaction transaction;
-  ASSERT_NO_THROW(transaction.freezeWith(&getTestClient()));
+  TokenCreateTransaction transaction = TokenCreateTransaction()
+                                         .setNodeAccountIds({ AccountId(1ULL) })
+                                         .setTransactionId(TransactionId::generate(AccountId(1ULL)));
+  ASSERT_NO_THROW(transaction.freeze());
 
   // When / Then
   EXPECT_THROW(transaction.setFeeScheduleKey(getTestFeeScheduleKey()), IllegalStateException);
@@ -652,8 +686,10 @@ TEST_F(TokenCreateTransactionTest, GetSetCustomFees)
 TEST_F(TokenCreateTransactionTest, GetSetCustomFeesFrozen)
 {
   // Given
-  TokenCreateTransaction transaction;
-  ASSERT_NO_THROW(transaction.freezeWith(&getTestClient()));
+  TokenCreateTransaction transaction = TokenCreateTransaction()
+                                         .setNodeAccountIds({ AccountId(1ULL) })
+                                         .setTransactionId(TransactionId::generate(AccountId(1ULL)));
+  ASSERT_NO_THROW(transaction.freeze());
 
   // When / Then
   EXPECT_THROW(transaction.setCustomFees(getTestCustomFees()), IllegalStateException);
@@ -676,8 +712,10 @@ TEST_F(TokenCreateTransactionTest, GetSetPauseKey)
 TEST_F(TokenCreateTransactionTest, GetSetPauseKeyFrozen)
 {
   // Given
-  TokenCreateTransaction transaction;
-  ASSERT_NO_THROW(transaction.freezeWith(&getTestClient()));
+  TokenCreateTransaction transaction = TokenCreateTransaction()
+                                         .setNodeAccountIds({ AccountId(1ULL) })
+                                         .setTransactionId(TransactionId::generate(AccountId(1ULL)));
+  ASSERT_NO_THROW(transaction.freeze());
 
   // When / Then
   EXPECT_THROW(transaction.setPauseKey(getTestPauseKey()), IllegalStateException);

--- a/sdk/tests/unit/TokenDeleteTransactionTest.cc
+++ b/sdk/tests/unit/TokenDeleteTransactionTest.cc
@@ -30,13 +30,9 @@ using namespace Hedera;
 class TokenDeleteTransactionTest : public ::testing::Test
 {
 protected:
-  void SetUp() override { mClient.setOperator(AccountId(), ECDSAsecp256k1PrivateKey::generatePrivateKey().get()); }
-
-  [[nodiscard]] inline const Client& getTestClient() const { return mClient; }
   [[nodiscard]] inline const TokenId& getTestTokenId() const { return mTestTokenId; }
 
 private:
-  Client mClient;
   const TokenId mTestTokenId = TokenId(1ULL);
 };
 
@@ -84,8 +80,10 @@ TEST_F(TokenDeleteTransactionTest, GetSetTokenId)
 TEST_F(TokenDeleteTransactionTest, GetSetTokenIdFrozen)
 {
   // Given
-  TokenDeleteTransaction transaction;
-  ASSERT_NO_THROW(transaction.freezeWith(&getTestClient()));
+  TokenDeleteTransaction transaction = TokenDeleteTransaction()
+                                         .setNodeAccountIds({ AccountId(1ULL) })
+                                         .setTransactionId(TransactionId::generate(AccountId(1ULL)));
+  ASSERT_NO_THROW(transaction.freeze());
 
   // When / Then
   EXPECT_THROW(transaction.setTokenId(getTestTokenId()), IllegalStateException);

--- a/sdk/tests/unit/TokenDissociateTransactionUnitTests.cc
+++ b/sdk/tests/unit/TokenDissociateTransactionUnitTests.cc
@@ -31,14 +31,10 @@ using namespace Hedera;
 class TokenDissociateTransactionTest : public ::testing::Test
 {
 protected:
-  void SetUp() override { mClient.setOperator(AccountId(), ECDSAsecp256k1PrivateKey::generatePrivateKey().get()); }
-
-  [[nodiscard]] inline const Client& getTestClient() const { return mClient; }
   [[nodiscard]] inline const AccountId& getTestAccountId() const { return mTestAccountId; }
   [[nodiscard]] inline const std::vector<TokenId>& getTestTokenIds() const { return mTestTokenIds; }
 
 private:
-  Client mClient;
   const AccountId mTestAccountId = AccountId(1ULL, 2ULL, 3ULL);
   const std::vector<TokenId> mTestTokenIds = { TokenId(4ULL, 5ULL, 6ULL),
                                                TokenId(7ULL, 8ULL, 9ULL),
@@ -85,8 +81,10 @@ TEST_F(TokenDissociateTransactionTest, GetSetAccountId)
 TEST_F(TokenDissociateTransactionTest, GetSetAccountIdFrozen)
 {
   // Given
-  TokenDissociateTransaction transaction;
-  ASSERT_NO_THROW(transaction.freezeWith(&getTestClient()));
+  TokenDissociateTransaction transaction = TokenDissociateTransaction()
+                                             .setNodeAccountIds({ AccountId(1ULL) })
+                                             .setTransactionId(TransactionId::generate(AccountId(1ULL)));
+  ASSERT_NO_THROW(transaction.freeze());
 
   // When / Then
   EXPECT_THROW(transaction.setAccountId(getTestAccountId()), IllegalStateException);
@@ -109,8 +107,10 @@ TEST_F(TokenDissociateTransactionTest, GetSetTokenIds)
 TEST_F(TokenDissociateTransactionTest, GetSetTokenIdFrozen)
 {
   // Given
-  TokenDissociateTransaction transaction;
-  ASSERT_NO_THROW(transaction.freezeWith(&getTestClient()));
+  TokenDissociateTransaction transaction = TokenDissociateTransaction()
+                                             .setNodeAccountIds({ AccountId(1ULL) })
+                                             .setTransactionId(TransactionId::generate(AccountId(1ULL)));
+  ASSERT_NO_THROW(transaction.freeze());
 
   // When / Then
   EXPECT_THROW(transaction.setTokenIds(getTestTokenIds()), IllegalStateException);

--- a/sdk/tests/unit/TokenFeeScheduleUpdateTransactionUnitTests.cc
+++ b/sdk/tests/unit/TokenFeeScheduleUpdateTransactionUnitTests.cc
@@ -34,9 +34,6 @@ using namespace Hedera;
 class TokenFeeScheduleUpdateTransactionTest : public ::testing::Test
 {
 protected:
-  void SetUp() override { mClient.setOperator(AccountId(), ECDSAsecp256k1PrivateKey::generatePrivateKey().get()); }
-
-  [[nodiscard]] inline const Client& getTestClient() const { return mClient; }
   [[nodiscard]] inline const TokenId& getTestTokenId() const { return mTestTokenId; }
   [[nodiscard]] inline const std::vector<std::shared_ptr<CustomFee>>& getTestCustomFees() const
   {
@@ -44,7 +41,6 @@ protected:
   }
 
 private:
-  Client mClient;
   const TokenId mTestTokenId = TokenId(1ULL);
   const std::vector<std::shared_ptr<CustomFee>> mTestCustomFees = { std::make_shared<CustomFixedFee>(),
                                                                     std::make_shared<CustomFractionalFee>(),
@@ -91,8 +87,10 @@ TEST_F(TokenFeeScheduleUpdateTransactionTest, GetSetTokenId)
 TEST_F(TokenFeeScheduleUpdateTransactionTest, GetSetTokenIdFrozen)
 {
   // Given
-  TokenFeeScheduleUpdateTransaction transaction;
-  ASSERT_NO_THROW(transaction.freezeWith(&getTestClient()));
+  TokenFeeScheduleUpdateTransaction transaction = TokenFeeScheduleUpdateTransaction()
+                                                    .setNodeAccountIds({ AccountId(1ULL) })
+                                                    .setTransactionId(TransactionId::generate(AccountId(1ULL)));
+  ASSERT_NO_THROW(transaction.freeze());
 
   // When / Then
   EXPECT_THROW(transaction.setTokenId(getTestTokenId()), IllegalStateException);
@@ -115,8 +113,10 @@ TEST_F(TokenFeeScheduleUpdateTransactionTest, GetSetCustomFees)
 TEST_F(TokenFeeScheduleUpdateTransactionTest, GetSetCustomFeesFrozen)
 {
   // Given
-  TokenFeeScheduleUpdateTransaction transaction;
-  ASSERT_NO_THROW(transaction.freezeWith(&getTestClient()));
+  TokenFeeScheduleUpdateTransaction transaction = TokenFeeScheduleUpdateTransaction()
+                                                    .setNodeAccountIds({ AccountId(1ULL) })
+                                                    .setTransactionId(TransactionId::generate(AccountId(1ULL)));
+  ASSERT_NO_THROW(transaction.freeze());
 
   // When / Then
   EXPECT_THROW(transaction.setCustomFees(getTestCustomFees()), IllegalStateException);

--- a/sdk/tests/unit/TokenFreezeTransactionUnitTests.cc
+++ b/sdk/tests/unit/TokenFreezeTransactionUnitTests.cc
@@ -31,14 +31,10 @@ using namespace Hedera;
 class TokenFreezeTransactionTest : public ::testing::Test
 {
 protected:
-  void SetUp() override { mClient.setOperator(AccountId(), ECDSAsecp256k1PrivateKey::generatePrivateKey().get()); }
-
-  [[nodiscard]] inline const Client& getTestClient() const { return mClient; }
   [[nodiscard]] inline const AccountId& getTestAccountId() const { return mTestAccountId; }
   [[nodiscard]] inline const TokenId& getTestTokenId() const { return mTestTokenId; }
 
 private:
-  Client mClient;
   const AccountId mTestAccountId = AccountId(1ULL, 2ULL, 3ULL);
   const TokenId mTestTokenId = TokenId(4ULL, 5ULL, 6ULL);
 };
@@ -79,8 +75,10 @@ TEST_F(TokenFreezeTransactionTest, GetSetAccountId)
 TEST_F(TokenFreezeTransactionTest, GetSetAccountIdFrozen)
 {
   // Given
-  TokenFreezeTransaction transaction;
-  ASSERT_NO_THROW(transaction.freezeWith(&getTestClient()));
+  TokenFreezeTransaction transaction = TokenFreezeTransaction()
+                                         .setNodeAccountIds({ AccountId(1ULL) })
+                                         .setTransactionId(TransactionId::generate(AccountId(1ULL)));
+  ASSERT_NO_THROW(transaction.freeze());
 
   // When / Then
   EXPECT_THROW(transaction.setAccountId(getTestAccountId()), IllegalStateException);
@@ -103,8 +101,10 @@ TEST_F(TokenFreezeTransactionTest, GetSetTokenId)
 TEST_F(TokenFreezeTransactionTest, GetSetTokenIdFrozen)
 {
   // Given
-  TokenFreezeTransaction transaction;
-  ASSERT_NO_THROW(transaction.freezeWith(&getTestClient()));
+  TokenFreezeTransaction transaction = TokenFreezeTransaction()
+                                         .setNodeAccountIds({ AccountId(1ULL) })
+                                         .setTransactionId(TransactionId::generate(AccountId(1ULL)));
+  ASSERT_NO_THROW(transaction.freeze());
 
   // When / Then
   EXPECT_THROW(transaction.setTokenId(getTestTokenId()), IllegalStateException);

--- a/sdk/tests/unit/TokenGrantKycTransactionUnitTests.cc
+++ b/sdk/tests/unit/TokenGrantKycTransactionUnitTests.cc
@@ -31,14 +31,10 @@ using namespace Hedera;
 class TokenGrantKycTransactionTest : public ::testing::Test
 {
 protected:
-  void SetUp() override { mClient.setOperator(AccountId(), ECDSAsecp256k1PrivateKey::generatePrivateKey().get()); }
-
-  [[nodiscard]] inline const Client& getTestClient() const { return mClient; }
   [[nodiscard]] inline const AccountId& getTestAccountId() const { return mTestAccountId; }
   [[nodiscard]] inline const TokenId& getTestTokenId() const { return mTestTokenId; }
 
 private:
-  Client mClient;
   const AccountId mTestAccountId = AccountId(1ULL, 2ULL, 3ULL);
   const TokenId mTestTokenId = TokenId(4ULL, 5ULL, 6ULL);
 };
@@ -79,8 +75,10 @@ TEST_F(TokenGrantKycTransactionTest, GetSetAccountId)
 TEST_F(TokenGrantKycTransactionTest, GetSetAccountIdFrozen)
 {
   // Given
-  TokenGrantKycTransaction transaction;
-  ASSERT_NO_THROW(transaction.freezeWith(&getTestClient()));
+  TokenGrantKycTransaction transaction = TokenGrantKycTransaction()
+                                           .setNodeAccountIds({ AccountId(1ULL) })
+                                           .setTransactionId(TransactionId::generate(AccountId(1ULL)));
+  ASSERT_NO_THROW(transaction.freeze());
 
   // When / Then
   EXPECT_THROW(transaction.setAccountId(getTestAccountId()), IllegalStateException);
@@ -103,8 +101,10 @@ TEST_F(TokenGrantKycTransactionTest, GetSetTokenId)
 TEST_F(TokenGrantKycTransactionTest, GetSetTokenIdFrozen)
 {
   // Given
-  TokenGrantKycTransaction transaction;
-  ASSERT_NO_THROW(transaction.freezeWith(&getTestClient()));
+  TokenGrantKycTransaction transaction = TokenGrantKycTransaction()
+                                           .setNodeAccountIds({ AccountId(1ULL) })
+                                           .setTransactionId(TransactionId::generate(AccountId(1ULL)));
+  ASSERT_NO_THROW(transaction.freeze());
 
   // When / Then
   EXPECT_THROW(transaction.setTokenId(getTestTokenId()), IllegalStateException);

--- a/sdk/tests/unit/TokenMintTransactionUnitTests.cc
+++ b/sdk/tests/unit/TokenMintTransactionUnitTests.cc
@@ -34,9 +34,6 @@ using namespace Hedera;
 class TokenMintTransactionTest : public ::testing::Test
 {
 protected:
-  void SetUp() override { mClient.setOperator(AccountId(), ECDSAsecp256k1PrivateKey::generatePrivateKey().get()); }
-
-  [[nodiscard]] inline const Client& getTestClient() const { return mClient; }
   [[nodiscard]] inline const TokenId& getTestTokenId() const { return mTestTokenId; }
   [[nodiscard]] inline const uint64_t& getTestAmount() const { return mTestAmount; }
   [[nodiscard]] inline const std::vector<std::vector<std::byte>>& getTestMetadataList() const
@@ -45,7 +42,6 @@ protected:
   }
 
 private:
-  Client mClient;
   const TokenId mTestTokenId = TokenId(1ULL, 2ULL, 3ULL);
   const uint64_t mTestAmount = 4ULL;
   const std::vector<std::vector<std::byte>> mTestMetadataList = {
@@ -97,8 +93,10 @@ TEST_F(TokenMintTransactionTest, GetSetTokenId)
 TEST_F(TokenMintTransactionTest, GetSetTokenIdFrozen)
 {
   // Given
-  TokenMintTransaction transaction;
-  ASSERT_NO_THROW(transaction.freezeWith(&getTestClient()));
+  TokenMintTransaction transaction = TokenMintTransaction()
+                                       .setNodeAccountIds({ AccountId(1ULL) })
+                                       .setTransactionId(TransactionId::generate(AccountId(1ULL)));
+  ASSERT_NO_THROW(transaction.freeze());
 
   // When / Then
   EXPECT_THROW(transaction.setTokenId(getTestTokenId()), IllegalStateException);
@@ -121,8 +119,10 @@ TEST_F(TokenMintTransactionTest, GetSetAmount)
 TEST_F(TokenMintTransactionTest, GetSetAmountFrozen)
 {
   // Given
-  TokenMintTransaction transaction;
-  ASSERT_NO_THROW(transaction.freezeWith(&getTestClient()));
+  TokenMintTransaction transaction = TokenMintTransaction()
+                                       .setNodeAccountIds({ AccountId(1ULL) })
+                                       .setTransactionId(TransactionId::generate(AccountId(1ULL)));
+  ASSERT_NO_THROW(transaction.freeze());
 
   // When / Then
   EXPECT_THROW(transaction.setAmount(getTestAmount()), IllegalStateException);
@@ -145,8 +145,10 @@ TEST_F(TokenMintTransactionTest, GetSetMetadata)
 TEST_F(TokenMintTransactionTest, GetSetMetadataFrozen)
 {
   // Given
-  TokenMintTransaction transaction;
-  ASSERT_NO_THROW(transaction.freezeWith(&getTestClient()));
+  TokenMintTransaction transaction = TokenMintTransaction()
+                                       .setNodeAccountIds({ AccountId(1ULL) })
+                                       .setTransactionId(TransactionId::generate(AccountId(1ULL)));
+  ASSERT_NO_THROW(transaction.freeze());
 
   // When / Then
   EXPECT_THROW(transaction.setMetadata(getTestMetadataList()), IllegalStateException);
@@ -164,4 +166,18 @@ TEST_F(TokenMintTransactionTest, AddMetadata)
 
   // Then
   EXPECT_EQ(tokenMintTransaction.getMetadata(), std::vector<std::vector<std::byte>>{ metadata });
+}
+
+//-----
+TEST_F(TokenMintTransactionTest, AddMetadataFrozen)
+{
+  // Given
+  TokenMintTransaction transaction = TokenMintTransaction()
+                                       .setNodeAccountIds({ AccountId(1ULL) })
+                                       .setTransactionId(TransactionId::generate(AccountId(1ULL)));
+  const std::vector<std::byte> metadata = { std::byte(0x0E), std::byte(0x0F) };
+  ASSERT_NO_THROW(transaction.freeze());
+
+  // When / Then
+  EXPECT_THROW(transaction.addMetadata(metadata), IllegalStateException);
 }

--- a/sdk/tests/unit/TokenPauseTransactionUnitTests.cc
+++ b/sdk/tests/unit/TokenPauseTransactionUnitTests.cc
@@ -30,13 +30,9 @@ using namespace Hedera;
 class TokenPauseTransactionTest : public ::testing::Test
 {
 protected:
-  void SetUp() override { mClient.setOperator(AccountId(), ECDSAsecp256k1PrivateKey::generatePrivateKey().get()); }
-
-  [[nodiscard]] inline const Client& getTestClient() const { return mClient; }
   [[nodiscard]] inline const TokenId& getTestTokenId() const { return mTestTokenId; }
 
 private:
-  Client mClient;
   const TokenId mTestTokenId = TokenId(1ULL);
 };
 
@@ -74,8 +70,10 @@ TEST_F(TokenPauseTransactionTest, GetSetTokenId)
 TEST_F(TokenPauseTransactionTest, GetSetTokenIdFrozen)
 {
   // Given
-  TokenPauseTransaction transaction;
-  ASSERT_NO_THROW(transaction.freezeWith(&getTestClient()));
+  TokenPauseTransaction transaction = TokenPauseTransaction()
+                                        .setNodeAccountIds({ AccountId(1ULL) })
+                                        .setTransactionId(TransactionId::generate(AccountId(1ULL)));
+  ASSERT_NO_THROW(transaction.freeze());
 
   // When / Then
   EXPECT_THROW(transaction.setTokenId(getTestTokenId()), IllegalStateException);

--- a/sdk/tests/unit/TokenRevokeKycTransactionUnitTests.cc
+++ b/sdk/tests/unit/TokenRevokeKycTransactionUnitTests.cc
@@ -31,14 +31,10 @@ using namespace Hedera;
 class TokenRevokeKycTransactionTest : public ::testing::Test
 {
 protected:
-  void SetUp() override { mClient.setOperator(AccountId(), ECDSAsecp256k1PrivateKey::generatePrivateKey().get()); }
-
-  [[nodiscard]] inline const Client& getTestClient() const { return mClient; }
   [[nodiscard]] inline const AccountId& getTestAccountId() const { return mTestAccountId; }
   [[nodiscard]] inline const TokenId& getTestTokenId() const { return mTestTokenId; }
 
 private:
-  Client mClient;
   const AccountId mTestAccountId = AccountId(1ULL, 2ULL, 3ULL);
   const TokenId mTestTokenId = TokenId(4ULL, 5ULL, 6ULL);
 };
@@ -79,8 +75,10 @@ TEST_F(TokenRevokeKycTransactionTest, GetSetAccountId)
 TEST_F(TokenRevokeKycTransactionTest, GetSetAccountIdFrozen)
 {
   // Given
-  TokenRevokeKycTransaction transaction;
-  ASSERT_NO_THROW(transaction.freezeWith(&getTestClient()));
+  TokenRevokeKycTransaction transaction = TokenRevokeKycTransaction()
+                                            .setNodeAccountIds({ AccountId(1ULL) })
+                                            .setTransactionId(TransactionId::generate(AccountId(1ULL)));
+  ASSERT_NO_THROW(transaction.freeze());
 
   // When / Then
   EXPECT_THROW(transaction.setAccountId(getTestAccountId()), IllegalStateException);
@@ -103,8 +101,10 @@ TEST_F(TokenRevokeKycTransactionTest, GetSetTokenId)
 TEST_F(TokenRevokeKycTransactionTest, GetSetTokenIdFrozen)
 {
   // Given
-  TokenRevokeKycTransaction transaction;
-  ASSERT_NO_THROW(transaction.freezeWith(&getTestClient()));
+  TokenRevokeKycTransaction transaction = TokenRevokeKycTransaction()
+                                            .setNodeAccountIds({ AccountId(1ULL) })
+                                            .setTransactionId(TransactionId::generate(AccountId(1ULL)));
+  ASSERT_NO_THROW(transaction.freeze());
 
   // When / Then
   EXPECT_THROW(transaction.setTokenId(getTestTokenId()), IllegalStateException);

--- a/sdk/tests/unit/TokenUnfreezeTransactionUnitTests.cc
+++ b/sdk/tests/unit/TokenUnfreezeTransactionUnitTests.cc
@@ -31,14 +31,10 @@ using namespace Hedera;
 class TokenUnfreezeTransactionTest : public ::testing::Test
 {
 protected:
-  void SetUp() override { mClient.setOperator(AccountId(), ECDSAsecp256k1PrivateKey::generatePrivateKey().get()); }
-
-  [[nodiscard]] inline const Client& getTestClient() const { return mClient; }
   [[nodiscard]] inline const AccountId& getTestAccountId() const { return mTestAccountId; }
   [[nodiscard]] inline const TokenId& getTestTokenId() const { return mTestTokenId; }
 
 private:
-  Client mClient;
   const AccountId mTestAccountId = AccountId(1ULL, 2ULL, 3ULL);
   const TokenId mTestTokenId = TokenId(4ULL, 5ULL, 6ULL);
 };
@@ -79,8 +75,10 @@ TEST_F(TokenUnfreezeTransactionTest, GetSetAccountId)
 TEST_F(TokenUnfreezeTransactionTest, GetSetAccountIdFrozen)
 {
   // Given
-  TokenUnfreezeTransaction transaction;
-  ASSERT_NO_THROW(transaction.freezeWith(&getTestClient()));
+  TokenUnfreezeTransaction transaction = TokenUnfreezeTransaction()
+                                           .setNodeAccountIds({ AccountId(1ULL) })
+                                           .setTransactionId(TransactionId::generate(AccountId(1ULL)));
+  ASSERT_NO_THROW(transaction.freeze());
 
   // When / Then
   EXPECT_THROW(transaction.setAccountId(getTestAccountId()), IllegalStateException);
@@ -103,8 +101,10 @@ TEST_F(TokenUnfreezeTransactionTest, GetSetTokenId)
 TEST_F(TokenUnfreezeTransactionTest, GetSetTokenIdFrozen)
 {
   // Given
-  TokenUnfreezeTransaction transaction;
-  ASSERT_NO_THROW(transaction.freezeWith(&getTestClient()));
+  TokenUnfreezeTransaction transaction = TokenUnfreezeTransaction()
+                                           .setNodeAccountIds({ AccountId(1ULL) })
+                                           .setTransactionId(TransactionId::generate(AccountId(1ULL)));
+  ASSERT_NO_THROW(transaction.freeze());
 
   // When / Then
   EXPECT_THROW(transaction.setTokenId(getTestTokenId()), IllegalStateException);

--- a/sdk/tests/unit/TokenUnpauseTransactionUnitTests.cc
+++ b/sdk/tests/unit/TokenUnpauseTransactionUnitTests.cc
@@ -30,13 +30,9 @@ using namespace Hedera;
 class TokenUnpauseTransactionTest : public ::testing::Test
 {
 protected:
-  void SetUp() override { mClient.setOperator(AccountId(), ECDSAsecp256k1PrivateKey::generatePrivateKey().get()); }
-
-  [[nodiscard]] inline const Client& getTestClient() const { return mClient; }
   [[nodiscard]] inline const TokenId& getTestTokenId() const { return mTestTokenId; }
 
 private:
-  Client mClient;
   const TokenId mTestTokenId = TokenId(1ULL);
 };
 
@@ -74,8 +70,10 @@ TEST_F(TokenUnpauseTransactionTest, GetSetTokenId)
 TEST_F(TokenUnpauseTransactionTest, GetSetTokenIdFrozen)
 {
   // Given
-  TokenUnpauseTransaction transaction;
-  ASSERT_NO_THROW(transaction.freezeWith(&getTestClient()));
+  TokenUnpauseTransaction transaction = TokenUnpauseTransaction()
+                                          .setNodeAccountIds({ AccountId(1ULL) })
+                                          .setTransactionId(TransactionId::generate(AccountId(1ULL)));
+  ASSERT_NO_THROW(transaction.freeze());
 
   // When / Then
   EXPECT_THROW(transaction.setTokenId(getTestTokenId()), IllegalStateException);

--- a/sdk/tests/unit/TokenUpdateTransactionUnitTests.cc
+++ b/sdk/tests/unit/TokenUpdateTransactionUnitTests.cc
@@ -42,9 +42,6 @@ using namespace Hedera;
 class TokenUpdateTransactionTest : public ::testing::Test
 {
 protected:
-  void SetUp() override { mClient.setOperator(AccountId(), ECDSAsecp256k1PrivateKey::generatePrivateKey().get()); }
-
-  [[nodiscard]] inline const Client& getTestClient() const { return mClient; }
   [[nodiscard]] inline const TokenId& getTestTokenId() const { return mTestTokenId; }
   [[nodiscard]] inline const std::string& getTestTokenName() const { return mTestTokenName; }
   [[nodiscard]] inline const std::string& getTestTokenSymbol() const { return mTestTokenSymbol; }
@@ -68,7 +65,6 @@ protected:
   [[nodiscard]] inline const std::shared_ptr<PublicKey>& getTestPauseKey() const { return mTestPauseKey; }
 
 private:
-  Client mClient;
   const TokenId mTestTokenId = TokenId(1ULL, 2ULL, 3ULL);
   const std::string mTestTokenName = "test name";
   const std::string mTestTokenSymbol = "test symbol";
@@ -160,8 +156,10 @@ TEST_F(TokenUpdateTransactionTest, GetSetTokenId)
 TEST_F(TokenUpdateTransactionTest, GetSetTokenIdFrozen)
 {
   // Given
-  TokenUpdateTransaction transaction;
-  ASSERT_NO_THROW(transaction.freezeWith(&getTestClient()));
+  TokenUpdateTransaction transaction = TokenUpdateTransaction()
+                                         .setNodeAccountIds({ AccountId(1ULL) })
+                                         .setTransactionId(TransactionId::generate(AccountId(1ULL)));
+  ASSERT_NO_THROW(transaction.freeze());
 
   // When / Then
   EXPECT_THROW(transaction.setTokenId(getTestTokenId()), IllegalStateException);
@@ -184,8 +182,10 @@ TEST_F(TokenUpdateTransactionTest, GetSetName)
 TEST_F(TokenUpdateTransactionTest, GetSetNameFrozen)
 {
   // Given
-  TokenUpdateTransaction transaction;
-  ASSERT_NO_THROW(transaction.freezeWith(&getTestClient()));
+  TokenUpdateTransaction transaction = TokenUpdateTransaction()
+                                         .setNodeAccountIds({ AccountId(1ULL) })
+                                         .setTransactionId(TransactionId::generate(AccountId(1ULL)));
+  ASSERT_NO_THROW(transaction.freeze());
 
   // When / Then
   EXPECT_THROW(transaction.setTokenName(getTestTokenName()), IllegalStateException);
@@ -208,8 +208,10 @@ TEST_F(TokenUpdateTransactionTest, GetSetSymbol)
 TEST_F(TokenUpdateTransactionTest, GetSetSymbolFrozen)
 {
   // Given
-  TokenUpdateTransaction transaction;
-  ASSERT_NO_THROW(transaction.freezeWith(&getTestClient()));
+  TokenUpdateTransaction transaction = TokenUpdateTransaction()
+                                         .setNodeAccountIds({ AccountId(1ULL) })
+                                         .setTransactionId(TransactionId::generate(AccountId(1ULL)));
+  ASSERT_NO_THROW(transaction.freeze());
 
   // When / Then
   EXPECT_THROW(transaction.setTokenSymbol(getTestTokenSymbol()), IllegalStateException);
@@ -232,8 +234,10 @@ TEST_F(TokenUpdateTransactionTest, GetSetTreasuryAccountId)
 TEST_F(TokenUpdateTransactionTest, GetSetTreasuryAccountIdFrozen)
 {
   // Given
-  TokenUpdateTransaction transaction;
-  ASSERT_NO_THROW(transaction.freezeWith(&getTestClient()));
+  TokenUpdateTransaction transaction = TokenUpdateTransaction()
+                                         .setNodeAccountIds({ AccountId(1ULL) })
+                                         .setTransactionId(TransactionId::generate(AccountId(1ULL)));
+  ASSERT_NO_THROW(transaction.freeze());
 
   // When / Then
   EXPECT_THROW(transaction.setTreasuryAccountId(getTestTreasuryAccountId()), IllegalStateException);
@@ -256,8 +260,10 @@ TEST_F(TokenUpdateTransactionTest, GetSetAdminKey)
 TEST_F(TokenUpdateTransactionTest, GetSetAdminKeyFrozen)
 {
   // Given
-  TokenUpdateTransaction transaction;
-  ASSERT_NO_THROW(transaction.freezeWith(&getTestClient()));
+  TokenUpdateTransaction transaction = TokenUpdateTransaction()
+                                         .setNodeAccountIds({ AccountId(1ULL) })
+                                         .setTransactionId(TransactionId::generate(AccountId(1ULL)));
+  ASSERT_NO_THROW(transaction.freeze());
 
   // When / Then
   EXPECT_THROW(transaction.setAdminKey(getTestAdminKey()), IllegalStateException);
@@ -280,8 +286,10 @@ TEST_F(TokenUpdateTransactionTest, GetSetKycKey)
 TEST_F(TokenUpdateTransactionTest, GetSetKycKeyFrozen)
 {
   // Given
-  TokenUpdateTransaction transaction;
-  ASSERT_NO_THROW(transaction.freezeWith(&getTestClient()));
+  TokenUpdateTransaction transaction = TokenUpdateTransaction()
+                                         .setNodeAccountIds({ AccountId(1ULL) })
+                                         .setTransactionId(TransactionId::generate(AccountId(1ULL)));
+  ASSERT_NO_THROW(transaction.freeze());
 
   // When / Then
   EXPECT_THROW(transaction.setKycKey(getTestKycKey()), IllegalStateException);
@@ -304,8 +312,10 @@ TEST_F(TokenUpdateTransactionTest, GetSetFreezeKey)
 TEST_F(TokenUpdateTransactionTest, GetSetFreezeKeyFrozen)
 {
   // Given
-  TokenUpdateTransaction transaction;
-  ASSERT_NO_THROW(transaction.freezeWith(&getTestClient()));
+  TokenUpdateTransaction transaction = TokenUpdateTransaction()
+                                         .setNodeAccountIds({ AccountId(1ULL) })
+                                         .setTransactionId(TransactionId::generate(AccountId(1ULL)));
+  ASSERT_NO_THROW(transaction.freeze());
 
   // When / Then
   EXPECT_THROW(transaction.setFreezeKey(getTestFreezeKey()), IllegalStateException);
@@ -328,8 +338,10 @@ TEST_F(TokenUpdateTransactionTest, GetSetWipeKey)
 TEST_F(TokenUpdateTransactionTest, GetSetWipeKeyFrozen)
 {
   // Given
-  TokenUpdateTransaction transaction;
-  ASSERT_NO_THROW(transaction.freezeWith(&getTestClient()));
+  TokenUpdateTransaction transaction = TokenUpdateTransaction()
+                                         .setNodeAccountIds({ AccountId(1ULL) })
+                                         .setTransactionId(TransactionId::generate(AccountId(1ULL)));
+  ASSERT_NO_THROW(transaction.freeze());
 
   // When / Then
   EXPECT_THROW(transaction.setWipeKey(getTestWipeKey()), IllegalStateException);
@@ -352,8 +364,10 @@ TEST_F(TokenUpdateTransactionTest, GetSetSupplyKey)
 TEST_F(TokenUpdateTransactionTest, GetSetSupplyKeyFrozen)
 {
   // Given
-  TokenUpdateTransaction transaction;
-  ASSERT_NO_THROW(transaction.freezeWith(&getTestClient()));
+  TokenUpdateTransaction transaction = TokenUpdateTransaction()
+                                         .setNodeAccountIds({ AccountId(1ULL) })
+                                         .setTransactionId(TransactionId::generate(AccountId(1ULL)));
+  ASSERT_NO_THROW(transaction.freeze());
 
   // When / Then
   EXPECT_THROW(transaction.setSupplyKey(getTestSupplyKey()), IllegalStateException);
@@ -376,8 +390,10 @@ TEST_F(TokenUpdateTransactionTest, GetSetAutoRenewAccountId)
 TEST_F(TokenUpdateTransactionTest, GetSetAutoRenewAccountIdFrozen)
 {
   // Given
-  TokenUpdateTransaction transaction;
-  ASSERT_NO_THROW(transaction.freezeWith(&getTestClient()));
+  TokenUpdateTransaction transaction = TokenUpdateTransaction()
+                                         .setNodeAccountIds({ AccountId(1ULL) })
+                                         .setTransactionId(TransactionId::generate(AccountId(1ULL)));
+  ASSERT_NO_THROW(transaction.freeze());
 
   // When / Then
   EXPECT_THROW(transaction.setAutoRenewAccountId(getTestAutoRenewAccountId()), IllegalStateException);
@@ -400,8 +416,10 @@ TEST_F(TokenUpdateTransactionTest, GetSetAutoRenewPeriod)
 TEST_F(TokenUpdateTransactionTest, GetSetAutoRenewPeriodFrozen)
 {
   // Given
-  TokenUpdateTransaction transaction;
-  ASSERT_NO_THROW(transaction.freezeWith(&getTestClient()));
+  TokenUpdateTransaction transaction = TokenUpdateTransaction()
+                                         .setNodeAccountIds({ AccountId(1ULL) })
+                                         .setTransactionId(TransactionId::generate(AccountId(1ULL)));
+  ASSERT_NO_THROW(transaction.freeze());
 
   // When / Then
   EXPECT_THROW(transaction.setAutoRenewPeriod(getTestAutoRenewPeriod()), IllegalStateException);
@@ -424,8 +442,10 @@ TEST_F(TokenUpdateTransactionTest, GetSetExpirationTime)
 TEST_F(TokenUpdateTransactionTest, GetSetExpirationTimeFrozen)
 {
   // Given
-  TokenUpdateTransaction transaction;
-  ASSERT_NO_THROW(transaction.freezeWith(&getTestClient()));
+  TokenUpdateTransaction transaction = TokenUpdateTransaction()
+                                         .setNodeAccountIds({ AccountId(1ULL) })
+                                         .setTransactionId(TransactionId::generate(AccountId(1ULL)));
+  ASSERT_NO_THROW(transaction.freeze());
 
   // When / Then
   EXPECT_THROW(transaction.setExpirationTime(getTestExpirationTime()), IllegalStateException);
@@ -448,8 +468,10 @@ TEST_F(TokenUpdateTransactionTest, GetSetMemo)
 TEST_F(TokenUpdateTransactionTest, GetSetMemoFrozen)
 {
   // Given
-  TokenUpdateTransaction transaction;
-  ASSERT_NO_THROW(transaction.freezeWith(&getTestClient()));
+  TokenUpdateTransaction transaction = TokenUpdateTransaction()
+                                         .setNodeAccountIds({ AccountId(1ULL) })
+                                         .setTransactionId(TransactionId::generate(AccountId(1ULL)));
+  ASSERT_NO_THROW(transaction.freeze());
 
   // When / Then
   EXPECT_THROW(transaction.setTokenMemo(getTestTokenMemo()), IllegalStateException);
@@ -472,8 +494,10 @@ TEST_F(TokenUpdateTransactionTest, GetSetFeeScheduleKey)
 TEST_F(TokenUpdateTransactionTest, GetSetFeeScheduleKeyFrozen)
 {
   // Given
-  TokenUpdateTransaction transaction;
-  ASSERT_NO_THROW(transaction.freezeWith(&getTestClient()));
+  TokenUpdateTransaction transaction = TokenUpdateTransaction()
+                                         .setNodeAccountIds({ AccountId(1ULL) })
+                                         .setTransactionId(TransactionId::generate(AccountId(1ULL)));
+  ASSERT_NO_THROW(transaction.freeze());
 
   // When / Then
   EXPECT_THROW(transaction.setFeeScheduleKey(getTestFeeScheduleKey()), IllegalStateException);
@@ -496,8 +520,10 @@ TEST_F(TokenUpdateTransactionTest, GetSetPauseKey)
 TEST_F(TokenUpdateTransactionTest, GetSetPauseKeyFrozen)
 {
   // Given
-  TokenUpdateTransaction transaction;
-  ASSERT_NO_THROW(transaction.freezeWith(&getTestClient()));
+  TokenUpdateTransaction transaction = TokenUpdateTransaction()
+                                         .setNodeAccountIds({ AccountId(1ULL) })
+                                         .setTransactionId(TransactionId::generate(AccountId(1ULL)));
+  ASSERT_NO_THROW(transaction.freeze());
 
   // When / Then
   EXPECT_THROW(transaction.setPauseKey(getTestPauseKey()), IllegalStateException);

--- a/sdk/tests/unit/TokenWipeTransactionUnitTests.cc
+++ b/sdk/tests/unit/TokenWipeTransactionUnitTests.cc
@@ -30,16 +30,12 @@ using namespace Hedera;
 class TokenWipeTransactionTest : public ::testing::Test
 {
 protected:
-  void SetUp() override { mClient.setOperator(AccountId(), ECDSAsecp256k1PrivateKey::generatePrivateKey().get()); }
-
-  [[nodiscard]] inline const Client& getTestClient() const { return mClient; }
   [[nodiscard]] inline const TokenId& getTestTokenId() const { return mTestTokenId; }
   [[nodiscard]] inline const AccountId& getTestAccountId() const { return mTestAccountId; }
   [[nodiscard]] inline const uint64_t& getTestAmount() const { return mTestAmount; }
   [[nodiscard]] inline const std::vector<uint64_t>& getTestSerialNumbers() const { return mTestSerialNumbers; }
 
 private:
-  Client mClient;
   const TokenId mTestTokenId = TokenId(1ULL, 2ULL, 3ULL);
   const AccountId mTestAccountId = AccountId(4ULL, 5ULL, 6ULL);
   const uint64_t mTestAmount = 7ULL;
@@ -90,8 +86,10 @@ TEST_F(TokenWipeTransactionTest, GetSetTokenId)
 TEST_F(TokenWipeTransactionTest, GetSetTokenIdFrozen)
 {
   // Given
-  TokenWipeTransaction transaction;
-  ASSERT_NO_THROW(transaction.freezeWith(&getTestClient()));
+  TokenWipeTransaction transaction = TokenWipeTransaction()
+                                       .setNodeAccountIds({ AccountId(1ULL) })
+                                       .setTransactionId(TransactionId::generate(AccountId(1ULL)));
+  ASSERT_NO_THROW(transaction.freeze());
 
   // When / Then
   EXPECT_THROW(transaction.setTokenId(getTestTokenId()), IllegalStateException);
@@ -114,8 +112,10 @@ TEST_F(TokenWipeTransactionTest, GetSetAccountId)
 TEST_F(TokenWipeTransactionTest, GetSetAccountIdFrozen)
 {
   // Given
-  TokenWipeTransaction transaction;
-  ASSERT_NO_THROW(transaction.freezeWith(&getTestClient()));
+  TokenWipeTransaction transaction = TokenWipeTransaction()
+                                       .setNodeAccountIds({ AccountId(1ULL) })
+                                       .setTransactionId(TransactionId::generate(AccountId(1ULL)));
+  ASSERT_NO_THROW(transaction.freeze());
 
   // When / Then
   EXPECT_THROW(transaction.setAccountId(getTestAccountId()), IllegalStateException);
@@ -138,8 +138,10 @@ TEST_F(TokenWipeTransactionTest, GetSetAmount)
 TEST_F(TokenWipeTransactionTest, GetSetAmountFrozen)
 {
   // Given
-  TokenWipeTransaction transaction;
-  ASSERT_NO_THROW(transaction.freezeWith(&getTestClient()));
+  TokenWipeTransaction transaction = TokenWipeTransaction()
+                                       .setNodeAccountIds({ AccountId(1ULL) })
+                                       .setTransactionId(TransactionId::generate(AccountId(1ULL)));
+  ASSERT_NO_THROW(transaction.freeze());
 
   // When / Then
   EXPECT_THROW(transaction.setAmount(getTestAmount()), IllegalStateException);
@@ -162,8 +164,10 @@ TEST_F(TokenWipeTransactionTest, GetSetSerialNumbers)
 TEST_F(TokenWipeTransactionTest, GetSetSerialNumbersFrozen)
 {
   // Given
-  TokenWipeTransaction transaction;
-  ASSERT_NO_THROW(transaction.freezeWith(&getTestClient()));
+  TokenWipeTransaction transaction = TokenWipeTransaction()
+                                       .setNodeAccountIds({ AccountId(1ULL) })
+                                       .setTransactionId(TransactionId::generate(AccountId(1ULL)));
+  ASSERT_NO_THROW(transaction.freeze());
 
   // When / Then
   EXPECT_THROW(transaction.setSerialNumbers(getTestSerialNumbers()), IllegalStateException);

--- a/sdk/tests/unit/TopicCreateTransactionUnitTests.cc
+++ b/sdk/tests/unit/TopicCreateTransactionUnitTests.cc
@@ -33,9 +33,6 @@ using namespace Hedera;
 class TopicCreateTransactionTest : public ::testing::Test
 {
 protected:
-  void SetUp() override { mClient.setOperator(AccountId(), ECDSAsecp256k1PrivateKey::generatePrivateKey().get()); }
-
-  [[nodiscard]] inline const Client& getTestClient() const { return mClient; }
   [[nodiscard]] inline const std::string& getTestTopicMemo() const { return mTestTopicMemo; }
   [[nodiscard]] inline const std::shared_ptr<ED25519PrivateKey>& getTestAdminKey() const { return mTestAdminKey; }
   [[nodiscard]] inline const std::shared_ptr<ED25519PrivateKey>& getTestSubmitKey() const { return mTestSubmitKey; }
@@ -46,7 +43,6 @@ protected:
   [[nodiscard]] inline const AccountId& getTestAutoRenewAccountId() const { return mTestAutoRenewAccountId; }
 
 private:
-  Client mClient;
   const std::string mTestTopicMemo = "test topic memo";
   const std::shared_ptr<ED25519PrivateKey> mTestAdminKey = ED25519PrivateKey::generatePrivateKey();
   const std::shared_ptr<ED25519PrivateKey> mTestSubmitKey = ED25519PrivateKey::generatePrivateKey();
@@ -108,8 +104,10 @@ TEST_F(TopicCreateTransactionTest, GetSetMemo)
 TEST_F(TopicCreateTransactionTest, GetSetMemoFrozen)
 {
   // Given
-  TopicCreateTransaction transaction;
-  ASSERT_NO_THROW(transaction.freezeWith(&getTestClient()));
+  TopicCreateTransaction transaction = TopicCreateTransaction()
+                                         .setNodeAccountIds({ AccountId(1ULL) })
+                                         .setTransactionId(TransactionId::generate(AccountId(1ULL)));
+  ASSERT_NO_THROW(transaction.freeze());
 
   // When / Then
   EXPECT_THROW(transaction.setMemo(getTestTopicMemo()), IllegalStateException);
@@ -132,8 +130,10 @@ TEST_F(TopicCreateTransactionTest, GetSetAdminKey)
 TEST_F(TopicCreateTransactionTest, GetSetAdminKeyFrozen)
 {
   // Given
-  TopicCreateTransaction transaction;
-  ASSERT_NO_THROW(transaction.freezeWith(&getTestClient()));
+  TopicCreateTransaction transaction = TopicCreateTransaction()
+                                         .setNodeAccountIds({ AccountId(1ULL) })
+                                         .setTransactionId(TransactionId::generate(AccountId(1ULL)));
+  ASSERT_NO_THROW(transaction.freeze());
 
   // When / Then
   EXPECT_THROW(transaction.setAdminKey(getTestAdminKey()), IllegalStateException);
@@ -156,8 +156,10 @@ TEST_F(TopicCreateTransactionTest, GetSetSubmitKey)
 TEST_F(TopicCreateTransactionTest, GetSetSubmitKeyFrozen)
 {
   // Given
-  TopicCreateTransaction transaction;
-  ASSERT_NO_THROW(transaction.freezeWith(&getTestClient()));
+  TopicCreateTransaction transaction = TopicCreateTransaction()
+                                         .setNodeAccountIds({ AccountId(1ULL) })
+                                         .setTransactionId(TransactionId::generate(AccountId(1ULL)));
+  ASSERT_NO_THROW(transaction.freeze());
 
   // When / Then
   EXPECT_THROW(transaction.setSubmitKey(getTestSubmitKey()), IllegalStateException);
@@ -180,8 +182,10 @@ TEST_F(TopicCreateTransactionTest, GetSetAutoRenewPeriod)
 TEST_F(TopicCreateTransactionTest, GetSetAutoRenewPeriodFrozen)
 {
   // Given
-  TopicCreateTransaction transaction;
-  ASSERT_NO_THROW(transaction.freezeWith(&getTestClient()));
+  TopicCreateTransaction transaction = TopicCreateTransaction()
+                                         .setNodeAccountIds({ AccountId(1ULL) })
+                                         .setTransactionId(TransactionId::generate(AccountId(1ULL)));
+  ASSERT_NO_THROW(transaction.freeze());
 
   // When / Then
   EXPECT_THROW(transaction.setAutoRenewPeriod(getTestAutoRenewPeriod()), IllegalStateException);
@@ -204,8 +208,10 @@ TEST_F(TopicCreateTransactionTest, GetSetAutoRenewAccountId)
 TEST_F(TopicCreateTransactionTest, GetSetAutoRenewAccountIdFrozen)
 {
   // Given
-  TopicCreateTransaction transaction;
-  ASSERT_NO_THROW(transaction.freezeWith(&getTestClient()));
+  TopicCreateTransaction transaction = TopicCreateTransaction()
+                                         .setNodeAccountIds({ AccountId(1ULL) })
+                                         .setTransactionId(TransactionId::generate(AccountId(1ULL)));
+  ASSERT_NO_THROW(transaction.freeze());
 
   // When / Then
   EXPECT_THROW(transaction.setAutoRenewAccountId(getTestAutoRenewAccountId()), IllegalStateException);

--- a/sdk/tests/unit/TopicDeleteTransactionUnitTests.cc
+++ b/sdk/tests/unit/TopicDeleteTransactionUnitTests.cc
@@ -30,13 +30,9 @@ using namespace Hedera;
 class TopicDeleteTransactionTest : public ::testing::Test
 {
 protected:
-  void SetUp() override { mClient.setOperator(AccountId(), ECDSAsecp256k1PrivateKey::generatePrivateKey().get()); }
-
-  [[nodiscard]] inline const Client& getTestClient() const { return mClient; }
   [[nodiscard]] inline const TopicId& getTestTopicId() const { return mTestTopicId; }
 
 private:
-  Client mClient;
   const TopicId mTestTopicId = TopicId(1ULL);
 };
 
@@ -84,8 +80,10 @@ TEST_F(TopicDeleteTransactionTest, GetSetTopicId)
 TEST_F(TopicDeleteTransactionTest, GetSetTopicIdFrozen)
 {
   // Given
-  TopicDeleteTransaction transaction;
-  ASSERT_NO_THROW(transaction.freezeWith(&getTestClient()));
+  TopicDeleteTransaction transaction = TopicDeleteTransaction()
+                                         .setNodeAccountIds({ AccountId(1ULL) })
+                                         .setTransactionId(TransactionId::generate(AccountId(1ULL)));
+  ASSERT_NO_THROW(transaction.freeze());
 
   // When / Then
   EXPECT_THROW(transaction.setTopicId(getTestTopicId()), IllegalStateException);

--- a/sdk/tests/unit/TopicMessageSubmitTransactionUnitTests.cc
+++ b/sdk/tests/unit/TopicMessageSubmitTransactionUnitTests.cc
@@ -31,14 +31,10 @@ using namespace Hedera;
 class TopicMessageSubmitTransactionTest : public ::testing::Test
 {
 protected:
-  void SetUp() override { mClient.setOperator(AccountId(), ECDSAsecp256k1PrivateKey::generatePrivateKey().get()); }
-
-  [[nodiscard]] inline const Client& getTestClient() const { return mClient; }
   [[nodiscard]] inline const TopicId& getTestTopicId() const { return mTestTopicId; }
   [[nodiscard]] inline const std::vector<std::byte>& getTestMessage() const { return mTestMessage; }
 
 private:
-  Client mClient;
   const TopicId mTestTopicId = TopicId(1ULL, 2ULL, 3ULL);
   const std::vector<std::byte> mTestMessage = { std::byte(0x04), std::byte(0x05), std::byte(0x06) };
 };
@@ -78,8 +74,10 @@ TEST_F(TopicMessageSubmitTransactionTest, GetSetTopicId)
 TEST_F(TopicMessageSubmitTransactionTest, GetSetTopicIdFrozen)
 {
   // Given
-  TopicMessageSubmitTransaction transaction;
-  ASSERT_NO_THROW(transaction.freezeWith(&getTestClient()));
+  TopicMessageSubmitTransaction transaction = TopicMessageSubmitTransaction()
+                                                .setNodeAccountIds({ AccountId(1ULL) })
+                                                .setTransactionId(TransactionId::generate(AccountId(1ULL)));
+  ASSERT_NO_THROW(transaction.freeze());
 
   // When / Then
   EXPECT_THROW(transaction.setTopicId(getTestTopicId()), IllegalStateException);
@@ -105,10 +103,14 @@ TEST_F(TopicMessageSubmitTransactionTest, GetSetMessage)
 TEST_F(TopicMessageSubmitTransactionTest, GetSetMessageFrozen)
 {
   // Given
-  TopicMessageSubmitTransaction transactionWithBytes;
-  TopicMessageSubmitTransaction transactionWithStr;
-  ASSERT_NO_THROW(transactionWithBytes.freezeWith(&getTestClient()));
-  ASSERT_NO_THROW(transactionWithStr.freezeWith(&getTestClient()));
+  TopicMessageSubmitTransaction transactionWithBytes = TopicMessageSubmitTransaction()
+                                                         .setNodeAccountIds({ AccountId(1ULL) })
+                                                         .setTransactionId(TransactionId::generate(AccountId(1ULL)));
+  TopicMessageSubmitTransaction transactionWithStr = TopicMessageSubmitTransaction()
+                                                       .setNodeAccountIds({ AccountId(1ULL) })
+                                                       .setTransactionId(TransactionId::generate(AccountId(1ULL)));
+  ASSERT_NO_THROW(transactionWithBytes.freeze());
+  ASSERT_NO_THROW(transactionWithStr.freeze());
 
   // When / Then
   EXPECT_THROW(transactionWithBytes.setMessage(getTestMessage()), IllegalStateException);

--- a/sdk/tests/unit/TopicUpdateTransactionUnitTests.cc
+++ b/sdk/tests/unit/TopicUpdateTransactionUnitTests.cc
@@ -34,9 +34,6 @@ using namespace Hedera;
 class TopicUpdateTransactionTest : public ::testing::Test
 {
 protected:
-  void SetUp() override { mClient.setOperator(AccountId(), ECDSAsecp256k1PrivateKey::generatePrivateKey().get()); }
-
-  [[nodiscard]] inline const Client& getTestClient() const { return mClient; }
   [[nodiscard]] inline const TopicId& getTestTopicId() const { return mTestTopicId; }
   [[nodiscard]] inline const std::string& getTestTopicMemo() const { return mTestTopicMemo; }
   [[nodiscard]] inline const std::chrono::system_clock::time_point& getTestExpirationTime() const
@@ -52,7 +49,6 @@ protected:
   [[nodiscard]] inline const AccountId& getTestAutoRenewAccountId() const { return mTestAutoRenewAccountId; }
 
 private:
-  Client mClient;
   const TopicId mTestTopicId = TopicId(1ULL, 2ULL, 3ULL);
   const std::string mTestTopicMemo = "test topic memo";
   const std::chrono::system_clock::time_point mTestExpirationTime = std::chrono::system_clock::now();
@@ -120,8 +116,10 @@ TEST_F(TopicUpdateTransactionTest, GetSetTopicId)
 TEST_F(TopicUpdateTransactionTest, GetSetTopicIdFrozen)
 {
   // Given
-  TopicUpdateTransaction transaction;
-  ASSERT_NO_THROW(transaction.freezeWith(&getTestClient()));
+  TopicUpdateTransaction transaction = TopicUpdateTransaction()
+                                         .setNodeAccountIds({ AccountId(1ULL) })
+                                         .setTransactionId(TransactionId::generate(AccountId(1ULL)));
+  ASSERT_NO_THROW(transaction.freeze());
 
   // When / Then
   EXPECT_THROW(transaction.setTopicId(getTestTopicId()), IllegalStateException);
@@ -144,8 +142,10 @@ TEST_F(TopicUpdateTransactionTest, GetSetMemo)
 TEST_F(TopicUpdateTransactionTest, GetSetMemoFrozen)
 {
   // Given
-  TopicUpdateTransaction transaction;
-  ASSERT_NO_THROW(transaction.freezeWith(&getTestClient()));
+  TopicUpdateTransaction transaction = TopicUpdateTransaction()
+                                         .setNodeAccountIds({ AccountId(1ULL) })
+                                         .setTransactionId(TransactionId::generate(AccountId(1ULL)));
+  ASSERT_NO_THROW(transaction.freeze());
 
   // When / Then
   EXPECT_THROW(transaction.setMemo(getTestTopicMemo()), IllegalStateException);
@@ -169,8 +169,10 @@ TEST_F(TopicUpdateTransactionTest, ClearMemo)
 TEST_F(TopicUpdateTransactionTest, ClearMemoFrozen)
 {
   // Given
-  TopicUpdateTransaction transaction;
-  ASSERT_NO_THROW(transaction.freezeWith(&getTestClient()));
+  TopicUpdateTransaction transaction = TopicUpdateTransaction()
+                                         .setNodeAccountIds({ AccountId(1ULL) })
+                                         .setTransactionId(TransactionId::generate(AccountId(1ULL)));
+  ASSERT_NO_THROW(transaction.freeze());
 
   // When / Then
   EXPECT_THROW(transaction.clearTopicMemo(), IllegalStateException);
@@ -193,8 +195,10 @@ TEST_F(TopicUpdateTransactionTest, GetSetExpirationTime)
 TEST_F(TopicUpdateTransactionTest, GetSetExpirationTimeFrozen)
 {
   // Given
-  TopicUpdateTransaction transaction;
-  ASSERT_NO_THROW(transaction.freezeWith(&getTestClient()));
+  TopicUpdateTransaction transaction = TopicUpdateTransaction()
+                                         .setNodeAccountIds({ AccountId(1ULL) })
+                                         .setTransactionId(TransactionId::generate(AccountId(1ULL)));
+  ASSERT_NO_THROW(transaction.freeze());
 
   // When / Then
   EXPECT_THROW(transaction.setExpirationTime(getTestExpirationTime()), IllegalStateException);
@@ -217,8 +221,10 @@ TEST_F(TopicUpdateTransactionTest, GetSetAdminKey)
 TEST_F(TopicUpdateTransactionTest, GetSetAdminKeyFrozen)
 {
   // Given
-  TopicUpdateTransaction transaction;
-  ASSERT_NO_THROW(transaction.freezeWith(&getTestClient()));
+  TopicUpdateTransaction transaction = TopicUpdateTransaction()
+                                         .setNodeAccountIds({ AccountId(1ULL) })
+                                         .setTransactionId(TransactionId::generate(AccountId(1ULL)));
+  ASSERT_NO_THROW(transaction.freeze());
 
   // When / Then
   EXPECT_THROW(transaction.setAdminKey(getTestAdminKey()), IllegalStateException);
@@ -241,8 +247,10 @@ TEST_F(TopicUpdateTransactionTest, ClearAdminKey)
 TEST_F(TopicUpdateTransactionTest, ClearAdminKeyFrozen)
 {
   // Given
-  TopicUpdateTransaction transaction;
-  ASSERT_NO_THROW(transaction.freezeWith(&getTestClient()));
+  TopicUpdateTransaction transaction = TopicUpdateTransaction()
+                                         .setNodeAccountIds({ AccountId(1ULL) })
+                                         .setTransactionId(TransactionId::generate(AccountId(1ULL)));
+  ASSERT_NO_THROW(transaction.freeze());
 
   // When / Then
   EXPECT_THROW(transaction.clearAdminKey(), IllegalStateException);
@@ -265,8 +273,10 @@ TEST_F(TopicUpdateTransactionTest, GetSetSubmitKey)
 TEST_F(TopicUpdateTransactionTest, GetSetSubmitKeyFrozen)
 {
   // Given
-  TopicUpdateTransaction transaction;
-  ASSERT_NO_THROW(transaction.freezeWith(&getTestClient()));
+  TopicUpdateTransaction transaction = TopicUpdateTransaction()
+                                         .setNodeAccountIds({ AccountId(1ULL) })
+                                         .setTransactionId(TransactionId::generate(AccountId(1ULL)));
+  ASSERT_NO_THROW(transaction.freeze());
 
   // When / Then
   EXPECT_THROW(transaction.setSubmitKey(getTestSubmitKey()), IllegalStateException);
@@ -289,8 +299,10 @@ TEST_F(TopicUpdateTransactionTest, ClearSubmitKey)
 TEST_F(TopicUpdateTransactionTest, ClearSubmitKeyFrozen)
 {
   // Given
-  TopicUpdateTransaction transaction;
-  ASSERT_NO_THROW(transaction.freezeWith(&getTestClient()));
+  TopicUpdateTransaction transaction = TopicUpdateTransaction()
+                                         .setNodeAccountIds({ AccountId(1ULL) })
+                                         .setTransactionId(TransactionId::generate(AccountId(1ULL)));
+  ASSERT_NO_THROW(transaction.freeze());
 
   // When / Then
   EXPECT_THROW(transaction.clearAdminKey(), IllegalStateException);
@@ -313,8 +325,10 @@ TEST_F(TopicUpdateTransactionTest, GetSetAutoRenewPeriod)
 TEST_F(TopicUpdateTransactionTest, GetSetAutoRenewPeriodFrozen)
 {
   // Given
-  TopicUpdateTransaction transaction;
-  ASSERT_NO_THROW(transaction.freezeWith(&getTestClient()));
+  TopicUpdateTransaction transaction = TopicUpdateTransaction()
+                                         .setNodeAccountIds({ AccountId(1ULL) })
+                                         .setTransactionId(TransactionId::generate(AccountId(1ULL)));
+  ASSERT_NO_THROW(transaction.freeze());
 
   // When / Then
   EXPECT_THROW(transaction.setAutoRenewPeriod(getTestAutoRenewPeriod()), IllegalStateException);
@@ -337,8 +351,10 @@ TEST_F(TopicUpdateTransactionTest, GetSetAutoRenewAccountId)
 TEST_F(TopicUpdateTransactionTest, GetSetAutoRenewAccountIdFrozen)
 {
   // Given
-  TopicUpdateTransaction transaction;
-  ASSERT_NO_THROW(transaction.freezeWith(&getTestClient()));
+  TopicUpdateTransaction transaction = TopicUpdateTransaction()
+                                         .setNodeAccountIds({ AccountId(1ULL) })
+                                         .setTransactionId(TransactionId::generate(AccountId(1ULL)));
+  ASSERT_NO_THROW(transaction.freeze());
 
   // When / Then
   EXPECT_THROW(transaction.setAutoRenewAccountId(getTestAutoRenewAccountId()), IllegalStateException);
@@ -362,8 +378,10 @@ TEST_F(TopicUpdateTransactionTest, ClearAutoRenewAccountId)
 TEST_F(TopicUpdateTransactionTest, ClearAutoRenewAccountIdFrozen)
 {
   // Given
-  TopicUpdateTransaction transaction;
-  ASSERT_NO_THROW(transaction.freezeWith(&getTestClient()));
+  TopicUpdateTransaction transaction = TopicUpdateTransaction()
+                                         .setNodeAccountIds({ AccountId(1ULL) })
+                                         .setTransactionId(TransactionId::generate(AccountId(1ULL)));
+  ASSERT_NO_THROW(transaction.freeze());
 
   // When / Then
   EXPECT_THROW(transaction.clearAutoRenewAccountId(), IllegalStateException);

--- a/sdk/tests/unit/TransactionTest.cc
+++ b/sdk/tests/unit/TransactionTest.cc
@@ -66,6 +66,7 @@
 #include <proto/transaction.pb.h>
 #include <proto/transaction_body.pb.h>
 #include <proto/transaction_contents.pb.h>
+#include <proto/transaction_list.pb.h>
 
 using namespace Hedera;
 
@@ -83,26 +84,6 @@ TEST_F(TransactionTest, AccountApproveAllowanceFromTransactionBodyBytes)
   // When
   const WrappedTransaction wrappedTx = Transaction<AccountAllowanceApproveTransaction>::fromBytes(
     internal::Utilities::stringToByteVector(txBody.SerializeAsString()));
-
-  // Then
-  ASSERT_EQ(wrappedTx.getTransactionType(), TransactionType::ACCOUNT_ALLOWANCE_APPROVE_TRANSACTION);
-  EXPECT_NE(wrappedTx.getTransaction<AccountAllowanceApproveTransaction>(), nullptr);
-}
-
-//-----
-TEST_F(TransactionTest, AccountApproveAllowanceFromSignedTransactionBytes)
-{
-  // Given
-  proto::TransactionBody txBody;
-  txBody.set_allocated_cryptoapproveallowance(new proto::CryptoApproveAllowanceTransactionBody);
-
-  proto::SignedTransaction signedTx;
-  signedTx.set_bodybytes(txBody.SerializeAsString());
-  // SignatureMap not required
-
-  // When
-  const WrappedTransaction wrappedTx = Transaction<AccountAllowanceApproveTransaction>::fromBytes(
-    internal::Utilities::stringToByteVector(signedTx.SerializeAsString()));
 
   // Then
   ASSERT_EQ(wrappedTx.getTransactionType(), TransactionType::ACCOUNT_ALLOWANCE_APPROVE_TRANSACTION);
@@ -133,6 +114,32 @@ TEST_F(TransactionTest, AccountApproveAllowanceFromTransactionBytes)
 }
 
 //-----
+TEST_F(TransactionTest, AccountApproveAllowanceFromTransactionListBytes)
+{
+  // Given
+  proto::TransactionBody txBody;
+  txBody.set_allocated_cryptoapproveallowance(new proto::CryptoApproveAllowanceTransactionBody);
+
+  proto::SignedTransaction signedTx;
+  signedTx.set_bodybytes(txBody.SerializeAsString());
+  // SignatureMap not required
+
+  proto::Transaction tx;
+  tx.set_signedtransactionbytes(signedTx.SerializeAsString());
+
+  proto::TransactionList txList;
+  *txList.add_transaction_list() = tx;
+
+  // When
+  const WrappedTransaction wrappedTx = Transaction<AccountAllowanceApproveTransaction>::fromBytes(
+    internal::Utilities::stringToByteVector(txList.SerializeAsString()));
+
+  // Then
+  ASSERT_EQ(wrappedTx.getTransactionType(), TransactionType::ACCOUNT_ALLOWANCE_APPROVE_TRANSACTION);
+  EXPECT_NE(wrappedTx.getTransaction<AccountAllowanceApproveTransaction>(), nullptr);
+}
+
+//-----
 TEST_F(TransactionTest, AccountDeleteAllowanceFromTransactionBodyBytes)
 {
   // Given
@@ -142,26 +149,6 @@ TEST_F(TransactionTest, AccountDeleteAllowanceFromTransactionBodyBytes)
   // When
   const WrappedTransaction wrappedTx = Transaction<AccountAllowanceDeleteTransaction>::fromBytes(
     internal::Utilities::stringToByteVector(txBody.SerializeAsString()));
-
-  // Then
-  ASSERT_EQ(wrappedTx.getTransactionType(), TransactionType::ACCOUNT_ALLOWANCE_DELETE_TRANSACTION);
-  EXPECT_NE(wrappedTx.getTransaction<AccountAllowanceDeleteTransaction>(), nullptr);
-}
-
-//-----
-TEST_F(TransactionTest, AccountDeleteAllowanceFromSignedTransactionBytes)
-{
-  // Given
-  proto::TransactionBody txBody;
-  txBody.set_allocated_cryptodeleteallowance(new proto::CryptoDeleteAllowanceTransactionBody);
-
-  proto::SignedTransaction signedTx;
-  signedTx.set_bodybytes(txBody.SerializeAsString());
-  // SignatureMap not required
-
-  // When
-  const WrappedTransaction wrappedTx = Transaction<AccountAllowanceDeleteTransaction>::fromBytes(
-    internal::Utilities::stringToByteVector(signedTx.SerializeAsString()));
 
   // Then
   ASSERT_EQ(wrappedTx.getTransactionType(), TransactionType::ACCOUNT_ALLOWANCE_DELETE_TRANSACTION);
@@ -192,6 +179,32 @@ TEST_F(TransactionTest, AccountDeleteAllowanceFromTransactionBytes)
 }
 
 //-----
+TEST_F(TransactionTest, AccountDeleteAllowanceFromTransactionListBytes)
+{
+  // Given
+  proto::TransactionBody txBody;
+  txBody.set_allocated_cryptodeleteallowance(new proto::CryptoDeleteAllowanceTransactionBody);
+
+  proto::SignedTransaction signedTx;
+  signedTx.set_bodybytes(txBody.SerializeAsString());
+  // SignatureMap not required
+
+  proto::Transaction tx;
+  tx.set_signedtransactionbytes(signedTx.SerializeAsString());
+
+  proto::TransactionList txList;
+  *txList.add_transaction_list() = tx;
+
+  // When
+  const WrappedTransaction wrappedTx = Transaction<AccountAllowanceDeleteTransaction>::fromBytes(
+    internal::Utilities::stringToByteVector(txList.SerializeAsString()));
+
+  // Then
+  ASSERT_EQ(wrappedTx.getTransactionType(), TransactionType::ACCOUNT_ALLOWANCE_DELETE_TRANSACTION);
+  EXPECT_NE(wrappedTx.getTransaction<AccountAllowanceDeleteTransaction>(), nullptr);
+}
+
+//-----
 TEST_F(TransactionTest, AccountCreateTransactionFromTransactionBodyBytes)
 {
   // Given
@@ -201,26 +214,6 @@ TEST_F(TransactionTest, AccountCreateTransactionFromTransactionBodyBytes)
   // When
   const WrappedTransaction wrappedTx = Transaction<AccountCreateTransaction>::fromBytes(
     internal::Utilities::stringToByteVector(txBody.SerializeAsString()));
-
-  // Then
-  ASSERT_EQ(wrappedTx.getTransactionType(), TransactionType::ACCOUNT_CREATE_TRANSACTION);
-  EXPECT_NE(wrappedTx.getTransaction<AccountCreateTransaction>(), nullptr);
-}
-
-//-----
-TEST_F(TransactionTest, AccountCreateTransactionFromSignedTransactionBytes)
-{
-  // Given
-  proto::TransactionBody txBody;
-  txBody.set_allocated_cryptocreateaccount(new proto::CryptoCreateTransactionBody);
-
-  proto::SignedTransaction signedTx;
-  signedTx.set_bodybytes(txBody.SerializeAsString());
-  // SignatureMap not required
-
-  // When
-  const WrappedTransaction wrappedTx = Transaction<AccountCreateTransaction>::fromBytes(
-    internal::Utilities::stringToByteVector(signedTx.SerializeAsString()));
 
   // Then
   ASSERT_EQ(wrappedTx.getTransactionType(), TransactionType::ACCOUNT_CREATE_TRANSACTION);
@@ -251,6 +244,32 @@ TEST_F(TransactionTest, AccountCreateTransactionFromTransactionBytes)
 }
 
 //-----
+TEST_F(TransactionTest, AccountCreateTransactionFromTransactionListBytes)
+{
+  // Given
+  proto::TransactionBody txBody;
+  txBody.set_allocated_cryptocreateaccount(new proto::CryptoCreateTransactionBody);
+
+  proto::SignedTransaction signedTx;
+  signedTx.set_bodybytes(txBody.SerializeAsString());
+  // SignatureMap not required
+
+  proto::Transaction tx;
+  tx.set_signedtransactionbytes(signedTx.SerializeAsString());
+
+  proto::TransactionList txList;
+  *txList.add_transaction_list() = tx;
+
+  // When
+  const WrappedTransaction wrappedTx = Transaction<AccountCreateTransaction>::fromBytes(
+    internal::Utilities::stringToByteVector(txList.SerializeAsString()));
+
+  // Then
+  ASSERT_EQ(wrappedTx.getTransactionType(), TransactionType::ACCOUNT_CREATE_TRANSACTION);
+  EXPECT_NE(wrappedTx.getTransaction<AccountCreateTransaction>(), nullptr);
+}
+
+//-----
 TEST_F(TransactionTest, AccountDeleteTransactionFromTransactionBodyBytes)
 {
   // Given
@@ -260,26 +279,6 @@ TEST_F(TransactionTest, AccountDeleteTransactionFromTransactionBodyBytes)
   // When
   const WrappedTransaction wrappedTx = Transaction<AccountDeleteTransaction>::fromBytes(
     internal::Utilities::stringToByteVector(txBody.SerializeAsString()));
-
-  // Then
-  ASSERT_EQ(wrappedTx.getTransactionType(), TransactionType::ACCOUNT_DELETE_TRANSACTION);
-  EXPECT_NE(wrappedTx.getTransaction<AccountDeleteTransaction>(), nullptr);
-}
-
-//-----
-TEST_F(TransactionTest, AccountDeleteTransactionFromSignedTransactionBytes)
-{
-  // Given
-  proto::TransactionBody txBody;
-  txBody.set_allocated_cryptodelete(new proto::CryptoDeleteTransactionBody);
-
-  proto::SignedTransaction signedTx;
-  signedTx.set_bodybytes(txBody.SerializeAsString());
-  // SignatureMap not required
-
-  // When
-  const WrappedTransaction wrappedTx = Transaction<AccountDeleteTransaction>::fromBytes(
-    internal::Utilities::stringToByteVector(signedTx.SerializeAsString()));
 
   // Then
   ASSERT_EQ(wrappedTx.getTransactionType(), TransactionType::ACCOUNT_DELETE_TRANSACTION);
@@ -310,6 +309,32 @@ TEST_F(TransactionTest, AccountDeleteTransactionFromTransactionBytes)
 }
 
 //-----
+TEST_F(TransactionTest, AccountDeleteTransactionFromTransactionListBytes)
+{
+  // Given
+  proto::TransactionBody txBody;
+  txBody.set_allocated_cryptodelete(new proto::CryptoDeleteTransactionBody);
+
+  proto::SignedTransaction signedTx;
+  signedTx.set_bodybytes(txBody.SerializeAsString());
+  // SignatureMap not required
+
+  proto::Transaction tx;
+  tx.set_signedtransactionbytes(signedTx.SerializeAsString());
+
+  proto::TransactionList txList;
+  *txList.add_transaction_list() = tx;
+
+  // When
+  const WrappedTransaction wrappedTx = Transaction<AccountDeleteTransaction>::fromBytes(
+    internal::Utilities::stringToByteVector(txList.SerializeAsString()));
+
+  // Then
+  ASSERT_EQ(wrappedTx.getTransactionType(), TransactionType::ACCOUNT_DELETE_TRANSACTION);
+  EXPECT_NE(wrappedTx.getTransaction<AccountDeleteTransaction>(), nullptr);
+}
+
+//-----
 TEST_F(TransactionTest, AccountUpdateTransactionFromTransactionBodyByte)
 {
   // Given
@@ -319,26 +344,6 @@ TEST_F(TransactionTest, AccountUpdateTransactionFromTransactionBodyByte)
   // When
   const WrappedTransaction wrappedTx = Transaction<AccountUpdateTransaction>::fromBytes(
     internal::Utilities::stringToByteVector(txBody.SerializeAsString()));
-
-  // Then
-  ASSERT_EQ(wrappedTx.getTransactionType(), TransactionType::ACCOUNT_UPDATE_TRANSACTION);
-  EXPECT_NE(wrappedTx.getTransaction<AccountUpdateTransaction>(), nullptr);
-}
-
-//-----
-TEST_F(TransactionTest, AccountUpdateTransactionFromSignedTransactionBytes)
-{
-  // Given
-  proto::TransactionBody txBody;
-  txBody.set_allocated_cryptoupdateaccount(new proto::CryptoUpdateTransactionBody);
-
-  proto::SignedTransaction signedTx;
-  signedTx.set_bodybytes(txBody.SerializeAsString());
-  // SignatureMap not required
-
-  // When
-  const WrappedTransaction wrappedTx = Transaction<AccountUpdateTransaction>::fromBytes(
-    internal::Utilities::stringToByteVector(signedTx.SerializeAsString()));
 
   // Then
   ASSERT_EQ(wrappedTx.getTransactionType(), TransactionType::ACCOUNT_UPDATE_TRANSACTION);
@@ -369,6 +374,32 @@ TEST_F(TransactionTest, AccountUpdateTransactionFromTransactionBytes)
 }
 
 //-----
+TEST_F(TransactionTest, AccountUpdateTransactionFromTransactionListBytes)
+{
+  // Given
+  proto::TransactionBody txBody;
+  txBody.set_allocated_cryptoupdateaccount(new proto::CryptoUpdateTransactionBody);
+
+  proto::SignedTransaction signedTx;
+  signedTx.set_bodybytes(txBody.SerializeAsString());
+  // SignatureMap not required
+
+  proto::Transaction tx;
+  tx.set_signedtransactionbytes(signedTx.SerializeAsString());
+
+  proto::TransactionList txList;
+  *txList.add_transaction_list() = tx;
+
+  // When
+  const WrappedTransaction wrappedTx = Transaction<AccountUpdateTransaction>::fromBytes(
+    internal::Utilities::stringToByteVector(txList.SerializeAsString()));
+
+  // Then
+  ASSERT_EQ(wrappedTx.getTransactionType(), TransactionType::ACCOUNT_UPDATE_TRANSACTION);
+  EXPECT_NE(wrappedTx.getTransaction<AccountUpdateTransaction>(), nullptr);
+}
+
+//-----
 TEST_F(TransactionTest, ContractCreateTransactionFromTransactionBodyBytes)
 {
   // Given
@@ -378,26 +409,6 @@ TEST_F(TransactionTest, ContractCreateTransactionFromTransactionBodyBytes)
   // When
   const WrappedTransaction wrappedTx = Transaction<ContractCreateTransaction>::fromBytes(
     internal::Utilities::stringToByteVector(txBody.SerializeAsString()));
-
-  // Then
-  ASSERT_EQ(wrappedTx.getTransactionType(), TransactionType::CONTRACT_CREATE_TRANSACTION);
-  EXPECT_NE(wrappedTx.getTransaction<ContractCreateTransaction>(), nullptr);
-}
-
-//-----
-TEST_F(TransactionTest, ContractCreateTransactionFromSignedTransactionBytes)
-{
-  // Given
-  proto::TransactionBody txBody;
-  txBody.set_allocated_contractcreateinstance(new proto::ContractCreateTransactionBody);
-
-  proto::SignedTransaction signedTx;
-  signedTx.set_bodybytes(txBody.SerializeAsString());
-  // SignatureMap not required
-
-  // When
-  const WrappedTransaction wrappedTx = Transaction<ContractCreateTransaction>::fromBytes(
-    internal::Utilities::stringToByteVector(signedTx.SerializeAsString()));
 
   // Then
   ASSERT_EQ(wrappedTx.getTransactionType(), TransactionType::CONTRACT_CREATE_TRANSACTION);
@@ -428,6 +439,32 @@ TEST_F(TransactionTest, ContractCreateTransactionFromTransactionBytes)
 }
 
 //-----
+TEST_F(TransactionTest, ContractCreateTransactionFromTransactionListBytes)
+{
+  // Given
+  proto::TransactionBody txBody;
+  txBody.set_allocated_contractcreateinstance(new proto::ContractCreateTransactionBody);
+
+  proto::SignedTransaction signedTx;
+  signedTx.set_bodybytes(txBody.SerializeAsString());
+  // SignatureMap not required
+
+  proto::Transaction tx;
+  tx.set_signedtransactionbytes(signedTx.SerializeAsString());
+
+  proto::TransactionList txList;
+  *txList.add_transaction_list() = tx;
+
+  // When
+  const WrappedTransaction wrappedTx = Transaction<ContractCreateTransaction>::fromBytes(
+    internal::Utilities::stringToByteVector(txList.SerializeAsString()));
+
+  // Then
+  ASSERT_EQ(wrappedTx.getTransactionType(), TransactionType::CONTRACT_CREATE_TRANSACTION);
+  EXPECT_NE(wrappedTx.getTransaction<ContractCreateTransaction>(), nullptr);
+}
+
+//-----
 TEST_F(TransactionTest, ContractDeleteTransactionFromTransactionBodyBytes)
 {
   // Given
@@ -437,26 +474,6 @@ TEST_F(TransactionTest, ContractDeleteTransactionFromTransactionBodyBytes)
   // When
   const WrappedTransaction wrappedTx = Transaction<ContractDeleteTransaction>::fromBytes(
     internal::Utilities::stringToByteVector(txBody.SerializeAsString()));
-
-  // Then
-  ASSERT_EQ(wrappedTx.getTransactionType(), TransactionType::CONTRACT_DELETE_TRANSACTION);
-  EXPECT_NE(wrappedTx.getTransaction<ContractDeleteTransaction>(), nullptr);
-}
-
-//-----
-TEST_F(TransactionTest, ContractDeleteTransactionFromSignedTransactionBytes)
-{
-  // Given
-  proto::TransactionBody txBody;
-  txBody.set_allocated_contractdeleteinstance(new proto::ContractDeleteTransactionBody());
-
-  proto::SignedTransaction signedTx;
-  signedTx.set_bodybytes(txBody.SerializeAsString());
-  // SignatureMap not required
-
-  // When
-  const WrappedTransaction wrappedTx = Transaction<ContractDeleteTransaction>::fromBytes(
-    internal::Utilities::stringToByteVector(signedTx.SerializeAsString()));
 
   // Then
   ASSERT_EQ(wrappedTx.getTransactionType(), TransactionType::CONTRACT_DELETE_TRANSACTION);
@@ -487,6 +504,32 @@ TEST_F(TransactionTest, ContractDeleteTransactionFromTransactionBytes)
 }
 
 //-----
+TEST_F(TransactionTest, ContractDeleteTransactionFromTransactionListBytes)
+{
+  // Given
+  proto::TransactionBody txBody;
+  txBody.set_allocated_contractdeleteinstance(new proto::ContractDeleteTransactionBody());
+
+  proto::SignedTransaction signedTx;
+  signedTx.set_bodybytes(txBody.SerializeAsString());
+  // SignatureMap not required
+
+  proto::Transaction tx;
+  tx.set_signedtransactionbytes(signedTx.SerializeAsString());
+
+  proto::TransactionList txList;
+  *txList.add_transaction_list() = tx;
+
+  // When
+  const WrappedTransaction wrappedTx = Transaction<ContractDeleteTransaction>::fromBytes(
+    internal::Utilities::stringToByteVector(txList.SerializeAsString()));
+
+  // Then
+  ASSERT_EQ(wrappedTx.getTransactionType(), TransactionType::CONTRACT_DELETE_TRANSACTION);
+  EXPECT_NE(wrappedTx.getTransaction<ContractDeleteTransaction>(), nullptr);
+}
+
+//-----
 TEST_F(TransactionTest, ContractExecuteTransactionFromTransactionBodyBytes)
 {
   // Given
@@ -496,26 +539,6 @@ TEST_F(TransactionTest, ContractExecuteTransactionFromTransactionBodyBytes)
   // When
   const WrappedTransaction wrappedTx = Transaction<ContractExecuteTransaction>::fromBytes(
     internal::Utilities::stringToByteVector(txBody.SerializeAsString()));
-
-  // Then
-  ASSERT_EQ(wrappedTx.getTransactionType(), TransactionType::CONTRACT_EXECUTE_TRANSACTION);
-  EXPECT_NE(wrappedTx.getTransaction<ContractExecuteTransaction>(), nullptr);
-}
-
-//-----
-TEST_F(TransactionTest, ContractExecuteTransactionFromSignedTransactionBytes)
-{
-  // Given
-  proto::TransactionBody txBody;
-  txBody.set_allocated_contractcall(new proto::ContractCallTransactionBody);
-
-  proto::SignedTransaction signedTx;
-  signedTx.set_bodybytes(txBody.SerializeAsString());
-  // SignatureMap not required
-
-  // When
-  const WrappedTransaction wrappedTx = Transaction<ContractExecuteTransaction>::fromBytes(
-    internal::Utilities::stringToByteVector(signedTx.SerializeAsString()));
 
   // Then
   ASSERT_EQ(wrappedTx.getTransactionType(), TransactionType::CONTRACT_EXECUTE_TRANSACTION);
@@ -546,6 +569,32 @@ TEST_F(TransactionTest, ContractExecuteTransactionFromTransactionBytes)
 }
 
 //-----
+TEST_F(TransactionTest, ContractExecuteTransactionFromTransactionListBytes)
+{
+  // Given
+  proto::TransactionBody txBody;
+  txBody.set_allocated_contractcall(new proto::ContractCallTransactionBody);
+
+  proto::SignedTransaction signedTx;
+  signedTx.set_bodybytes(txBody.SerializeAsString());
+  // SignatureMap not required
+
+  proto::Transaction tx;
+  tx.set_signedtransactionbytes(signedTx.SerializeAsString());
+
+  proto::TransactionList txList;
+  *txList.add_transaction_list() = tx;
+
+  // When
+  const WrappedTransaction wrappedTx = Transaction<ContractExecuteTransaction>::fromBytes(
+    internal::Utilities::stringToByteVector(txList.SerializeAsString()));
+
+  // Then
+  ASSERT_EQ(wrappedTx.getTransactionType(), TransactionType::CONTRACT_EXECUTE_TRANSACTION);
+  EXPECT_NE(wrappedTx.getTransaction<ContractExecuteTransaction>(), nullptr);
+}
+
+//-----
 TEST_F(TransactionTest, ContractUpdateTransactionFromTransactionBodyBytes)
 {
   // Given
@@ -555,26 +604,6 @@ TEST_F(TransactionTest, ContractUpdateTransactionFromTransactionBodyBytes)
   // When
   const WrappedTransaction wrappedTx = Transaction<ContractUpdateTransaction>::fromBytes(
     internal::Utilities::stringToByteVector(txBody.SerializeAsString()));
-
-  // Then
-  ASSERT_EQ(wrappedTx.getTransactionType(), TransactionType::CONTRACT_UPDATE_TRANSACTION);
-  EXPECT_NE(wrappedTx.getTransaction<ContractUpdateTransaction>(), nullptr);
-}
-
-//-----
-TEST_F(TransactionTest, ContractUpdateTransactionFromSignedTransactionBytes)
-{
-  // Given
-  proto::TransactionBody txBody;
-  txBody.set_allocated_contractupdateinstance(new proto::ContractUpdateTransactionBody);
-
-  proto::SignedTransaction signedTx;
-  signedTx.set_bodybytes(txBody.SerializeAsString());
-  // SignatureMap not required
-
-  // When
-  const WrappedTransaction wrappedTx = Transaction<ContractUpdateTransaction>::fromBytes(
-    internal::Utilities::stringToByteVector(signedTx.SerializeAsString()));
 
   // Then
   ASSERT_EQ(wrappedTx.getTransactionType(), TransactionType::CONTRACT_UPDATE_TRANSACTION);
@@ -605,6 +634,32 @@ TEST_F(TransactionTest, ContractUpdateTransactionFromTransactionBytes)
 }
 
 //-----
+TEST_F(TransactionTest, ContractUpdateTransactionFromTransactionListBytes)
+{
+  // Given
+  proto::TransactionBody txBody;
+  txBody.set_allocated_contractupdateinstance(new proto::ContractUpdateTransactionBody);
+
+  proto::SignedTransaction signedTx;
+  signedTx.set_bodybytes(txBody.SerializeAsString());
+  // SignatureMap not required
+
+  proto::Transaction tx;
+  tx.set_signedtransactionbytes(signedTx.SerializeAsString());
+
+  proto::TransactionList txList;
+  *txList.add_transaction_list() = tx;
+
+  // When
+  const WrappedTransaction wrappedTx = Transaction<ContractUpdateTransaction>::fromBytes(
+    internal::Utilities::stringToByteVector(txList.SerializeAsString()));
+
+  // Then
+  ASSERT_EQ(wrappedTx.getTransactionType(), TransactionType::CONTRACT_UPDATE_TRANSACTION);
+  EXPECT_NE(wrappedTx.getTransaction<ContractUpdateTransaction>(), nullptr);
+}
+
+//-----
 TEST_F(TransactionTest, EthereumTransactionFromTransactionBodyBytes)
 {
   // Given
@@ -614,26 +669,6 @@ TEST_F(TransactionTest, EthereumTransactionFromTransactionBodyBytes)
   // When
   const WrappedTransaction wrappedTx =
     Transaction<EthereumTransaction>::fromBytes(internal::Utilities::stringToByteVector(txBody.SerializeAsString()));
-
-  // Then
-  ASSERT_EQ(wrappedTx.getTransactionType(), TransactionType::ETHEREUM_TRANSACTION);
-  EXPECT_NE(wrappedTx.getTransaction<EthereumTransaction>(), nullptr);
-}
-
-//-----
-TEST_F(TransactionTest, EthereumTransactionFromSignedTransactionBytes)
-{
-  // Given
-  proto::TransactionBody txBody;
-  txBody.set_allocated_ethereumtransaction(new proto::EthereumTransactionBody);
-
-  proto::SignedTransaction signedTx;
-  signedTx.set_bodybytes(txBody.SerializeAsString());
-  // SignatureMap not required
-
-  // When
-  const WrappedTransaction wrappedTx =
-    Transaction<EthereumTransaction>::fromBytes(internal::Utilities::stringToByteVector(signedTx.SerializeAsString()));
 
   // Then
   ASSERT_EQ(wrappedTx.getTransactionType(), TransactionType::ETHEREUM_TRANSACTION);
@@ -663,31 +698,37 @@ TEST_F(TransactionTest, EthereumTransactionFromTransactionBytes)
   EXPECT_NE(wrappedTx.getTransaction<EthereumTransaction>(), nullptr);
 }
 
+//-----
+TEST_F(TransactionTest, EthereumTransactionFromTransactionListBytes)
+{
+  // Given
+  proto::TransactionBody txBody;
+  txBody.set_allocated_ethereumtransaction(new proto::EthereumTransactionBody);
+
+  proto::SignedTransaction signedTx;
+  signedTx.set_bodybytes(txBody.SerializeAsString());
+  // SignatureMap not required
+
+  proto::Transaction tx;
+  tx.set_signedtransactionbytes(signedTx.SerializeAsString());
+
+  proto::TransactionList txList;
+  *txList.add_transaction_list() = tx;
+
+  // When
+  const WrappedTransaction wrappedTx =
+    Transaction<EthereumTransaction>::fromBytes(internal::Utilities::stringToByteVector(txList.SerializeAsString()));
+
+  // Then
+  ASSERT_EQ(wrappedTx.getTransactionType(), TransactionType::ETHEREUM_TRANSACTION);
+  EXPECT_NE(wrappedTx.getTransaction<EthereumTransaction>(), nullptr);
+}
+
 TEST_F(TransactionTest, FileAppendTransactionFromTransactionBodyBytes)
 {
   // Given
   proto::TransactionBody txBody;
   txBody.set_allocated_fileappend(new proto::FileAppendTransactionBody);
-
-  // When
-  const WrappedTransaction wrappedTx =
-    Transaction<FileAppendTransaction>::fromBytes(internal::Utilities::stringToByteVector(txBody.SerializeAsString()));
-
-  // Then
-  ASSERT_EQ(wrappedTx.getTransactionType(), TransactionType::FILE_APPEND_TRANSACTION);
-  EXPECT_NE(wrappedTx.getTransaction<FileAppendTransaction>(), nullptr);
-}
-
-//-----
-TEST_F(TransactionTest, FileAppendTransactionFromSignedTransactionBytes)
-{
-  // Given
-  proto::TransactionBody txBody;
-  txBody.set_allocated_fileappend(new proto::FileAppendTransactionBody);
-
-  proto::SignedTransaction signedTx;
-  signedTx.set_bodybytes(txBody.SerializeAsString());
-  // SignatureMap not required
 
   // When
   const WrappedTransaction wrappedTx =
@@ -722,6 +763,32 @@ TEST_F(TransactionTest, FileAppendTransactionFromTransactionBytes)
 }
 
 //-----
+TEST_F(TransactionTest, FileAppendTransactionFromTransactionListBytes)
+{
+  // Given
+  proto::TransactionBody txBody;
+  txBody.set_allocated_fileappend(new proto::FileAppendTransactionBody);
+
+  proto::SignedTransaction signedTx;
+  signedTx.set_bodybytes(txBody.SerializeAsString());
+  // SignatureMap not required
+
+  proto::Transaction tx;
+  tx.set_signedtransactionbytes(signedTx.SerializeAsString());
+
+  proto::TransactionList txList;
+  *txList.add_transaction_list() = tx;
+
+  // When
+  const WrappedTransaction wrappedTx =
+    Transaction<FileAppendTransaction>::fromBytes(internal::Utilities::stringToByteVector(txList.SerializeAsString()));
+
+  // Then
+  ASSERT_EQ(wrappedTx.getTransactionType(), TransactionType::FILE_APPEND_TRANSACTION);
+  EXPECT_NE(wrappedTx.getTransaction<FileAppendTransaction>(), nullptr);
+}
+
+//-----
 TEST_F(TransactionTest, FileCreateTransactionFromTransactionBodyBytes)
 {
   // Given
@@ -731,26 +798,6 @@ TEST_F(TransactionTest, FileCreateTransactionFromTransactionBodyBytes)
   // When
   const WrappedTransaction wrappedTx =
     Transaction<FileCreateTransaction>::fromBytes(internal::Utilities::stringToByteVector(txBody.SerializeAsString()));
-
-  // Then
-  ASSERT_EQ(wrappedTx.getTransactionType(), TransactionType::FILE_CREATE_TRANSACTION);
-  EXPECT_NE(wrappedTx.getTransaction<FileCreateTransaction>(), nullptr);
-}
-
-//-----
-TEST_F(TransactionTest, FileCreateTransactionFromSignedTransactionBytes)
-{
-  // Given
-  proto::TransactionBody txBody;
-  txBody.set_allocated_filecreate(new proto::FileCreateTransactionBody);
-
-  proto::SignedTransaction signedTx;
-  signedTx.set_bodybytes(txBody.SerializeAsString());
-  // SignatureMap not required
-
-  // When
-  const WrappedTransaction wrappedTx = Transaction<FileCreateTransaction>::fromBytes(
-    internal::Utilities::stringToByteVector(signedTx.SerializeAsString()));
 
   // Then
   ASSERT_EQ(wrappedTx.getTransactionType(), TransactionType::FILE_CREATE_TRANSACTION);
@@ -781,6 +828,32 @@ TEST_F(TransactionTest, FileCreateTransactionFromTransactionBytes)
 }
 
 //-----
+TEST_F(TransactionTest, FileCreateTransactionFromTransactionListBytes)
+{
+  // Given
+  proto::TransactionBody txBody;
+  txBody.set_allocated_filecreate(new proto::FileCreateTransactionBody);
+
+  proto::SignedTransaction signedTx;
+  signedTx.set_bodybytes(txBody.SerializeAsString());
+  // SignatureMap not required
+
+  proto::Transaction tx;
+  tx.set_signedtransactionbytes(signedTx.SerializeAsString());
+
+  proto::TransactionList txList;
+  *txList.add_transaction_list() = tx;
+
+  // When
+  const WrappedTransaction wrappedTx =
+    Transaction<FileCreateTransaction>::fromBytes(internal::Utilities::stringToByteVector(txList.SerializeAsString()));
+
+  // Then
+  ASSERT_EQ(wrappedTx.getTransactionType(), TransactionType::FILE_CREATE_TRANSACTION);
+  EXPECT_NE(wrappedTx.getTransaction<FileCreateTransaction>(), nullptr);
+}
+
+//-----
 TEST_F(TransactionTest, FileDeleteTransactionFromTransactionBodyBytes)
 {
   // Given
@@ -790,26 +863,6 @@ TEST_F(TransactionTest, FileDeleteTransactionFromTransactionBodyBytes)
   // When
   const WrappedTransaction wrappedTx =
     Transaction<FileDeleteTransaction>::fromBytes(internal::Utilities::stringToByteVector(txBody.SerializeAsString()));
-
-  // Then
-  ASSERT_EQ(wrappedTx.getTransactionType(), TransactionType::FILE_DELETE_TRANSACTION);
-  EXPECT_NE(wrappedTx.getTransaction<FileDeleteTransaction>(), nullptr);
-}
-
-//-----
-TEST_F(TransactionTest, FileDeleteTransactionFromSignedTransactionBytes)
-{
-  // Given
-  proto::TransactionBody txBody;
-  txBody.set_allocated_filedelete(new proto::FileDeleteTransactionBody);
-
-  proto::SignedTransaction signedTx;
-  signedTx.set_bodybytes(txBody.SerializeAsString());
-  // SignatureMap not required
-
-  // When
-  const WrappedTransaction wrappedTx = Transaction<FileDeleteTransaction>::fromBytes(
-    internal::Utilities::stringToByteVector(signedTx.SerializeAsString()));
 
   // Then
   ASSERT_EQ(wrappedTx.getTransactionType(), TransactionType::FILE_DELETE_TRANSACTION);
@@ -840,31 +893,37 @@ TEST_F(TransactionTest, FileDeleteTransactionFromTransactionBytes)
 }
 
 //-----
+TEST_F(TransactionTest, FileDeleteTransactionFromTransactionListBytes)
+{
+  // Given
+  proto::TransactionBody txBody;
+  txBody.set_allocated_filedelete(new proto::FileDeleteTransactionBody);
+
+  proto::SignedTransaction signedTx;
+  signedTx.set_bodybytes(txBody.SerializeAsString());
+  // SignatureMap not required
+
+  proto::Transaction tx;
+  tx.set_signedtransactionbytes(signedTx.SerializeAsString());
+
+  proto::TransactionList txList;
+  *txList.add_transaction_list() = tx;
+
+  // When
+  const WrappedTransaction wrappedTx =
+    Transaction<FileDeleteTransaction>::fromBytes(internal::Utilities::stringToByteVector(txList.SerializeAsString()));
+
+  // Then
+  ASSERT_EQ(wrappedTx.getTransactionType(), TransactionType::FILE_DELETE_TRANSACTION);
+  EXPECT_NE(wrappedTx.getTransaction<FileDeleteTransaction>(), nullptr);
+}
+
+//-----
 TEST_F(TransactionTest, FileUpdateTransactionFromTransactionBodyBytes)
 {
   // Given
   proto::TransactionBody txBody;
   txBody.set_allocated_fileupdate(new proto::FileUpdateTransactionBody);
-
-  // When
-  const WrappedTransaction wrappedTx =
-    Transaction<FileUpdateTransaction>::fromBytes(internal::Utilities::stringToByteVector(txBody.SerializeAsString()));
-
-  // Then
-  ASSERT_EQ(wrappedTx.getTransactionType(), TransactionType::FILE_UPDATE_TRANSACTION);
-  EXPECT_NE(wrappedTx.getTransaction<FileUpdateTransaction>(), nullptr);
-}
-
-//-----
-TEST_F(TransactionTest, FileUpdateTransactionFromSignedTransactionBytes)
-{
-  // Given
-  proto::TransactionBody txBody;
-  txBody.set_allocated_fileupdate(new proto::FileUpdateTransactionBody);
-
-  proto::SignedTransaction signedTx;
-  signedTx.set_bodybytes(txBody.SerializeAsString());
-  // SignatureMap not required
 
   // When
   const WrappedTransaction wrappedTx =
@@ -899,31 +958,37 @@ TEST_F(TransactionTest, FileUpdateTransactionFromTransactionBytes)
 }
 
 //-----
+TEST_F(TransactionTest, FileUpdateTransactionFromTransactionListBytes)
+{
+  // Given
+  proto::TransactionBody txBody;
+  txBody.set_allocated_fileupdate(new proto::FileUpdateTransactionBody);
+
+  proto::SignedTransaction signedTx;
+  signedTx.set_bodybytes(txBody.SerializeAsString());
+  // SignatureMap not required
+
+  proto::Transaction tx;
+  tx.set_signedtransactionbytes(signedTx.SerializeAsString());
+
+  proto::TransactionList txList;
+  *txList.add_transaction_list() = tx;
+
+  // When
+  const WrappedTransaction wrappedTx =
+    Transaction<FileUpdateTransaction>::fromBytes(internal::Utilities::stringToByteVector(txList.SerializeAsString()));
+
+  // Then
+  ASSERT_EQ(wrappedTx.getTransactionType(), TransactionType::FILE_UPDATE_TRANSACTION);
+  EXPECT_NE(wrappedTx.getTransaction<FileUpdateTransaction>(), nullptr);
+}
+
+//-----
 TEST_F(TransactionTest, FreezeTransactionFromTransactionBodyBytes)
 {
   // Given
   proto::TransactionBody txBody;
   txBody.set_allocated_freeze(new proto::FreezeTransactionBody);
-
-  // When
-  const WrappedTransaction wrappedTx =
-    Transaction<FreezeTransaction>::fromBytes(internal::Utilities::stringToByteVector(txBody.SerializeAsString()));
-
-  // Then
-  ASSERT_EQ(wrappedTx.getTransactionType(), TransactionType::FREEZE_TRANSACTION);
-  EXPECT_NE(wrappedTx.getTransaction<FreezeTransaction>(), nullptr);
-}
-
-//-----
-TEST_F(TransactionTest, FreezeTransactionFromSignedTransactionBytes)
-{
-  // Given
-  proto::TransactionBody txBody;
-  txBody.set_allocated_freeze(new proto::FreezeTransactionBody);
-
-  proto::SignedTransaction signedTx;
-  signedTx.set_bodybytes(txBody.SerializeAsString());
-  // SignatureMap not required
 
   // When
   const WrappedTransaction wrappedTx =
@@ -958,6 +1023,32 @@ TEST_F(TransactionTest, FreezeTransactionFromTransactionBytes)
 }
 
 //-----
+TEST_F(TransactionTest, FreezeTransactionFromTransactionListBytes)
+{
+  // Given
+  proto::TransactionBody txBody;
+  txBody.set_allocated_freeze(new proto::FreezeTransactionBody);
+
+  proto::SignedTransaction signedTx;
+  signedTx.set_bodybytes(txBody.SerializeAsString());
+  // SignatureMap not required
+
+  proto::Transaction tx;
+  tx.set_signedtransactionbytes(signedTx.SerializeAsString());
+
+  proto::TransactionList txList;
+  *txList.add_transaction_list() = tx;
+
+  // When
+  const WrappedTransaction wrappedTx =
+    Transaction<FreezeTransaction>::fromBytes(internal::Utilities::stringToByteVector(txList.SerializeAsString()));
+
+  // Then
+  ASSERT_EQ(wrappedTx.getTransactionType(), TransactionType::FREEZE_TRANSACTION);
+  EXPECT_NE(wrappedTx.getTransaction<FreezeTransaction>(), nullptr);
+}
+
+//-----
 TEST_F(TransactionTest, ScheduleCreateTransactionTransactionFromTransactionBodyBytes)
 {
   // Given
@@ -967,26 +1058,6 @@ TEST_F(TransactionTest, ScheduleCreateTransactionTransactionFromTransactionBodyB
   // When
   const WrappedTransaction wrappedTx = Transaction<ScheduleCreateTransaction>::fromBytes(
     internal::Utilities::stringToByteVector(txBody.SerializeAsString()));
-
-  // Then
-  ASSERT_EQ(wrappedTx.getTransactionType(), TransactionType::SCHEDULE_CREATE_TRANSACTION);
-  EXPECT_NE(wrappedTx.getTransaction<ScheduleCreateTransaction>(), nullptr);
-}
-
-//-----
-TEST_F(TransactionTest, ScheduleCreateTransactionFromSignedTransactionBytes)
-{
-  // Given
-  proto::TransactionBody txBody;
-  txBody.set_allocated_schedulecreate(new proto::ScheduleCreateTransactionBody);
-
-  proto::SignedTransaction signedTx;
-  signedTx.set_bodybytes(txBody.SerializeAsString());
-  // SignatureMap not required
-
-  // When
-  const WrappedTransaction wrappedTx = Transaction<ScheduleCreateTransaction>::fromBytes(
-    internal::Utilities::stringToByteVector(signedTx.SerializeAsString()));
 
   // Then
   ASSERT_EQ(wrappedTx.getTransactionType(), TransactionType::SCHEDULE_CREATE_TRANSACTION);
@@ -1017,6 +1088,32 @@ TEST_F(TransactionTest, ScheduleCreateTransactionFromTransactionBytes)
 }
 
 //-----
+TEST_F(TransactionTest, ScheduleCreateTransactionFromTransactionListBytes)
+{
+  // Given
+  proto::TransactionBody txBody;
+  txBody.set_allocated_schedulecreate(new proto::ScheduleCreateTransactionBody);
+
+  proto::SignedTransaction signedTx;
+  signedTx.set_bodybytes(txBody.SerializeAsString());
+  // SignatureMap not required
+
+  proto::Transaction tx;
+  tx.set_signedtransactionbytes(signedTx.SerializeAsString());
+
+  proto::TransactionList txList;
+  *txList.add_transaction_list() = tx;
+
+  // When
+  const WrappedTransaction wrappedTx = Transaction<ScheduleCreateTransaction>::fromBytes(
+    internal::Utilities::stringToByteVector(txList.SerializeAsString()));
+
+  // Then
+  ASSERT_EQ(wrappedTx.getTransactionType(), TransactionType::SCHEDULE_CREATE_TRANSACTION);
+  EXPECT_NE(wrappedTx.getTransaction<ScheduleCreateTransaction>(), nullptr);
+}
+
+//-----
 TEST_F(TransactionTest, ScheduleDeleteTransactionTransactionFromTransactionBodyBytes)
 {
   // Given
@@ -1026,26 +1123,6 @@ TEST_F(TransactionTest, ScheduleDeleteTransactionTransactionFromTransactionBodyB
   // When
   const WrappedTransaction wrappedTx = Transaction<ScheduleDeleteTransaction>::fromBytes(
     internal::Utilities::stringToByteVector(txBody.SerializeAsString()));
-
-  // Then
-  ASSERT_EQ(wrappedTx.getTransactionType(), TransactionType::SCHEDULE_DELETE_TRANSACTION);
-  EXPECT_NE(wrappedTx.getTransaction<ScheduleDeleteTransaction>(), nullptr);
-}
-
-//-----
-TEST_F(TransactionTest, ScheduleDeleteTransactionFromSignedTransactionBytes)
-{
-  // Given
-  proto::TransactionBody txBody;
-  txBody.set_allocated_scheduledelete(new proto::ScheduleDeleteTransactionBody);
-
-  proto::SignedTransaction signedTx;
-  signedTx.set_bodybytes(txBody.SerializeAsString());
-  // SignatureMap not required
-
-  // When
-  const WrappedTransaction wrappedTx = Transaction<ScheduleDeleteTransaction>::fromBytes(
-    internal::Utilities::stringToByteVector(signedTx.SerializeAsString()));
 
   // Then
   ASSERT_EQ(wrappedTx.getTransactionType(), TransactionType::SCHEDULE_DELETE_TRANSACTION);
@@ -1076,6 +1153,32 @@ TEST_F(TransactionTest, ScheduleDeleteTransactionFromTransactionBytes)
 }
 
 //-----
+TEST_F(TransactionTest, ScheduleDeleteTransactionFromTransactionListBytes)
+{
+  // Given
+  proto::TransactionBody txBody;
+  txBody.set_allocated_scheduledelete(new proto::ScheduleDeleteTransactionBody);
+
+  proto::SignedTransaction signedTx;
+  signedTx.set_bodybytes(txBody.SerializeAsString());
+  // SignatureMap not required
+
+  proto::Transaction tx;
+  tx.set_signedtransactionbytes(signedTx.SerializeAsString());
+
+  proto::TransactionList txList;
+  *txList.add_transaction_list() = tx;
+
+  // When
+  const WrappedTransaction wrappedTx = Transaction<ScheduleDeleteTransaction>::fromBytes(
+    internal::Utilities::stringToByteVector(txList.SerializeAsString()));
+
+  // Then
+  ASSERT_EQ(wrappedTx.getTransactionType(), TransactionType::SCHEDULE_DELETE_TRANSACTION);
+  EXPECT_NE(wrappedTx.getTransaction<ScheduleDeleteTransaction>(), nullptr);
+}
+
+//-----
 TEST_F(TransactionTest, ScheduleSignTransactionTransactionFromTransactionBodyBytes)
 {
   // Given
@@ -1085,26 +1188,6 @@ TEST_F(TransactionTest, ScheduleSignTransactionTransactionFromTransactionBodyByt
   // When
   const WrappedTransaction wrappedTx = Transaction<ScheduleSignTransaction>::fromBytes(
     internal::Utilities::stringToByteVector(txBody.SerializeAsString()));
-
-  // Then
-  ASSERT_EQ(wrappedTx.getTransactionType(), TransactionType::SCHEDULE_SIGN_TRANSACTION);
-  EXPECT_NE(wrappedTx.getTransaction<ScheduleSignTransaction>(), nullptr);
-}
-
-//-----
-TEST_F(TransactionTest, ScheduleSignTransactionFromSignedTransactionBytes)
-{
-  // Given
-  proto::TransactionBody txBody;
-  txBody.set_allocated_schedulesign(new proto::ScheduleSignTransactionBody);
-
-  proto::SignedTransaction signedTx;
-  signedTx.set_bodybytes(txBody.SerializeAsString());
-  // SignatureMap not required
-
-  // When
-  const WrappedTransaction wrappedTx = Transaction<ScheduleSignTransaction>::fromBytes(
-    internal::Utilities::stringToByteVector(signedTx.SerializeAsString()));
 
   // Then
   ASSERT_EQ(wrappedTx.getTransactionType(), TransactionType::SCHEDULE_SIGN_TRANSACTION);
@@ -1135,6 +1218,32 @@ TEST_F(TransactionTest, ScheduleSignTransactionFromTransactionBytes)
 }
 
 //-----
+TEST_F(TransactionTest, ScheduleSignTransactionFromTransactionListBytes)
+{
+  // Given
+  proto::TransactionBody txBody;
+  txBody.set_allocated_schedulesign(new proto::ScheduleSignTransactionBody);
+
+  proto::SignedTransaction signedTx;
+  signedTx.set_bodybytes(txBody.SerializeAsString());
+  // SignatureMap not required
+
+  proto::Transaction tx;
+  tx.set_signedtransactionbytes(signedTx.SerializeAsString());
+
+  proto::TransactionList txList;
+  *txList.add_transaction_list() = tx;
+
+  // When
+  const WrappedTransaction wrappedTx = Transaction<ScheduleSignTransaction>::fromBytes(
+    internal::Utilities::stringToByteVector(txList.SerializeAsString()));
+
+  // Then
+  ASSERT_EQ(wrappedTx.getTransactionType(), TransactionType::SCHEDULE_SIGN_TRANSACTION);
+  EXPECT_NE(wrappedTx.getTransaction<ScheduleSignTransaction>(), nullptr);
+}
+
+//-----
 TEST_F(TransactionTest, SystemDeleteTransactionTransactionFromTransactionBodyBytes)
 {
   // Given
@@ -1144,26 +1253,6 @@ TEST_F(TransactionTest, SystemDeleteTransactionTransactionFromTransactionBodyByt
   // When
   const WrappedTransaction wrappedTx = Transaction<SystemDeleteTransaction>::fromBytes(
     internal::Utilities::stringToByteVector(txBody.SerializeAsString()));
-
-  // Then
-  ASSERT_EQ(wrappedTx.getTransactionType(), TransactionType::SYSTEM_DELETE_TRANSACTION);
-  EXPECT_NE(wrappedTx.getTransaction<SystemDeleteTransaction>(), nullptr);
-}
-
-//-----
-TEST_F(TransactionTest, SystemDeleteTransactionFromSignedTransactionBytes)
-{
-  // Given
-  proto::TransactionBody txBody;
-  txBody.set_allocated_systemdelete(new proto::SystemDeleteTransactionBody);
-
-  proto::SignedTransaction signedTx;
-  signedTx.set_bodybytes(txBody.SerializeAsString());
-  // SignatureMap not required
-
-  // When
-  const WrappedTransaction wrappedTx = Transaction<SystemDeleteTransaction>::fromBytes(
-    internal::Utilities::stringToByteVector(signedTx.SerializeAsString()));
 
   // Then
   ASSERT_EQ(wrappedTx.getTransactionType(), TransactionType::SYSTEM_DELETE_TRANSACTION);
@@ -1194,6 +1283,32 @@ TEST_F(TransactionTest, SystemDeleteTransactionFromTransactionBytes)
 }
 
 //-----
+TEST_F(TransactionTest, SystemDeleteTransactionFromTransactionListBytes)
+{
+  // Given
+  proto::TransactionBody txBody;
+  txBody.set_allocated_systemdelete(new proto::SystemDeleteTransactionBody);
+
+  proto::SignedTransaction signedTx;
+  signedTx.set_bodybytes(txBody.SerializeAsString());
+  // SignatureMap not required
+
+  proto::Transaction tx;
+  tx.set_signedtransactionbytes(signedTx.SerializeAsString());
+
+  proto::TransactionList txList;
+  *txList.add_transaction_list() = tx;
+
+  // When
+  const WrappedTransaction wrappedTx = Transaction<SystemDeleteTransaction>::fromBytes(
+    internal::Utilities::stringToByteVector(txList.SerializeAsString()));
+
+  // Then
+  ASSERT_EQ(wrappedTx.getTransactionType(), TransactionType::SYSTEM_DELETE_TRANSACTION);
+  EXPECT_NE(wrappedTx.getTransaction<SystemDeleteTransaction>(), nullptr);
+}
+
+//-----
 TEST_F(TransactionTest, SystemUndeleteTransactionTransactionFromTransactionBodyBytes)
 {
   // Given
@@ -1203,26 +1318,6 @@ TEST_F(TransactionTest, SystemUndeleteTransactionTransactionFromTransactionBodyB
   // When
   const WrappedTransaction wrappedTx = Transaction<SystemUndeleteTransaction>::fromBytes(
     internal::Utilities::stringToByteVector(txBody.SerializeAsString()));
-
-  // Then
-  ASSERT_EQ(wrappedTx.getTransactionType(), TransactionType::SYSTEM_UNDELETE_TRANSACTION);
-  EXPECT_NE(wrappedTx.getTransaction<SystemUndeleteTransaction>(), nullptr);
-}
-
-//-----
-TEST_F(TransactionTest, SystemUndeleteTransactionFromSignedTransactionBytes)
-{
-  // Given
-  proto::TransactionBody txBody;
-  txBody.set_allocated_systemundelete(new proto::SystemUndeleteTransactionBody);
-
-  proto::SignedTransaction signedTx;
-  signedTx.set_bodybytes(txBody.SerializeAsString());
-  // SignatureMap not required
-
-  // When
-  const WrappedTransaction wrappedTx = Transaction<SystemUndeleteTransaction>::fromBytes(
-    internal::Utilities::stringToByteVector(signedTx.SerializeAsString()));
 
   // Then
   ASSERT_EQ(wrappedTx.getTransactionType(), TransactionType::SYSTEM_UNDELETE_TRANSACTION);
@@ -1253,31 +1348,37 @@ TEST_F(TransactionTest, SystemUndeleteTransactionFromTransactionBytes)
 }
 
 //-----
+TEST_F(TransactionTest, SystemUndeleteTransactionFromTransactionListBytes)
+{
+  // Given
+  proto::TransactionBody txBody;
+  txBody.set_allocated_systemundelete(new proto::SystemUndeleteTransactionBody);
+
+  proto::SignedTransaction signedTx;
+  signedTx.set_bodybytes(txBody.SerializeAsString());
+  // SignatureMap not required
+
+  proto::Transaction tx;
+  tx.set_signedtransactionbytes(signedTx.SerializeAsString());
+
+  proto::TransactionList txList;
+  *txList.add_transaction_list() = tx;
+
+  // When
+  const WrappedTransaction wrappedTx = Transaction<SystemUndeleteTransaction>::fromBytes(
+    internal::Utilities::stringToByteVector(txList.SerializeAsString()));
+
+  // Then
+  ASSERT_EQ(wrappedTx.getTransactionType(), TransactionType::SYSTEM_UNDELETE_TRANSACTION);
+  EXPECT_NE(wrappedTx.getTransaction<SystemUndeleteTransaction>(), nullptr);
+}
+
+//-----
 TEST_F(TransactionTest, TokenAssociateTransactionFromTransactionBodyBytes)
 {
   // Given
   proto::TransactionBody txBody;
   txBody.set_allocated_tokenassociate(new proto::TokenAssociateTransactionBody);
-
-  // When
-  const WrappedTransaction wrappedTx = Transaction<TokenAssociateTransaction>::fromBytes(
-    internal::Utilities::stringToByteVector(txBody.SerializeAsString()));
-
-  // Then
-  ASSERT_EQ(wrappedTx.getTransactionType(), TransactionType::TOKEN_ASSOCIATE_TRANSACTION);
-  EXPECT_NE(wrappedTx.getTransaction<TokenAssociateTransaction>(), nullptr);
-}
-
-//-----
-TEST_F(TransactionTest, TokenAssociateTransactionFromSignedTransactionBytes)
-{
-  // Given
-  proto::TransactionBody txBody;
-  txBody.set_allocated_tokenassociate(new proto::TokenAssociateTransactionBody);
-
-  proto::SignedTransaction signedTx;
-  signedTx.set_bodybytes(txBody.SerializeAsString());
-  // SignatureMap not required
 
   // When
   const WrappedTransaction wrappedTx = Transaction<TokenAssociateTransaction>::fromBytes(
@@ -1312,31 +1413,37 @@ TEST_F(TransactionTest, TokenAssociateTransactionFromTransactionBytes)
 }
 
 //-----
+TEST_F(TransactionTest, TokenAssociateTransactionFromTransactionListBytes)
+{
+  // Given
+  proto::TransactionBody txBody;
+  txBody.set_allocated_tokenassociate(new proto::TokenAssociateTransactionBody);
+
+  proto::SignedTransaction signedTx;
+  signedTx.set_bodybytes(txBody.SerializeAsString());
+  // SignatureMap not required
+
+  proto::Transaction tx;
+  tx.set_signedtransactionbytes(signedTx.SerializeAsString());
+
+  proto::TransactionList txList;
+  *txList.add_transaction_list() = tx;
+
+  // When
+  const WrappedTransaction wrappedTx = Transaction<TokenAssociateTransaction>::fromBytes(
+    internal::Utilities::stringToByteVector(txList.SerializeAsString()));
+
+  // Then
+  ASSERT_EQ(wrappedTx.getTransactionType(), TransactionType::TOKEN_ASSOCIATE_TRANSACTION);
+  EXPECT_NE(wrappedTx.getTransaction<TokenAssociateTransaction>(), nullptr);
+}
+
+//-----
 TEST_F(TransactionTest, TokenBurnTransactionFromTransactionBodyBytes)
 {
   // Given
   proto::TransactionBody txBody;
   txBody.set_allocated_tokenburn(new proto::TokenBurnTransactionBody);
-
-  // When
-  const WrappedTransaction wrappedTx =
-    Transaction<TokenBurnTransaction>::fromBytes(internal::Utilities::stringToByteVector(txBody.SerializeAsString()));
-
-  // Then
-  ASSERT_EQ(wrappedTx.getTransactionType(), TransactionType::TOKEN_BURN_TRANSACTION);
-  EXPECT_NE(wrappedTx.getTransaction<TokenBurnTransaction>(), nullptr);
-}
-
-//-----
-TEST_F(TransactionTest, TokenBurnTransactionFromSignedTransactionBytes)
-{
-  // Given
-  proto::TransactionBody txBody;
-  txBody.set_allocated_tokenburn(new proto::TokenBurnTransactionBody);
-
-  proto::SignedTransaction signedTx;
-  signedTx.set_bodybytes(txBody.SerializeAsString());
-  // SignatureMap not required
 
   // When
   const WrappedTransaction wrappedTx =
@@ -1371,31 +1478,37 @@ TEST_F(TransactionTest, TokenBurnTransactionFromTransactionBytes)
 }
 
 //-----
+TEST_F(TransactionTest, TokenBurnTransactionFromTransactionListBytes)
+{
+  // Given
+  proto::TransactionBody txBody;
+  txBody.set_allocated_tokenburn(new proto::TokenBurnTransactionBody);
+
+  proto::SignedTransaction signedTx;
+  signedTx.set_bodybytes(txBody.SerializeAsString());
+  // SignatureMap not required
+
+  proto::Transaction tx;
+  tx.set_signedtransactionbytes(signedTx.SerializeAsString());
+
+  proto::TransactionList txList;
+  *txList.add_transaction_list() = tx;
+
+  // When
+  const WrappedTransaction wrappedTx =
+    Transaction<TokenBurnTransaction>::fromBytes(internal::Utilities::stringToByteVector(txList.SerializeAsString()));
+
+  // Then
+  ASSERT_EQ(wrappedTx.getTransactionType(), TransactionType::TOKEN_BURN_TRANSACTION);
+  EXPECT_NE(wrappedTx.getTransaction<TokenBurnTransaction>(), nullptr);
+}
+
+//-----
 TEST_F(TransactionTest, TokenCreateTransactionFromTransactionBodyBytes)
 {
   // Given
   proto::TransactionBody txBody;
   txBody.set_allocated_tokencreation(new proto::TokenCreateTransactionBody);
-
-  // When
-  const WrappedTransaction wrappedTx =
-    Transaction<TokenCreateTransaction>::fromBytes(internal::Utilities::stringToByteVector(txBody.SerializeAsString()));
-
-  // Then
-  ASSERT_EQ(wrappedTx.getTransactionType(), TransactionType::TOKEN_CREATE_TRANSACTION);
-  EXPECT_NE(wrappedTx.getTransaction<TokenCreateTransaction>(), nullptr);
-}
-
-//-----
-TEST_F(TransactionTest, TokenCreateTransactionFromSignedTransactionBytes)
-{
-  // Given
-  proto::TransactionBody txBody;
-  txBody.set_allocated_tokencreation(new proto::TokenCreateTransactionBody);
-
-  proto::SignedTransaction signedTx;
-  signedTx.set_bodybytes(txBody.SerializeAsString());
-  // SignatureMap not required
 
   // When
   const WrappedTransaction wrappedTx =
@@ -1430,31 +1543,37 @@ TEST_F(TransactionTest, TokenCreateTransactionFromTransactionBytes)
 }
 
 //-----
+TEST_F(TransactionTest, TokenCreateTransactionFromTransactionListBytes)
+{
+  // Given
+  proto::TransactionBody txBody;
+  txBody.set_allocated_tokencreation(new proto::TokenCreateTransactionBody);
+
+  proto::SignedTransaction signedTx;
+  signedTx.set_bodybytes(txBody.SerializeAsString());
+  // SignatureMap not required
+
+  proto::Transaction tx;
+  tx.set_signedtransactionbytes(signedTx.SerializeAsString());
+
+  proto::TransactionList txList;
+  *txList.add_transaction_list() = tx;
+
+  // When
+  const WrappedTransaction wrappedTx =
+    Transaction<TokenCreateTransaction>::fromBytes(internal::Utilities::stringToByteVector(txList.SerializeAsString()));
+
+  // Then
+  ASSERT_EQ(wrappedTx.getTransactionType(), TransactionType::TOKEN_CREATE_TRANSACTION);
+  EXPECT_NE(wrappedTx.getTransaction<TokenCreateTransaction>(), nullptr);
+}
+
+//-----
 TEST_F(TransactionTest, TokenDeleteTransactionFromTransactionBodyBytes)
 {
   // Given
   proto::TransactionBody txBody;
   txBody.set_allocated_tokendeletion(new proto::TokenDeleteTransactionBody);
-
-  // When
-  const WrappedTransaction wrappedTx =
-    Transaction<TokenDeleteTransaction>::fromBytes(internal::Utilities::stringToByteVector(txBody.SerializeAsString()));
-
-  // Then
-  ASSERT_EQ(wrappedTx.getTransactionType(), TransactionType::TOKEN_DELETE_TRANSACTION);
-  EXPECT_NE(wrappedTx.getTransaction<TokenDeleteTransaction>(), nullptr);
-}
-
-//-----
-TEST_F(TransactionTest, TokenDeleteTransactionFromSignedTransactionBytes)
-{
-  // Given
-  proto::TransactionBody txBody;
-  txBody.set_allocated_tokendeletion(new proto::TokenDeleteTransactionBody);
-
-  proto::SignedTransaction signedTx;
-  signedTx.set_bodybytes(txBody.SerializeAsString());
-  // SignatureMap not required
 
   // When
   const WrappedTransaction wrappedTx =
@@ -1489,31 +1608,37 @@ TEST_F(TransactionTest, TokenDeleteTransactionFromTransactionBytes)
 }
 
 //-----
+TEST_F(TransactionTest, TokenDeleteTransactionFromTransactionListBytes)
+{
+  // Given
+  proto::TransactionBody txBody;
+  txBody.set_allocated_tokendeletion(new proto::TokenDeleteTransactionBody);
+
+  proto::SignedTransaction signedTx;
+  signedTx.set_bodybytes(txBody.SerializeAsString());
+  // SignatureMap not required
+
+  proto::Transaction tx;
+  tx.set_signedtransactionbytes(signedTx.SerializeAsString());
+
+  proto::TransactionList txList;
+  *txList.add_transaction_list() = tx;
+
+  // When
+  const WrappedTransaction wrappedTx =
+    Transaction<TokenDeleteTransaction>::fromBytes(internal::Utilities::stringToByteVector(txList.SerializeAsString()));
+
+  // Then
+  ASSERT_EQ(wrappedTx.getTransactionType(), TransactionType::TOKEN_DELETE_TRANSACTION);
+  EXPECT_NE(wrappedTx.getTransaction<TokenDeleteTransaction>(), nullptr);
+}
+
+//-----
 TEST_F(TransactionTest, TokenDissociateTransactionFromTransactionBodyBytes)
 {
   // Given
   proto::TransactionBody txBody;
   txBody.set_allocated_tokendissociate(new proto::TokenDissociateTransactionBody);
-
-  // When
-  const WrappedTransaction wrappedTx = Transaction<TokenDissociateTransaction>::fromBytes(
-    internal::Utilities::stringToByteVector(txBody.SerializeAsString()));
-
-  // Then
-  ASSERT_EQ(wrappedTx.getTransactionType(), TransactionType::TOKEN_DISSOCIATE_TRANSACTION);
-  EXPECT_NE(wrappedTx.getTransaction<TokenDissociateTransaction>(), nullptr);
-}
-
-//-----
-TEST_F(TransactionTest, TokenDissociateTransactionFromSignedTransactionBytes)
-{
-  // Given
-  proto::TransactionBody txBody;
-  txBody.set_allocated_tokendissociate(new proto::TokenDissociateTransactionBody);
-
-  proto::SignedTransaction signedTx;
-  signedTx.set_bodybytes(txBody.SerializeAsString());
-  // SignatureMap not required
 
   // When
   const WrappedTransaction wrappedTx = Transaction<TokenDissociateTransaction>::fromBytes(
@@ -1548,31 +1673,37 @@ TEST_F(TransactionTest, TokenDissociateTransactionFromTransactionBytes)
 }
 
 //-----
+TEST_F(TransactionTest, TokenDissociateTransactionFromTransactionListBytes)
+{
+  // Given
+  proto::TransactionBody txBody;
+  txBody.set_allocated_tokendissociate(new proto::TokenDissociateTransactionBody);
+
+  proto::SignedTransaction signedTx;
+  signedTx.set_bodybytes(txBody.SerializeAsString());
+  // SignatureMap not required
+
+  proto::Transaction tx;
+  tx.set_signedtransactionbytes(signedTx.SerializeAsString());
+
+  proto::TransactionList txList;
+  *txList.add_transaction_list() = tx;
+
+  // When
+  const WrappedTransaction wrappedTx = Transaction<TokenDissociateTransaction>::fromBytes(
+    internal::Utilities::stringToByteVector(txList.SerializeAsString()));
+
+  // Then
+  ASSERT_EQ(wrappedTx.getTransactionType(), TransactionType::TOKEN_DISSOCIATE_TRANSACTION);
+  EXPECT_NE(wrappedTx.getTransaction<TokenDissociateTransaction>(), nullptr);
+}
+
+//-----
 TEST_F(TransactionTest, TokenFeeScheduleUpdateTransactionFromTransactionBodyBytes)
 {
   // Given
   proto::TransactionBody txBody;
   txBody.set_allocated_token_fee_schedule_update(new proto::TokenFeeScheduleUpdateTransactionBody);
-
-  // When
-  const WrappedTransaction wrappedTx = Transaction<TokenFeeScheduleUpdateTransaction>::fromBytes(
-    internal::Utilities::stringToByteVector(txBody.SerializeAsString()));
-
-  // Then
-  ASSERT_EQ(wrappedTx.getTransactionType(), TransactionType::TOKEN_FEE_SCHEDULE_UPDATE_TRANSACTION);
-  EXPECT_NE(wrappedTx.getTransaction<TokenFeeScheduleUpdateTransaction>(), nullptr);
-}
-
-//-----
-TEST_F(TransactionTest, TokenFeeScheduleUpdateTransactionFromSignedTransactionBytes)
-{
-  // Given
-  proto::TransactionBody txBody;
-  txBody.set_allocated_token_fee_schedule_update(new proto::TokenFeeScheduleUpdateTransactionBody);
-
-  proto::SignedTransaction signedTx;
-  signedTx.set_bodybytes(txBody.SerializeAsString());
-  // SignatureMap not required
 
   // When
   const WrappedTransaction wrappedTx = Transaction<TokenFeeScheduleUpdateTransaction>::fromBytes(
@@ -1607,31 +1738,37 @@ TEST_F(TransactionTest, TokenFeeScheduleUpdateTransactionFromTransactionBytes)
 }
 
 //-----
+TEST_F(TransactionTest, TokenFeeScheduleUpdateTransactionFromTransactionListBytes)
+{
+  // Given
+  proto::TransactionBody txBody;
+  txBody.set_allocated_token_fee_schedule_update(new proto::TokenFeeScheduleUpdateTransactionBody);
+
+  proto::SignedTransaction signedTx;
+  signedTx.set_bodybytes(txBody.SerializeAsString());
+  // SignatureMap not required
+
+  proto::Transaction tx;
+  tx.set_signedtransactionbytes(signedTx.SerializeAsString());
+
+  proto::TransactionList txList;
+  *txList.add_transaction_list() = tx;
+
+  // When
+  const WrappedTransaction wrappedTx = Transaction<TokenFeeScheduleUpdateTransaction>::fromBytes(
+    internal::Utilities::stringToByteVector(txList.SerializeAsString()));
+
+  // Then
+  ASSERT_EQ(wrappedTx.getTransactionType(), TransactionType::TOKEN_FEE_SCHEDULE_UPDATE_TRANSACTION);
+  EXPECT_NE(wrappedTx.getTransaction<TokenFeeScheduleUpdateTransaction>(), nullptr);
+}
+
+//-----
 TEST_F(TransactionTest, TokenFreezeTransactionFromTransactionBodyBytes)
 {
   // Given
   proto::TransactionBody txBody;
   txBody.set_allocated_tokenfreeze(new proto::TokenFreezeAccountTransactionBody);
-
-  // When
-  const WrappedTransaction wrappedTx =
-    Transaction<TokenFreezeTransaction>::fromBytes(internal::Utilities::stringToByteVector(txBody.SerializeAsString()));
-
-  // Then
-  ASSERT_EQ(wrappedTx.getTransactionType(), TransactionType::TOKEN_FREEZE_TRANSACTION);
-  EXPECT_NE(wrappedTx.getTransaction<TokenFreezeTransaction>(), nullptr);
-}
-
-//-----
-TEST_F(TransactionTest, TokenFreezeTransactionFromSignedTransactionBytes)
-{
-  // Given
-  proto::TransactionBody txBody;
-  txBody.set_allocated_tokenfreeze(new proto::TokenFreezeAccountTransactionBody);
-
-  proto::SignedTransaction signedTx;
-  signedTx.set_bodybytes(txBody.SerializeAsString());
-  // SignatureMap not required
 
   // When
   const WrappedTransaction wrappedTx =
@@ -1666,31 +1803,37 @@ TEST_F(TransactionTest, TokenFreezeTransactionFromTransactionBytes)
 }
 
 //-----
+TEST_F(TransactionTest, TokenFreezeTransactionFromTransactionListBytes)
+{
+  // Given
+  proto::TransactionBody txBody;
+  txBody.set_allocated_tokenfreeze(new proto::TokenFreezeAccountTransactionBody);
+
+  proto::SignedTransaction signedTx;
+  signedTx.set_bodybytes(txBody.SerializeAsString());
+  // SignatureMap not required
+
+  proto::Transaction tx;
+  tx.set_signedtransactionbytes(signedTx.SerializeAsString());
+
+  proto::TransactionList txList;
+  *txList.add_transaction_list() = tx;
+
+  // When
+  const WrappedTransaction wrappedTx =
+    Transaction<TokenFreezeTransaction>::fromBytes(internal::Utilities::stringToByteVector(txList.SerializeAsString()));
+
+  // Then
+  ASSERT_EQ(wrappedTx.getTransactionType(), TransactionType::TOKEN_FREEZE_TRANSACTION);
+  EXPECT_NE(wrappedTx.getTransaction<TokenFreezeTransaction>(), nullptr);
+}
+
+//-----
 TEST_F(TransactionTest, TokenGrantKycTransactionFromTransactionBodyBytes)
 {
   // Given
   proto::TransactionBody txBody;
   txBody.set_allocated_tokengrantkyc(new proto::TokenGrantKycTransactionBody);
-
-  // When
-  const WrappedTransaction wrappedTx = Transaction<TokenGrantKycTransaction>::fromBytes(
-    internal::Utilities::stringToByteVector(txBody.SerializeAsString()));
-
-  // Then
-  ASSERT_EQ(wrappedTx.getTransactionType(), TransactionType::TOKEN_GRANT_KYC_TRANSACTION);
-  EXPECT_NE(wrappedTx.getTransaction<TokenGrantKycTransaction>(), nullptr);
-}
-
-//-----
-TEST_F(TransactionTest, TokenGrantKycTransactionFromSignedTransactionBytes)
-{
-  // Given
-  proto::TransactionBody txBody;
-  txBody.set_allocated_tokengrantkyc(new proto::TokenGrantKycTransactionBody);
-
-  proto::SignedTransaction signedTx;
-  signedTx.set_bodybytes(txBody.SerializeAsString());
-  // SignatureMap not required
 
   // When
   const WrappedTransaction wrappedTx = Transaction<TokenGrantKycTransaction>::fromBytes(
@@ -1725,31 +1868,37 @@ TEST_F(TransactionTest, TokenGrantKycTransactionFromTransactionBytes)
 }
 
 //-----
+TEST_F(TransactionTest, TokenGrantKycTransactionFromTransactionListBytes)
+{
+  // Given
+  proto::TransactionBody txBody;
+  txBody.set_allocated_tokengrantkyc(new proto::TokenGrantKycTransactionBody);
+
+  proto::SignedTransaction signedTx;
+  signedTx.set_bodybytes(txBody.SerializeAsString());
+  // SignatureMap not required
+
+  proto::Transaction tx;
+  tx.set_signedtransactionbytes(signedTx.SerializeAsString());
+
+  proto::TransactionList txList;
+  *txList.add_transaction_list() = tx;
+
+  // When
+  const WrappedTransaction wrappedTx = Transaction<TokenGrantKycTransaction>::fromBytes(
+    internal::Utilities::stringToByteVector(txList.SerializeAsString()));
+
+  // Then
+  ASSERT_EQ(wrappedTx.getTransactionType(), TransactionType::TOKEN_GRANT_KYC_TRANSACTION);
+  EXPECT_NE(wrappedTx.getTransaction<TokenGrantKycTransaction>(), nullptr);
+}
+
+//-----
 TEST_F(TransactionTest, TokenMintTransactionFromTransactionBodyBytes)
 {
   // Given
   proto::TransactionBody txBody;
   txBody.set_allocated_tokenmint(new proto::TokenMintTransactionBody);
-
-  // When
-  const WrappedTransaction wrappedTx =
-    Transaction<TokenMintTransaction>::fromBytes(internal::Utilities::stringToByteVector(txBody.SerializeAsString()));
-
-  // Then
-  ASSERT_EQ(wrappedTx.getTransactionType(), TransactionType::TOKEN_MINT_TRANSACTION);
-  EXPECT_NE(wrappedTx.getTransaction<TokenMintTransaction>(), nullptr);
-}
-
-//-----
-TEST_F(TransactionTest, TokenMintTransactionFromSignedTransactionBytes)
-{
-  // Given
-  proto::TransactionBody txBody;
-  txBody.set_allocated_tokenmint(new proto::TokenMintTransactionBody);
-
-  proto::SignedTransaction signedTx;
-  signedTx.set_bodybytes(txBody.SerializeAsString());
-  // SignatureMap not required
 
   // When
   const WrappedTransaction wrappedTx =
@@ -1784,31 +1933,37 @@ TEST_F(TransactionTest, TokenMintTransactionFromTransactionBytes)
 }
 
 //-----
+TEST_F(TransactionTest, TokenMintTransactionFromTransactionListBytes)
+{
+  // Given
+  proto::TransactionBody txBody;
+  txBody.set_allocated_tokenmint(new proto::TokenMintTransactionBody);
+
+  proto::SignedTransaction signedTx;
+  signedTx.set_bodybytes(txBody.SerializeAsString());
+  // SignatureMap not required
+
+  proto::Transaction tx;
+  tx.set_signedtransactionbytes(signedTx.SerializeAsString());
+
+  proto::TransactionList txList;
+  *txList.add_transaction_list() = tx;
+
+  // When
+  const WrappedTransaction wrappedTx =
+    Transaction<TokenMintTransaction>::fromBytes(internal::Utilities::stringToByteVector(txList.SerializeAsString()));
+
+  // Then
+  ASSERT_EQ(wrappedTx.getTransactionType(), TransactionType::TOKEN_MINT_TRANSACTION);
+  EXPECT_NE(wrappedTx.getTransaction<TokenMintTransaction>(), nullptr);
+}
+
+//-----
 TEST_F(TransactionTest, TokenPauseTransactionFromTransactionBodyBytes)
 {
   // Given
   proto::TransactionBody txBody;
   txBody.set_allocated_token_pause(new proto::TokenPauseTransactionBody);
-
-  // When
-  const WrappedTransaction wrappedTx =
-    Transaction<TokenPauseTransaction>::fromBytes(internal::Utilities::stringToByteVector(txBody.SerializeAsString()));
-
-  // Then
-  ASSERT_EQ(wrappedTx.getTransactionType(), TransactionType::TOKEN_PAUSE_TRANSACTION);
-  EXPECT_NE(wrappedTx.getTransaction<TokenPauseTransaction>(), nullptr);
-}
-
-//-----
-TEST_F(TransactionTest, TokenPauseTransactionFromSignedTransactionBytes)
-{
-  // Given
-  proto::TransactionBody txBody;
-  txBody.set_allocated_token_pause(new proto::TokenPauseTransactionBody);
-
-  proto::SignedTransaction signedTx;
-  signedTx.set_bodybytes(txBody.SerializeAsString());
-  // SignatureMap not required
 
   // When
   const WrappedTransaction wrappedTx =
@@ -1843,31 +1998,37 @@ TEST_F(TransactionTest, TokenPauseTransactionFromTransactionBytes)
 }
 
 //-----
+TEST_F(TransactionTest, TokenPauseTransactionFromTransactionListBytes)
+{
+  // Given
+  proto::TransactionBody txBody;
+  txBody.set_allocated_token_pause(new proto::TokenPauseTransactionBody);
+
+  proto::SignedTransaction signedTx;
+  signedTx.set_bodybytes(txBody.SerializeAsString());
+  // SignatureMap not required
+
+  proto::Transaction tx;
+  tx.set_signedtransactionbytes(signedTx.SerializeAsString());
+
+  proto::TransactionList txList;
+  *txList.add_transaction_list() = tx;
+
+  // When
+  const WrappedTransaction wrappedTx =
+    Transaction<TokenPauseTransaction>::fromBytes(internal::Utilities::stringToByteVector(txList.SerializeAsString()));
+
+  // Then
+  ASSERT_EQ(wrappedTx.getTransactionType(), TransactionType::TOKEN_PAUSE_TRANSACTION);
+  EXPECT_NE(wrappedTx.getTransaction<TokenPauseTransaction>(), nullptr);
+}
+
+//-----
 TEST_F(TransactionTest, TokenRevokeKycTransactionFromTransactionBodyBytes)
 {
   // Given
   proto::TransactionBody txBody;
   txBody.set_allocated_tokenrevokekyc(new proto::TokenRevokeKycTransactionBody);
-
-  // When
-  const WrappedTransaction wrappedTx = Transaction<TokenRevokeKycTransaction>::fromBytes(
-    internal::Utilities::stringToByteVector(txBody.SerializeAsString()));
-
-  // Then
-  ASSERT_EQ(wrappedTx.getTransactionType(), TransactionType::TOKEN_REVOKE_KYC_TRANSACTION);
-  EXPECT_NE(wrappedTx.getTransaction<TokenRevokeKycTransaction>(), nullptr);
-}
-
-//-----
-TEST_F(TransactionTest, TokenRevokeKycTransactionFromSignedTransactionBytes)
-{
-  // Given
-  proto::TransactionBody txBody;
-  txBody.set_allocated_tokenrevokekyc(new proto::TokenRevokeKycTransactionBody);
-
-  proto::SignedTransaction signedTx;
-  signedTx.set_bodybytes(txBody.SerializeAsString());
-  // SignatureMap not required
 
   // When
   const WrappedTransaction wrappedTx = Transaction<TokenRevokeKycTransaction>::fromBytes(
@@ -1902,31 +2063,37 @@ TEST_F(TransactionTest, TokenRevokeKycTransactionFromTransactionBytes)
 }
 
 //-----
+TEST_F(TransactionTest, TokenRevokeKycTransactionFromTransactionListBytes)
+{
+  // Given
+  proto::TransactionBody txBody;
+  txBody.set_allocated_tokenrevokekyc(new proto::TokenRevokeKycTransactionBody);
+
+  proto::SignedTransaction signedTx;
+  signedTx.set_bodybytes(txBody.SerializeAsString());
+  // SignatureMap not required
+
+  proto::Transaction tx;
+  tx.set_signedtransactionbytes(signedTx.SerializeAsString());
+
+  proto::TransactionList txList;
+  *txList.add_transaction_list() = tx;
+
+  // When
+  const WrappedTransaction wrappedTx = Transaction<TokenRevokeKycTransaction>::fromBytes(
+    internal::Utilities::stringToByteVector(txList.SerializeAsString()));
+
+  // Then
+  ASSERT_EQ(wrappedTx.getTransactionType(), TransactionType::TOKEN_REVOKE_KYC_TRANSACTION);
+  EXPECT_NE(wrappedTx.getTransaction<TokenRevokeKycTransaction>(), nullptr);
+}
+
+//-----
 TEST_F(TransactionTest, TokenUnfreezeTransactionFromTransactionBodyBytes)
 {
   // Given
   proto::TransactionBody txBody;
   txBody.set_allocated_tokenunfreeze(new proto::TokenUnfreezeAccountTransactionBody);
-
-  // When
-  const WrappedTransaction wrappedTx = Transaction<TokenUnfreezeTransaction>::fromBytes(
-    internal::Utilities::stringToByteVector(txBody.SerializeAsString()));
-
-  // Then
-  ASSERT_EQ(wrappedTx.getTransactionType(), TransactionType::TOKEN_UNFREEZE_TRANSACTION);
-  EXPECT_NE(wrappedTx.getTransaction<TokenUnfreezeTransaction>(), nullptr);
-}
-
-//-----
-TEST_F(TransactionTest, TokenUnfreezeTransactionFromSignedTransactionBytes)
-{
-  // Given
-  proto::TransactionBody txBody;
-  txBody.set_allocated_tokenunfreeze(new proto::TokenUnfreezeAccountTransactionBody);
-
-  proto::SignedTransaction signedTx;
-  signedTx.set_bodybytes(txBody.SerializeAsString());
-  // SignatureMap not required
 
   // When
   const WrappedTransaction wrappedTx = Transaction<TokenUnfreezeTransaction>::fromBytes(
@@ -1961,31 +2128,37 @@ TEST_F(TransactionTest, TokenUnfreezeTransactionFromTransactionBytes)
 }
 
 //-----
+TEST_F(TransactionTest, TokenUnfreezeTransactionFromTransactionListBytes)
+{
+  // Given
+  proto::TransactionBody txBody;
+  txBody.set_allocated_tokenunfreeze(new proto::TokenUnfreezeAccountTransactionBody);
+
+  proto::SignedTransaction signedTx;
+  signedTx.set_bodybytes(txBody.SerializeAsString());
+  // SignatureMap not required
+
+  proto::Transaction tx;
+  tx.set_signedtransactionbytes(signedTx.SerializeAsString());
+
+  proto::TransactionList txList;
+  *txList.add_transaction_list() = tx;
+
+  // When
+  const WrappedTransaction wrappedTx = Transaction<TokenUnfreezeTransaction>::fromBytes(
+    internal::Utilities::stringToByteVector(txList.SerializeAsString()));
+
+  // Then
+  ASSERT_EQ(wrappedTx.getTransactionType(), TransactionType::TOKEN_UNFREEZE_TRANSACTION);
+  EXPECT_NE(wrappedTx.getTransaction<TokenUnfreezeTransaction>(), nullptr);
+}
+
+//-----
 TEST_F(TransactionTest, TokenUnpauseTransactionFromTransactionBodyBytes)
 {
   // Given
   proto::TransactionBody txBody;
   txBody.set_allocated_token_unpause(new proto::TokenUnpauseTransactionBody);
-
-  // When
-  const WrappedTransaction wrappedTx = Transaction<TokenUnpauseTransaction>::fromBytes(
-    internal::Utilities::stringToByteVector(txBody.SerializeAsString()));
-
-  // Then
-  ASSERT_EQ(wrappedTx.getTransactionType(), TransactionType::TOKEN_UNPAUSE_TRANSACTION);
-  EXPECT_NE(wrappedTx.getTransaction<TokenUnpauseTransaction>(), nullptr);
-}
-
-//-----
-TEST_F(TransactionTest, TokenUnpauseTransactionFromSignedTransactionBytes)
-{
-  // Given
-  proto::TransactionBody txBody;
-  txBody.set_allocated_token_unpause(new proto::TokenUnpauseTransactionBody);
-
-  proto::SignedTransaction signedTx;
-  signedTx.set_bodybytes(txBody.SerializeAsString());
-  // SignatureMap not required
 
   // When
   const WrappedTransaction wrappedTx = Transaction<TokenUnpauseTransaction>::fromBytes(
@@ -2020,31 +2193,37 @@ TEST_F(TransactionTest, TokenUnpauseTransactionFromTransactionBytes)
 }
 
 //-----
+TEST_F(TransactionTest, TokenUnpauseTransactionFromTransactionListBytes)
+{
+  // Given
+  proto::TransactionBody txBody;
+  txBody.set_allocated_token_unpause(new proto::TokenUnpauseTransactionBody);
+
+  proto::SignedTransaction signedTx;
+  signedTx.set_bodybytes(txBody.SerializeAsString());
+  // SignatureMap not required
+
+  proto::Transaction tx;
+  tx.set_signedtransactionbytes(signedTx.SerializeAsString());
+
+  proto::TransactionList txList;
+  *txList.add_transaction_list() = tx;
+
+  // When
+  const WrappedTransaction wrappedTx = Transaction<TokenUnpauseTransaction>::fromBytes(
+    internal::Utilities::stringToByteVector(txList.SerializeAsString()));
+
+  // Then
+  ASSERT_EQ(wrappedTx.getTransactionType(), TransactionType::TOKEN_UNPAUSE_TRANSACTION);
+  EXPECT_NE(wrappedTx.getTransaction<TokenUnpauseTransaction>(), nullptr);
+}
+
+//-----
 TEST_F(TransactionTest, TokenUpdateTransactionFromTransactionBodyBytes)
 {
   // Given
   proto::TransactionBody txBody;
   txBody.set_allocated_tokenupdate(new proto::TokenUpdateTransactionBody);
-
-  // When
-  const WrappedTransaction wrappedTx =
-    Transaction<TokenUpdateTransaction>::fromBytes(internal::Utilities::stringToByteVector(txBody.SerializeAsString()));
-
-  // Then
-  ASSERT_EQ(wrappedTx.getTransactionType(), TransactionType::TOKEN_UPDATE_TRANSACTION);
-  EXPECT_NE(wrappedTx.getTransaction<TokenUpdateTransaction>(), nullptr);
-}
-
-//-----
-TEST_F(TransactionTest, TokenUpdateTransactionFromSignedTransactionBytes)
-{
-  // Given
-  proto::TransactionBody txBody;
-  txBody.set_allocated_tokenupdate(new proto::TokenUpdateTransactionBody);
-
-  proto::SignedTransaction signedTx;
-  signedTx.set_bodybytes(txBody.SerializeAsString());
-  // SignatureMap not required
 
   // When
   const WrappedTransaction wrappedTx =
@@ -2079,31 +2258,37 @@ TEST_F(TransactionTest, TokenUpdateTransactionFromTransactionBytes)
 }
 
 //-----
+TEST_F(TransactionTest, TokenUpdateTransactionFromTransactionListBytes)
+{
+  // Given
+  proto::TransactionBody txBody;
+  txBody.set_allocated_tokenupdate(new proto::TokenUpdateTransactionBody);
+
+  proto::SignedTransaction signedTx;
+  signedTx.set_bodybytes(txBody.SerializeAsString());
+  // SignatureMap not required
+
+  proto::Transaction tx;
+  tx.set_signedtransactionbytes(signedTx.SerializeAsString());
+
+  proto::TransactionList txList;
+  *txList.add_transaction_list() = tx;
+
+  // When
+  const WrappedTransaction wrappedTx =
+    Transaction<TokenUpdateTransaction>::fromBytes(internal::Utilities::stringToByteVector(txList.SerializeAsString()));
+
+  // Then
+  ASSERT_EQ(wrappedTx.getTransactionType(), TransactionType::TOKEN_UPDATE_TRANSACTION);
+  EXPECT_NE(wrappedTx.getTransaction<TokenUpdateTransaction>(), nullptr);
+}
+
+//-----
 TEST_F(TransactionTest, TokenWipeTransactionFromTransactionBodyBytes)
 {
   // Given
   proto::TransactionBody txBody;
   txBody.set_allocated_tokenwipe(new proto::TokenWipeAccountTransactionBody);
-
-  // When
-  const WrappedTransaction wrappedTx =
-    Transaction<TokenWipeTransaction>::fromBytes(internal::Utilities::stringToByteVector(txBody.SerializeAsString()));
-
-  // Then
-  ASSERT_EQ(wrappedTx.getTransactionType(), TransactionType::TOKEN_WIPE_TRANSACTION);
-  EXPECT_NE(wrappedTx.getTransaction<TokenWipeTransaction>(), nullptr);
-}
-
-//-----
-TEST_F(TransactionTest, TokenWipeTransactionFromSignedTransactionBytes)
-{
-  // Given
-  proto::TransactionBody txBody;
-  txBody.set_allocated_tokenwipe(new proto::TokenWipeAccountTransactionBody);
-
-  proto::SignedTransaction signedTx;
-  signedTx.set_bodybytes(txBody.SerializeAsString());
-  // SignatureMap not required
 
   // When
   const WrappedTransaction wrappedTx =
@@ -2138,31 +2323,37 @@ TEST_F(TransactionTest, TokenWipeTransactionFromTransactionBytes)
 }
 
 //-----
+TEST_F(TransactionTest, TokenWipeTransactionFromTransactionListBytes)
+{
+  // Given
+  proto::TransactionBody txBody;
+  txBody.set_allocated_tokenwipe(new proto::TokenWipeAccountTransactionBody);
+
+  proto::SignedTransaction signedTx;
+  signedTx.set_bodybytes(txBody.SerializeAsString());
+  // SignatureMap not required
+
+  proto::Transaction tx;
+  tx.set_signedtransactionbytes(signedTx.SerializeAsString());
+
+  proto::TransactionList txList;
+  *txList.add_transaction_list() = tx;
+
+  // When
+  const WrappedTransaction wrappedTx =
+    Transaction<TokenWipeTransaction>::fromBytes(internal::Utilities::stringToByteVector(txList.SerializeAsString()));
+
+  // Then
+  ASSERT_EQ(wrappedTx.getTransactionType(), TransactionType::TOKEN_WIPE_TRANSACTION);
+  EXPECT_NE(wrappedTx.getTransaction<TokenWipeTransaction>(), nullptr);
+}
+
+//-----
 TEST_F(TransactionTest, TopicCreateTransactionFromTransactionBodyBytes)
 {
   // Given
   proto::TransactionBody txBody;
   txBody.set_allocated_consensuscreatetopic(new proto::ConsensusCreateTopicTransactionBody);
-
-  // When
-  const WrappedTransaction wrappedTx =
-    Transaction<TopicCreateTransaction>::fromBytes(internal::Utilities::stringToByteVector(txBody.SerializeAsString()));
-
-  // Then
-  ASSERT_EQ(wrappedTx.getTransactionType(), TransactionType::TOPIC_CREATE_TRANSACTION);
-  EXPECT_NE(wrappedTx.getTransaction<TopicCreateTransaction>(), nullptr);
-}
-
-//-----
-TEST_F(TransactionTest, TopicCreateTransactionFromSignedTransactionBytes)
-{
-  // Given
-  proto::TransactionBody txBody;
-  txBody.set_allocated_consensuscreatetopic(new proto::ConsensusCreateTopicTransactionBody);
-
-  proto::SignedTransaction signedTx;
-  signedTx.set_bodybytes(txBody.SerializeAsString());
-  // SignatureMap not required
 
   // When
   const WrappedTransaction wrappedTx =
@@ -2197,31 +2388,37 @@ TEST_F(TransactionTest, TopicCreateTransactionFromTransactionBytes)
 }
 
 //-----
+TEST_F(TransactionTest, TopicCreateTransactionFromTransactionListBytes)
+{
+  // Given
+  proto::TransactionBody txBody;
+  txBody.set_allocated_consensuscreatetopic(new proto::ConsensusCreateTopicTransactionBody);
+
+  proto::SignedTransaction signedTx;
+  signedTx.set_bodybytes(txBody.SerializeAsString());
+  // SignatureMap not required
+
+  proto::Transaction tx;
+  tx.set_signedtransactionbytes(signedTx.SerializeAsString());
+
+  proto::TransactionList txList;
+  *txList.add_transaction_list() = tx;
+
+  // When
+  const WrappedTransaction wrappedTx =
+    Transaction<TopicCreateTransaction>::fromBytes(internal::Utilities::stringToByteVector(txList.SerializeAsString()));
+
+  // Then
+  ASSERT_EQ(wrappedTx.getTransactionType(), TransactionType::TOPIC_CREATE_TRANSACTION);
+  EXPECT_NE(wrappedTx.getTransaction<TopicCreateTransaction>(), nullptr);
+}
+
+//-----
 TEST_F(TransactionTest, TopicDeleteTransactionFromTransactionBodyBytes)
 {
   // Given
   proto::TransactionBody txBody;
   txBody.set_allocated_consensusdeletetopic(new proto::ConsensusDeleteTopicTransactionBody);
-
-  // When
-  const WrappedTransaction wrappedTx =
-    Transaction<TopicDeleteTransaction>::fromBytes(internal::Utilities::stringToByteVector(txBody.SerializeAsString()));
-
-  // Then
-  ASSERT_EQ(wrappedTx.getTransactionType(), TransactionType::TOPIC_DELETE_TRANSACTION);
-  EXPECT_NE(wrappedTx.getTransaction<TopicDeleteTransaction>(), nullptr);
-}
-
-//-----
-TEST_F(TransactionTest, TopicDeleteTransactionFromSignedTransactionBytes)
-{
-  // Given
-  proto::TransactionBody txBody;
-  txBody.set_allocated_consensusdeletetopic(new proto::ConsensusDeleteTopicTransactionBody);
-
-  proto::SignedTransaction signedTx;
-  signedTx.set_bodybytes(txBody.SerializeAsString());
-  // SignatureMap not required
 
   // When
   const WrappedTransaction wrappedTx =
@@ -2256,6 +2453,32 @@ TEST_F(TransactionTest, TopicDeleteTransactionFromTransactionBytes)
 }
 
 //-----
+TEST_F(TransactionTest, TopicDeleteTransactionFromTransactionListBytes)
+{
+  // Given
+  proto::TransactionBody txBody;
+  txBody.set_allocated_consensusdeletetopic(new proto::ConsensusDeleteTopicTransactionBody);
+
+  proto::SignedTransaction signedTx;
+  signedTx.set_bodybytes(txBody.SerializeAsString());
+  // SignatureMap not required
+
+  proto::Transaction tx;
+  tx.set_signedtransactionbytes(signedTx.SerializeAsString());
+
+  proto::TransactionList txList;
+  *txList.add_transaction_list() = tx;
+
+  // When
+  const WrappedTransaction wrappedTx =
+    Transaction<TopicDeleteTransaction>::fromBytes(internal::Utilities::stringToByteVector(txList.SerializeAsString()));
+
+  // Then
+  ASSERT_EQ(wrappedTx.getTransactionType(), TransactionType::TOPIC_DELETE_TRANSACTION);
+  EXPECT_NE(wrappedTx.getTransaction<TopicDeleteTransaction>(), nullptr);
+}
+
+//-----
 TEST_F(TransactionTest, TopicMessageSubmitTransactionFromTransactionBodyBytes)
 {
   // Given
@@ -2265,26 +2488,6 @@ TEST_F(TransactionTest, TopicMessageSubmitTransactionFromTransactionBodyBytes)
   // When
   const WrappedTransaction wrappedTx = Transaction<TopicMessageSubmitTransaction>::fromBytes(
     internal::Utilities::stringToByteVector(txBody.SerializeAsString()));
-
-  // Then
-  ASSERT_EQ(wrappedTx.getTransactionType(), TransactionType::TOPIC_MESSAGE_SUBMIT_TRANSACTION);
-  EXPECT_NE(wrappedTx.getTransaction<TopicMessageSubmitTransaction>(), nullptr);
-}
-
-//-----
-TEST_F(TransactionTest, TopicMessageSubmitTransactionFromSignedTransactionBytes)
-{
-  // Given
-  proto::TransactionBody txBody;
-  txBody.set_allocated_consensussubmitmessage(new proto::ConsensusSubmitMessageTransactionBody);
-
-  proto::SignedTransaction signedTx;
-  signedTx.set_bodybytes(txBody.SerializeAsString());
-  // SignatureMap not required
-
-  // When
-  const WrappedTransaction wrappedTx = Transaction<TopicMessageSubmitTransaction>::fromBytes(
-    internal::Utilities::stringToByteVector(signedTx.SerializeAsString()));
 
   // Then
   ASSERT_EQ(wrappedTx.getTransactionType(), TransactionType::TOPIC_MESSAGE_SUBMIT_TRANSACTION);
@@ -2315,6 +2518,32 @@ TEST_F(TransactionTest, TopicMessageSubmitTransactionFromTransactionBytes)
 }
 
 //-----
+TEST_F(TransactionTest, TopicMessageSubmitTransactionFromTransactionListBytes)
+{
+  // Given
+  proto::TransactionBody txBody;
+  txBody.set_allocated_consensussubmitmessage(new proto::ConsensusSubmitMessageTransactionBody);
+
+  proto::SignedTransaction signedTx;
+  signedTx.set_bodybytes(txBody.SerializeAsString());
+  // SignatureMap not required
+
+  proto::Transaction tx;
+  tx.set_signedtransactionbytes(signedTx.SerializeAsString());
+
+  proto::TransactionList txList;
+  *txList.add_transaction_list() = tx;
+
+  // When
+  const WrappedTransaction wrappedTx = Transaction<TopicMessageSubmitTransaction>::fromBytes(
+    internal::Utilities::stringToByteVector(txList.SerializeAsString()));
+
+  // Then
+  ASSERT_EQ(wrappedTx.getTransactionType(), TransactionType::TOPIC_MESSAGE_SUBMIT_TRANSACTION);
+  EXPECT_NE(wrappedTx.getTransaction<TopicMessageSubmitTransaction>(), nullptr);
+}
+
+//-----
 TEST_F(TransactionTest, TopicUpdateTransactionFromTransactionBodyBytes)
 {
   // Given
@@ -2324,26 +2553,6 @@ TEST_F(TransactionTest, TopicUpdateTransactionFromTransactionBodyBytes)
   // When
   const WrappedTransaction wrappedTx =
     Transaction<TopicUpdateTransaction>::fromBytes(internal::Utilities::stringToByteVector(txBody.SerializeAsString()));
-
-  // Then
-  ASSERT_EQ(wrappedTx.getTransactionType(), TransactionType::TOPIC_UPDATE_TRANSACTION);
-  EXPECT_NE(wrappedTx.getTransaction<TopicUpdateTransaction>(), nullptr);
-}
-
-//-----
-TEST_F(TransactionTest, TopicUpdateTransactionFromSignedTransactionBytes)
-{
-  // Given
-  proto::TransactionBody txBody;
-  txBody.set_allocated_consensusupdatetopic(new proto::ConsensusUpdateTopicTransactionBody);
-
-  proto::SignedTransaction signedTx;
-  signedTx.set_bodybytes(txBody.SerializeAsString());
-  // SignatureMap not required
-
-  // When
-  const WrappedTransaction wrappedTx = Transaction<TopicUpdateTransaction>::fromBytes(
-    internal::Utilities::stringToByteVector(signedTx.SerializeAsString()));
 
   // Then
   ASSERT_EQ(wrappedTx.getTransactionType(), TransactionType::TOPIC_UPDATE_TRANSACTION);
@@ -2374,6 +2583,32 @@ TEST_F(TransactionTest, TopicUpdateTransactionFromTransactionBytes)
 }
 
 //-----
+TEST_F(TransactionTest, TopicUpdateTransactionFromTransactionListBytes)
+{
+  // Given
+  proto::TransactionBody txBody;
+  txBody.set_allocated_consensusupdatetopic(new proto::ConsensusUpdateTopicTransactionBody);
+
+  proto::SignedTransaction signedTx;
+  signedTx.set_bodybytes(txBody.SerializeAsString());
+  // SignatureMap not required
+
+  proto::Transaction tx;
+  tx.set_signedtransactionbytes(signedTx.SerializeAsString());
+
+  proto::TransactionList txList;
+  *txList.add_transaction_list() = tx;
+
+  // When
+  const WrappedTransaction wrappedTx =
+    Transaction<TopicUpdateTransaction>::fromBytes(internal::Utilities::stringToByteVector(txList.SerializeAsString()));
+
+  // Then
+  ASSERT_EQ(wrappedTx.getTransactionType(), TransactionType::TOPIC_UPDATE_TRANSACTION);
+  EXPECT_NE(wrappedTx.getTransaction<TopicUpdateTransaction>(), nullptr);
+}
+
+//-----
 TEST_F(TransactionTest, TransferTransactionFromTransactionBodyBytes)
 {
   // Given
@@ -2383,26 +2618,6 @@ TEST_F(TransactionTest, TransferTransactionFromTransactionBodyBytes)
   // When
   const WrappedTransaction wrappedTx =
     Transaction<TransferTransaction>::fromBytes(internal::Utilities::stringToByteVector(txBody.SerializeAsString()));
-
-  // Then
-  ASSERT_EQ(wrappedTx.getTransactionType(), TransactionType::TRANSFER_TRANSACTION);
-  EXPECT_NE(wrappedTx.getTransaction<TransferTransaction>(), nullptr);
-}
-
-//-----
-TEST_F(TransactionTest, TransferTransactionFromSignedTransactionBytes)
-{
-  // Given
-  proto::TransactionBody txBody;
-  txBody.set_allocated_cryptotransfer(new proto::CryptoTransferTransactionBody);
-
-  proto::SignedTransaction signedTx;
-  signedTx.set_bodybytes(txBody.SerializeAsString());
-  // SignatureMap not required
-
-  // When
-  const WrappedTransaction wrappedTx =
-    Transaction<TransferTransaction>::fromBytes(internal::Utilities::stringToByteVector(signedTx.SerializeAsString()));
 
   // Then
   ASSERT_EQ(wrappedTx.getTransactionType(), TransactionType::TRANSFER_TRANSACTION);
@@ -2426,6 +2641,32 @@ TEST_F(TransactionTest, TransferTransactionFromTransactionBytes)
   // When
   const WrappedTransaction wrappedTx =
     Transaction<TransferTransaction>::fromBytes(internal::Utilities::stringToByteVector(tx.SerializeAsString()));
+
+  // Then
+  ASSERT_EQ(wrappedTx.getTransactionType(), TransactionType::TRANSFER_TRANSACTION);
+  EXPECT_NE(wrappedTx.getTransaction<TransferTransaction>(), nullptr);
+}
+
+//-----
+TEST_F(TransactionTest, TransferTransactionFromTransactionListBytes)
+{
+  // Given
+  proto::TransactionBody txBody;
+  txBody.set_allocated_cryptotransfer(new proto::CryptoTransferTransactionBody);
+
+  proto::SignedTransaction signedTx;
+  signedTx.set_bodybytes(txBody.SerializeAsString());
+  // SignatureMap not required
+
+  proto::Transaction tx;
+  tx.set_signedtransactionbytes(signedTx.SerializeAsString());
+
+  proto::TransactionList txList;
+  *txList.add_transaction_list() = tx;
+
+  // When
+  const WrappedTransaction wrappedTx =
+    Transaction<TransferTransaction>::fromBytes(internal::Utilities::stringToByteVector(txList.SerializeAsString()));
 
   // Then
   ASSERT_EQ(wrappedTx.getTransactionType(), TransactionType::TRANSFER_TRANSACTION);

--- a/sdk/tests/unit/TransferTransactionTest.cc
+++ b/sdk/tests/unit/TransferTransactionTest.cc
@@ -33,12 +33,6 @@ using namespace Hedera;
 class TransferTransactionTest : public ::testing::Test
 {
 protected:
-  void SetUp() override
-  {
-    mClient.setOperator(getTestAccountId1(), ECDSAsecp256k1PrivateKey::generatePrivateKey().get());
-  }
-
-  [[nodiscard]] inline const Client& getTestClient() const { return mClient; }
   [[nodiscard]] inline const AccountId& getTestAccountId1() const { return mAccountId1; }
   [[nodiscard]] inline const AccountId& getTestAccountId2() const { return mAccountId2; }
   [[nodiscard]] inline const TokenId& getTestTokenId() const { return mTokenId; }
@@ -48,7 +42,6 @@ protected:
   [[nodiscard]] inline bool getTestApproval() const { return mApproval; }
 
 private:
-  Client mClient;
   const AccountId mAccountId1 = AccountId(10ULL);
   const AccountId mAccountId2 = AccountId(20ULL);
   const TokenId mTokenId = TokenId(30ULL);
@@ -150,8 +143,10 @@ TEST_F(TransferTransactionTest, AddHbarTransfer)
 TEST_F(TransferTransactionTest, AddHbarTransferFrozen)
 {
   // Given
-  TransferTransaction transaction;
-  ASSERT_NO_THROW(transaction.freezeWith(&getTestClient()));
+  TransferTransaction transaction = TransferTransaction()
+                                      .setNodeAccountIds({ AccountId(1ULL) })
+                                      .setTransactionId(TransactionId::generate(AccountId(1ULL)));
+  ASSERT_NO_THROW(transaction.freeze());
 
   // When / Then
   EXPECT_THROW(transaction.addHbarTransfer(getTestAccountId1(), getTestAmount()), IllegalStateException);
@@ -192,8 +187,10 @@ TEST_F(TransferTransactionTest, AddTokenTransfer)
 TEST_F(TransferTransactionTest, AddTokenTransferFrozen)
 {
   // Given
-  TransferTransaction transaction;
-  ASSERT_NO_THROW(transaction.freezeWith(&getTestClient()));
+  TransferTransaction transaction = TransferTransaction()
+                                      .setNodeAccountIds({ AccountId(1ULL) })
+                                      .setTransactionId(TransactionId::generate(AccountId(1ULL)));
+  ASSERT_NO_THROW(transaction.freeze());
 
   // When / Then
   EXPECT_THROW(transaction.addTokenTransfer(getTestTokenId(), getTestAccountId1(), getTestAmount().toTinybars()),
@@ -237,8 +234,10 @@ TEST_F(TransferTransactionTest, AddNftTransfer)
 TEST_F(TransferTransactionTest, AddNftTransferFrozen)
 {
   // Given
-  TransferTransaction transaction;
-  ASSERT_NO_THROW(transaction.freezeWith(&getTestClient()));
+  TransferTransaction transaction = TransferTransaction()
+                                      .setNodeAccountIds({ AccountId(1ULL) })
+                                      .setTransactionId(TransactionId::generate(AccountId(1ULL)));
+  ASSERT_NO_THROW(transaction.freeze());
 
   // When / Then
   EXPECT_THROW(transaction.addNftTransfer(getTestNftId(), getTestAccountId1(), getTestAccountId2()),
@@ -283,8 +282,10 @@ TEST_F(TransferTransactionTest, AddTokenTransferWithDecimals)
 TEST_F(TransferTransactionTest, AddTokenTransferWithDecimalsFrozen)
 {
   // Given
-  TransferTransaction transaction;
-  ASSERT_NO_THROW(transaction.freezeWith(&getTestClient()));
+  TransferTransaction transaction = TransferTransaction()
+                                      .setNodeAccountIds({ AccountId(1ULL) })
+                                      .setTransactionId(TransactionId::generate(AccountId(1ULL)));
+  ASSERT_NO_THROW(transaction.freeze());
 
   // When / Then
   EXPECT_THROW(transaction.addTokenTransferWithDecimals(getTestTokenId(),


### PR DESCRIPTION
**Description**:
This PR finishes up and completes all API implementations for `Transaction`, `Query`, and a lot of the internal utility classes used by the SDK (such as `BaseNetwork` and derived classes, `BaseNode` and derived classes, etc.). There were quite a few changes and reworks of processing and I will try to highlight all of them here.

This PR, which originally started as a PR to implement the `ConsensusPubSubChunkedExample`, turned into a whole `Executable` processing overhaul which now matches more closely with how other Hedera SDKs operate.

Major changes:

- Add `ConsensusPubSubChunkedExample`, which shows users how to send and subscribe to large topic messages.
- `Transaction`s now properly pre-generate `Transaction` protobuf objects for a random 1/3 of the selected `Client` network’s nodes.
- All `Transaction` APIs are now implemented.
- `Query` cost is queried from the network and properly added to the `Query` as it is sent as a `TransferTransaction` to its header.
- All `Query` APIs are now implemented.
- `ChunkedTransaction`s add their data correctly to each chunk as it is sent, as opposed to copying a whole new `ChunkedTransaction` and sending only a portion of the data.
- All `ChunkedTransaction` APIs are now implemented.
- Common backend network processing for `Network`, `MirrorNetwork`, `Node`, `MirrorNode`, etc. was consolidated into base classes (i.e. `BaseNode`, `BaseNetwork`, `BaseNodeAddress`). These APIs were fully implemented as well.
- Completed all APIs for `NodeAddress` and `NodeAddressBook`.

Other changes:

- `sign` and `getNodesWithAccountIds` APIs removed from `Client`. Now `getNetwork()` can be called to get the `Network` object and get `Node`s that way (which lines up with how other SDKs do it). This is done in `Executable` via the `getNodesFromNodeAccountIds()` and `getNodeIndexForExecute()` private functions.
- `toSignaturePairProtobuf()` added for `PublicKey` classes.
- `makeRequest()` and `submitRequest()` function signatures changed for `Executable` derived classes that better streamline creating and sending protobufs to the network.
- `isKnownNetwork()` added to `LedgerId` which allows a user to determine if the ledger represented by that `LedgerId` is known (i.e. Mainnet, Testnet, or Previewnet).
- `fromBytes()` added to `PublicKey`, which allows a `PublicKey` to be created from raw bytes.
- `operator!=` and `less<Hedera::TransactionId>` added to `TransactionId`.
- `MaxQueryPaymentExceededException` added.
- Update all derived `Transaction` unit tests setter/getter tests to properly be allowed to freeze (set node account ID and transaction ID).
- Add tests for `Transaction::fromBytes()` that deserializes `TransactionList` protobuf objects.

**Related issue(s)**:

Fixes #496 

**Checklist**

- [x] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
