### PR TITLE
Add `GetAddressBookExample`

### DIFF
--- a/sdk/examples/CMakeLists.txt
+++ b/sdk/examples/CMakeLists.txt
@@ -16,6 +16,7 @@ set(EXEMPT_CUSTOM_FEES_EXAMPLE_NAME ${PROJECT_NAME}-exempt-custom-fees-example)
 set(FILE_APPEND_CHUNKED_EXAMPLE_NAME ${PROJECT_NAME}-file-append-chunked-example)
 set(GENERATE_PRIVATE_KEY_FROM_MNEMONIC_EXAMPLE_NAME ${PROJECT_NAME}-generate-private-key-from-mnemonic-example)
 set(GET_ACCOUNT_BALANCE_EXAMPLE_NAME ${PROJECT_NAME}-get-account-balance-example)
+set(GET_ADDRESS_BOOK_EXAMPLE_NAME ${PROJECT_NAME}-get-address-book-example)
 set(GET_FILE_CONTENTS_EXAMPLE_NAME ${PROJECT_NAME}-get-file-contents-example)
 set(NFT_ADD_REMOVE_ALLOWANCES_EXAMPLE_NAME ${PROJECT_NAME}-nft-add-remove-allowances-example)
 set(SCHEDULE_EXAMPLE_NAME ${PROJECT_NAME}-schedule-example)
@@ -46,6 +47,7 @@ add_executable(${EXEMPT_CUSTOM_FEES_EXAMPLE_NAME} ExemptCustomFeesExample.cc)
 add_executable(${FILE_APPEND_CHUNKED_EXAMPLE_NAME} FileAppendChunkedExample.cc)
 add_executable(${GENERATE_PRIVATE_KEY_FROM_MNEMONIC_EXAMPLE_NAME} GeneratePrivateKeyFromMnemonic.cc)
 add_executable(${GET_ACCOUNT_BALANCE_EXAMPLE_NAME} GetAccountBalanceExample.cc)
+add_executable(${GET_ADDRESS_BOOK_EXAMPLE_NAME} GetAddressBookExample.cc)
 add_executable(${GET_FILE_CONTENTS_EXAMPLE_NAME} GetFileContentsExample.cc)
 add_executable(${NFT_ADD_REMOVE_ALLOWANCES_EXAMPLE_NAME} NftAddRemoveAllowancesExample.cc)
 add_executable(${SCHEDULE_EXAMPLE_NAME} ScheduleExample.cc)
@@ -94,6 +96,7 @@ target_link_libraries(${EXEMPT_CUSTOM_FEES_EXAMPLE_NAME} PUBLIC ${PROJECT_NAME})
 target_link_libraries(${FILE_APPEND_CHUNKED_EXAMPLE_NAME} PUBLIC ${PROJECT_NAME})
 target_link_libraries(${GENERATE_PRIVATE_KEY_FROM_MNEMONIC_EXAMPLE_NAME} PUBLIC ${PROJECT_NAME})
 target_link_libraries(${GET_ACCOUNT_BALANCE_EXAMPLE_NAME} PUBLIC ${PROJECT_NAME})
+target_link_libraries(${GET_ADDRESS_BOOK_EXAMPLE_NAME} PUBLIC ${PROJECT_NAME})
 target_link_libraries(${GET_FILE_CONTENTS_EXAMPLE_NAME} PUBLIC ${PROJECT_NAME})
 target_link_libraries(${NFT_ADD_REMOVE_ALLOWANCES_EXAMPLE_NAME} PUBLIC ${PROJECT_NAME})
 target_link_libraries(${SCHEDULE_EXAMPLE_NAME} PUBLIC ${PROJECT_NAME})
@@ -127,6 +130,7 @@ install(TARGETS
         ${FILE_APPEND_CHUNKED_EXAMPLE_NAME}
         ${GENERATE_PRIVATE_KEY_FROM_MNEMONIC_EXAMPLE_NAME}
         ${GET_ACCOUNT_BALANCE_EXAMPLE_NAME}
+        ${GET_ADDRESS_BOOK_EXAMPLE_NAME}
         ${GET_FILE_CONTENTS_EXAMPLE_NAME}
         ${NFT_ADD_REMOVE_ALLOWANCES_EXAMPLE_NAME}
         ${SCHEDULE_EXAMPLE_NAME}

--- a/sdk/examples/GetAddressBookExample.cc
+++ b/sdk/examples/GetAddressBookExample.cc
@@ -1,0 +1,44 @@
+/*-
+ *
+ * Hedera C++ SDK
+ *
+ * Copyright (C) 2020 - 2023 Hedera Hashgraph, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+#include "AddressBookQuery.h"
+#include "Client.h"
+#include "FileId.h"
+#include "NodeAddressBook.h"
+
+#include <iostream>
+
+using namespace Hedera;
+
+int main(int argc, char** argv)
+{
+  // Create a client for the Hedera network of which to get the address book.
+  Client client = Client::forTestnet();
+
+  // Query for the address book using the client.
+  const NodeAddressBook nodeAddressBook = AddressBookQuery().setFileId(FileId::ADDRESS_BOOK).execute(client);
+
+  // Print off the received addresses contained in the address book.
+  for (const auto& nodeAddress : nodeAddressBook.getNodeAddresses())
+  {
+    std::cout << nodeAddress.toString() << std::endl;
+  }
+
+  return 0;
+}

--- a/sdk/main/CMakeLists.txt
+++ b/sdk/main/CMakeLists.txt
@@ -12,6 +12,7 @@ add_library(${PROJECT_NAME} STATIC
         src/AccountRecordsQuery.cc
         src/AccountStakersQuery.cc
         src/AccountUpdateTransaction.cc
+        src/AddressBookQuery.cc
         src/AssessedCustomFee.cc
         src/ChunkedTransaction.cc
         src/Client.cc
@@ -40,6 +41,7 @@ add_library(${PROJECT_NAME} STATIC
         src/ECDSAsecp256k1PublicKey.cc
         src/ED25519PrivateKey.cc
         src/ED25519PublicKey.cc
+        src/Endpoint.cc
         src/EthereumFlow.cc
         src/EthereumTransaction.cc
         src/EthereumTransactionData.cc
@@ -61,6 +63,7 @@ add_library(${PROJECT_NAME} STATIC
         src/FreezeType.cc
         src/HbarAllowance.cc
         src/HbarTransfer.cc
+        src/IPv4Address.cc
         src/Key.cc
         src/KeyList.cc
         src/LedgerId.cc
@@ -69,6 +72,8 @@ add_library(${PROJECT_NAME} STATIC
         src/NetworkVersionInfo.cc
         src/NetworkVersionInfoQuery.cc
         src/NftId.cc
+        src/NodeAddress.cc
+        src/NodeAddressBook.cc
         src/PrivateKey.cc
         src/ProxyStaker.cc
         src/PublicKey.cc
@@ -136,17 +141,13 @@ add_library(${PROJECT_NAME} STATIC
         src/impl/BaseNode.cc
         src/impl/BaseNodeAddress.cc
         src/impl/DerivationPathUtils.cc
-        src/impl/Endpoint.cc
         src/impl/DurationConverter.cc
         src/impl/HederaCertificateVerifier.cc
         src/impl/HexConverter.cc
-        src/impl/IPv4Address.cc
         src/impl/MirrorNetwork.cc
         src/impl/MirrorNode.cc
         src/impl/Network.cc
         src/impl/Node.cc
-        src/impl/NodeAddress.cc
-        src/impl/NodeAddressBook.cc
         src/impl/OpenSSLUtils.cc
         src/impl/RLPItem.cc
         src/impl/TimestampConverter.cc

--- a/sdk/main/include/AddressBookQuery.h
+++ b/sdk/main/include/AddressBookQuery.h
@@ -1,0 +1,164 @@
+/*-
+ *
+ * Hedera C++ SDK
+ *
+ * Copyright (C) 2020 - 2023 Hedera Hashgraph, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+#ifndef HEDERA_SDK_CPP_ADDRESS_BOOK_QUERY_H_
+#define HEDERA_SDK_CPP_ADDRESS_BOOK_QUERY_H_
+
+#include "Defaults.h"
+#include "FileId.h"
+
+#include <chrono>
+
+namespace Hedera
+{
+class Client;
+class NodeAddressBook;
+}
+
+namespace com::hedera::mirror::api::proto
+{
+class AddressBookQuery;
+}
+
+namespace Hedera
+{
+/**
+ * A query that returns the current address book being used by the network's consensus nodes.
+ */
+class AddressBookQuery
+{
+public:
+  /**
+   * Submit this AddressBookQuery to a Hedera network.
+   *
+   * @param client The Client to use to submit this AddressBookQuery.
+   * @return The NodeAddressBook object sent from the Hedera network that contains the result of this AddressBookQuery.
+   * @throws MaxAttemptsExceededException If this AddressBookQuery attempts to execute past the number of allowable
+   *                                      attempts.
+   * @throws PrecheckStatusException      If this AddressBookQuery fails its pre-check.
+   * @throws UninitializedException       If the input Client has not yet been initialized.
+   */
+  NodeAddressBook execute(const Client& client);
+
+  /**
+   * Submit this AddressBookQuery to a Hedera network with a specific timeout.
+   *
+   * @param client  The Client to use to submit this AddressBookQuery.
+   * @param timeout The desired timeout for the execution of this AddressBookQuery.
+   * @return The NodeAddressBook object sent from the Hedera network that contains the result of this AddressBookQuery.
+   * @throws MaxAttemptsExceededException If this AddressBookQuery attempts to execute past the number of allowable
+   *                                      attempts.
+   * @throws PrecheckStatusException      If this AddressBookQuery fails its pre-check.
+   * @throws UninitializedException       If the input Client has not yet been initialized.
+   */
+  NodeAddressBook execute(const Client& client, const std::chrono::duration<double>& timeout);
+
+  /**
+   * Set the ID of the file of which to request the address book.
+   *
+   * @param fileId The ID of the file of which to request the address book.
+   * @return A reference to this AddressBookQuery object with the newly-set file ID.
+   */
+  AddressBookQuery& setFileId(const FileId& fileId);
+
+  /**
+   * Set the number of node addresses to retrieve. Set to 0 to retrieve all node addresses.
+   *
+   * @param limit The number of node addresses to retrieve.
+   * @return A reference to this AddressBookQuery object with the newly-set node address limit.
+   */
+  AddressBookQuery& setLimit(unsigned int limit);
+
+  /**
+   * Set the maximum number of attempts to try and execute this AddressBookQuery.
+   *
+   * @param attempts The maximum number of attempts to try and execute this AddressBookQuery.
+   * @return A reference to this AddressBookQuery object with the newly-set maximum attempts.
+   */
+  AddressBookQuery& setMaxAttempts(unsigned int attempts);
+
+  /**
+   * Set the maximum amount of time to wait before attempting to resubmit this AddressBookQuery.
+   *
+   * @param backoff The maximum amount of time to wait before attempting to resubmit this AddressBookQuery.
+   * @return A reference to this Client with the newly-set maximum backoff time.
+   * @throws std::invalid_argument If the desired maximum backoff duration is shorter than DEFAULT_MIN_BACKOFF.
+   */
+  AddressBookQuery& setMaxBackoff(const std::chrono::duration<double>& backoff);
+
+  /**
+   * Get the ID of the file of which this query is currently configured to get the address book.
+   *
+   * @return The ID of the file for which this query is meant.
+   */
+  [[nodiscard]] inline FileId getFileId() const { return mFileId; }
+
+  /**
+   * Get the number of node addresses to retrieve.
+   *
+   * @return The number of node addresses to retrieve.
+   */
+  [[nodiscard]] inline unsigned int getLimit() const { return mLimit; }
+
+  /**
+   * Get the maximum number of attempts to try and execute this AddressBookQuery.
+   *
+   * @return The maximum number of attempts to try and execute this AddressBookQuery.
+   */
+  [[nodiscard]] inline unsigned int getMaxAttempts() const { return mMaxAttempts; }
+
+  /**
+   * Get the maximum amount of time to wait before attempting to resubmit this AddressBookQuery.
+   *
+   * @return The the maximum amount of time to wait before attempting to resubmit this AddressBookQuery.
+   */
+  [[nodiscard]] inline std::chrono::duration<double> getMaxBackoff() const { return mMaxBackoff; }
+
+private:
+  /**
+   * Build an AddressBookQuery protobuf object from this AddressBookQuery.
+   *
+   * @return The AddressBookQuery protobuf object built from this AddressBookQuery.
+   */
+  com::hedera::mirror::api::proto::AddressBookQuery build() const;
+
+  /**
+   * The ID of the file of which this query should get the address book.
+   */
+  FileId mFileId;
+
+  /**
+   * The number of node addresses to retrieve. 0 retrieves all node addresses.
+   */
+  unsigned int mLimit = 0U;
+
+  /**
+   * The maximum number of attempts to try and execute this AddressBookQuery.
+   */
+  unsigned int mMaxAttempts = DEFAULT_MAX_ATTEMPTS;
+
+  /**
+   * The the maximum amount of time to wait before attempting to resubmit this AddressBookQuery.
+   */
+  std::chrono::duration<double> mMaxBackoff = DEFAULT_MAX_BACKOFF;
+};
+
+} // namespace Hedera
+
+#endif // HEDERA_SDK_CPP_ADDRESS_BOOK_QUERY_H_

--- a/sdk/main/include/Client.h
+++ b/sdk/main/include/Client.h
@@ -119,7 +119,7 @@ public:
    *
    * After this method returns, this Client can be re-used. All network communication can be re-established as needed.
    */
-  void close() const;
+  void close();
 
   /**
    * Set the length of time a request sent by this Client can be processed before it times out.
@@ -293,6 +293,13 @@ public:
   [[nodiscard]] std::optional<std::chrono::duration<double>> getMaxBackoff() const;
 
   /**
+   * Get the period of time this Client wait between updating its network.
+   *
+   * @return The period of time this Client wait between updating its network.
+   */
+  [[nodiscard]] std::chrono::duration<double> getNetworkUpdatePeriod() const;
+
+  /**
    * Get a pointer to the MirrorNetwork being used by this client.
    *
    * @return A pointer to the MirrorNetwork being used by this client.
@@ -300,6 +307,13 @@ public:
   [[nodiscard]] std::shared_ptr<internal::MirrorNetwork> getMirrorNetwork() const;
 
 private:
+  /**
+   * Start the network update thread.
+   *
+   * @param period The period of time to wait before a network update is performed.
+   */
+  void startNetworkUpdateThread(const std::chrono::duration<double>& period);
+
   /**
    * Schedule a network update a certain period of time from when this is called.
    *
@@ -311,6 +325,14 @@ private:
    * Cancel any scheduled network updates.
    */
   void cancelScheduledNetworkUpdate();
+
+  /**
+   * Helper function used for moving a Client implementation into this Client, as well as doing network update thread
+   * handling.
+   *
+   * @param other The Client to move into this Client.
+   */
+  void moveClient(Client&& other);
 
   /**
    * Implementation object used to hide implementation details and internal headers.

--- a/sdk/main/include/Client.h
+++ b/sdk/main/include/Client.h
@@ -199,6 +199,15 @@ public:
   Client& setMaxBackoff(const std::chrono::duration<double>& backoff);
 
   /**
+   * Set the period of time this Client wait between updating its network. This will immediately cancel any scheduled
+   * network updates and start a new waiting period.
+   *
+   * @param update The period of time this Client wait between updating its network.
+   * @return A reference to this Client with the newly-set network update period.
+   */
+  Client& setNetworkUpdatePeriod(const std::chrono::duration<double>& update);
+
+  /**
    * Get a pointer to the Network this Client is using to communicate with consensus nodes.
    *
    * @return A pointer to the Network this Client is using to communicate with consensus nodes.
@@ -291,6 +300,18 @@ public:
   [[nodiscard]] std::shared_ptr<internal::MirrorNetwork> getMirrorNetwork() const;
 
 private:
+  /**
+   * Schedule a network update a certain period of time from when this is called.
+   *
+   * @param period The period of time to wait before a network update is performed.
+   */
+  void scheduleNetworkUpdate(const std::chrono::duration<double>& period);
+
+  /**
+   * Cancel any scheduled network updates.
+   */
+  void cancelScheduledNetworkUpdate();
+
   /**
    * Implementation object used to hide implementation details and internal headers.
    */

--- a/sdk/main/include/Defaults.h
+++ b/sdk/main/include/Defaults.h
@@ -83,6 +83,14 @@ constexpr auto DEFAULT_CHUNK_SIZE = 1024U;
  * The default number of chunks for a ChunkedTransaction.
  */
 constexpr auto DEFAULT_MAX_CHUNKS = 20U;
+/**
+ * The default amount of time to wait after a network update to update again.
+ */
+constexpr auto DEFAULT_NETWORK_UPDATE_PERIOD = std::chrono::hours(24);
+/**
+ * The default amount of time to wait after Client creation to update the network for the first time.
+ */
+constexpr auto DEFAULT_NETWORK_UPDATE_INITIAL_DELAY = std::chrono::seconds(10);
 
 }
 

--- a/sdk/main/include/Endpoint.h
+++ b/sdk/main/include/Endpoint.h
@@ -17,8 +17,8 @@
  * limitations under the License.
  *
  */
-#ifndef HEDERA_SDK_CPP_IMPL_ENDPOINT_H_
-#define HEDERA_SDK_CPP_IMPL_ENDPOINT_H_
+#ifndef HEDERA_SDK_CPP_ENDPOINT_H_
+#define HEDERA_SDK_CPP_ENDPOINT_H_
 
 #include "IPv4Address.h"
 
@@ -30,7 +30,7 @@ namespace proto
 class ServiceEndpoint;
 }
 
-namespace Hedera::internal
+namespace Hedera
 {
 /**
  * A network endpoint, which contains an IPv4 address and a port.
@@ -102,6 +102,6 @@ private:
   unsigned int mPort = 0U;
 };
 
-} // namespace Hedera::internal
+} // namespace Hedera
 
-#endif // HEDERA_SDK_CPP_IMPL_ENDPOINT_H_
+#endif // HEDERA_SDK_CPP_ENDPOINT_H_

--- a/sdk/main/include/FileId.h
+++ b/sdk/main/include/FileId.h
@@ -40,6 +40,21 @@ public:
   FileId() = default;
 
   /**
+   * The public NodeAddressBook for the current network.
+   */
+  [[maybe_unused]] static const FileId ADDRESS_BOOK;
+
+  /**
+   * The fee schedule for the current network.
+   */
+  [[maybe_unused]] static const FileId FEE_SCHEDULE;
+
+  /**
+   * The current exchange rate of HBAR to USD for the current network.
+   */
+  [[maybe_unused]] static const FileId EXCHANGE_RATES;
+
+  /**
    * Construct with a file number.
    *
    * @param num The desired file number.

--- a/sdk/main/include/IPv4Address.h
+++ b/sdk/main/include/IPv4Address.h
@@ -17,15 +17,15 @@
  * limitations under the License.
  *
  */
-#ifndef HEDERA_SDK_CPP_IMPL_IPV4_ADDRESS_H_
-#define HEDERA_SDK_CPP_IMPL_IPV4_ADDRESS_H_
+#ifndef HEDERA_SDK_CPP_IPV4_ADDRESS_H_
+#define HEDERA_SDK_CPP_IPV4_ADDRESS_H_
 
 #include <array>
 #include <cstddef>
 #include <string>
 #include <vector>
 
-namespace Hedera::internal
+namespace Hedera
 {
 /**
  * An IPv4 address (without port).
@@ -63,6 +63,6 @@ private:
   std::array<std::byte, 4> mAddress;
 };
 
-} // namespace Hedera::internal
+} // namespace Hedera
 
-#endif // HEDERA_SDK_CPP_IMPL_IPV4_ADDRESS_H_
+#endif // HEDERA_SDK_CPP_IPV4_ADDRESS_H_

--- a/sdk/main/include/NodeAddress.h
+++ b/sdk/main/include/NodeAddress.h
@@ -17,11 +17,11 @@
  * limitations under the License.
  *
  */
-#ifndef HEDERA_SDK_CPP_IMPL_NODE_ADDRESS_H_
-#define HEDERA_SDK_CPP_IMPL_NODE_ADDRESS_H_
+#ifndef HEDERA_SDK_CPP_NODE_ADDRESS_H_
+#define HEDERA_SDK_CPP_NODE_ADDRESS_H_
 
 #include "AccountId.h"
-#include "impl/Endpoint.h"
+#include "Endpoint.h"
 
 #include <cstddef>
 #include <string>
@@ -33,7 +33,7 @@ namespace proto
 class NodeAddress;
 }
 
-namespace Hedera::internal
+namespace Hedera
 {
 /**
  * Class containing all information related to the address(es) of a node.
@@ -187,6 +187,6 @@ private:
   std::string mDescription;
 };
 
-} // namespace Hedera::internal
+} // namespace Hedera
 
-#endif // HEDERA_SDK_CPP_IMPL_NODE_ADDRESS_H_
+#endif // HEDERA_SDK_CPP_NODE_ADDRESS_H_

--- a/sdk/main/include/NodeAddressBook.h
+++ b/sdk/main/include/NodeAddressBook.h
@@ -17,10 +17,10 @@
  * limitations under the License.
  *
  */
-#ifndef HEDERA_SDK_CPP_IMPL_NODE_ADDRESS_BOOK_H_
-#define HEDERA_SDK_CPP_IMPL_NODE_ADDRESS_BOOK_H_
+#ifndef HEDERA_SDK_CPP_NODE_ADDRESS_BOOK_H_
+#define HEDERA_SDK_CPP_NODE_ADDRESS_BOOK_H_
 
-#include "impl/NodeAddress.h"
+#include "NodeAddress.h"
 
 #include <cstddef>
 #include <vector>
@@ -30,7 +30,7 @@ namespace proto
 class NodeAddressBook;
 }
 
-namespace Hedera::internal
+namespace Hedera
 {
 /**
  * An address book containing all known nodes on the network.
@@ -90,6 +90,6 @@ private:
   std::vector<NodeAddress> mNodeAddresses;
 };
 
-} // namespace Hedera::internal
+} // namespace Hedera
 
-#endif // HEDERA_SDK_CPP_IMPL_NODE_ADDRESS_BOOK_H_
+#endif // HEDERA_SDK_CPP_NODE_ADDRESS_BOOK_H_

--- a/sdk/main/include/impl/MirrorNode.h
+++ b/sdk/main/include/impl/MirrorNode.h
@@ -21,6 +21,7 @@
 #define HEDERA_SDK_CPP_IMPL_MIRROR_NODE_H_
 
 #include <proto/mirror/consensus_service.grpc.pb.h>
+#include <proto/mirror/mirror_network_service.grpc.pb.h>
 
 #include "BaseNode.h"
 
@@ -71,6 +72,16 @@ public:
     return mConsensusStub;
   }
 
+  /**
+   * Get a pointer to the NetworkService stub used by this MirrorNode.
+   *
+   * @return A pointer ot the NetworkService stub used by this MirrorNode.
+   */
+  [[nodiscard]] std::shared_ptr<com::hedera::mirror::api::proto::NetworkService::Stub> getNetworkServiceStub() const
+  {
+    return mNetworkStub;
+  }
+
 private:
   /**
    * Derived from BaseNode. Get the authority of this MirrorNode.
@@ -95,6 +106,11 @@ private:
    * Pointer to the gRPC stub used to communicate with the consensus service living on the remote mirror node.
    */
   std::shared_ptr<com::hedera::mirror::api::proto::ConsensusService::Stub> mConsensusStub = nullptr;
+
+  /**
+   * Pointer to the gRPC stub used to communicate with the network service living on the remote mirror node.
+   */
+  std::shared_ptr<com::hedera::mirror::api::proto::NetworkService::Stub> mNetworkStub = nullptr;
 };
 
 } // namespace Hedera::internal

--- a/sdk/main/include/impl/Network.h
+++ b/sdk/main/include/impl/Network.h
@@ -62,7 +62,7 @@ public:
   [[nodiscard]] static Network forPreviewnet();
 
   /**
-   * Construct a custom Network.
+   * Construct a custom Network from a map of node addresses to their corresponding AccountId.
    *
    * @param network The map with string representation of node addresses with their corresponding AccountIds.
    * @return A Network object that is set-up to communicate with the custom network.

--- a/sdk/main/src/AddressBookQuery.cc
+++ b/sdk/main/src/AddressBookQuery.cc
@@ -1,0 +1,129 @@
+/*-
+ *
+ * Hedera C++ SDK
+ *
+ * Copyright (C) 2020 - 2023 Hedera Hashgraph, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+#include "AddressBookQuery.h"
+#include "Client.h"
+#include "NodeAddress.h"
+#include "NodeAddressBook.h"
+#include "exceptions/MaxAttemptsExceededException.h"
+#include "impl/MirrorNetwork.h"
+#include "impl/MirrorNode.h"
+
+#include <proto/mirror/mirror_network_service.pb.h>
+#include <thread>
+#include <vector>
+
+namespace Hedera
+{
+//-----
+NodeAddressBook AddressBookQuery::execute(const Client& client)
+{
+  return execute(client, client.getRequestTimeout());
+}
+
+//-----
+NodeAddressBook AddressBookQuery::execute(const Client& client, const std::chrono::duration<double>& timeout)
+{
+  const std::chrono::system_clock::time_point timeoutTime =
+    std::chrono::system_clock::now() + std::chrono::duration_cast<std::chrono::system_clock::duration>(timeout);
+
+  for (unsigned int attempt = 0U;; ++attempt)
+  {
+    if (attempt >= mMaxAttempts)
+    {
+      throw MaxAttemptsExceededException("Max number of attempts made (max attempts allowed: " +
+                                         std::to_string(mMaxAttempts));
+    }
+
+    // Send this AddressBookQuery.
+    grpc::ClientContext context;
+    context.set_deadline(timeoutTime);
+    auto reader = client.getMirrorNetwork()->getNextMirrorNode()->getNetworkServiceStub()->getNodes(&context, build());
+
+    // Container in which to put the received NodeAddresses.
+    std::vector<NodeAddress> nodeAddresses;
+
+    // Read node addresses until there are none more to read.
+    proto::NodeAddress nodeAddress;
+    while (reader->Read(&nodeAddress))
+    {
+      nodeAddresses.push_back(NodeAddress::fromProtobuf(nodeAddress));
+    }
+
+    grpc::Status status = reader->Finish();
+    if (const grpc::StatusCode errorCode = status.error_code(); errorCode == grpc::StatusCode::UNAVAILABLE ||
+                                                                errorCode == grpc::StatusCode::RESOURCE_EXHAUSTED ||
+                                                                errorCode == grpc::StatusCode::INTERNAL)
+    {
+      // Sleep and retry.
+      std::this_thread::sleep_for(
+        std::min(std::chrono::duration_cast<std::chrono::system_clock::duration>(
+                   DEFAULT_MIN_BACKOFF * pow(static_cast<double>(attempt), 2.0)),
+                 std::chrono::duration_cast<std::chrono::system_clock::duration>(mMaxBackoff)));
+      continue;
+    }
+
+    return NodeAddressBook().setNodeAddresses(nodeAddresses);
+  }
+}
+
+//-----
+AddressBookQuery& AddressBookQuery::setFileId(const FileId& fileId)
+{
+  mFileId = fileId;
+  return *this;
+}
+
+//-----
+AddressBookQuery& AddressBookQuery::setLimit(unsigned int limit)
+{
+  mLimit = limit;
+  return *this;
+}
+
+//-----
+AddressBookQuery& AddressBookQuery::setMaxAttempts(unsigned int attempts)
+{
+  mMaxAttempts = attempts;
+  return *this;
+}
+
+//-----
+AddressBookQuery& AddressBookQuery::setMaxBackoff(const std::chrono::duration<double>& backoff)
+{
+  mMaxBackoff = backoff;
+  return *this;
+}
+
+//-----
+com::hedera::mirror::api::proto::AddressBookQuery AddressBookQuery::build() const
+{
+  com::hedera::mirror::api::proto::AddressBookQuery addressBookQuery;
+
+  if (!(mFileId == FileId()))
+  {
+    addressBookQuery.set_allocated_file_id(mFileId.toProtobuf().release());
+  }
+
+  addressBookQuery.set_limit(static_cast<int32_t>(mLimit));
+
+  return addressBookQuery;
+}
+
+} // namespace Hedera

--- a/sdk/main/src/Client.cc
+++ b/sdk/main/src/Client.cc
@@ -117,6 +117,7 @@ Client::~Client()
 
 //-----
 Client::Client(Client&& other) noexcept
+  : mImpl(std::make_unique<ClientImpl>())
 {
   moveClient(std::move(other));
 
@@ -436,6 +437,7 @@ void Client::cancelScheduledNetworkUpdate()
 //-----
 void Client::moveClient(Client&& other)
 {
+  // Cancel this Client's network update if one exists.
   cancelScheduledNetworkUpdate();
 
   // If there's a network update thread running in the moved-from Client, it can't be simply moved. Since it still holds
@@ -443,9 +445,6 @@ void Client::moveClient(Client&& other)
   // time so that the Client reference can be updated to this Client and no longer be pointing to a moved-from Client.
   if (other.mImpl->mNetworkUpdateThread)
   {
-    // Cancel this Client's network update if one exists.
-    cancelScheduledNetworkUpdate();
-
     // Cancel the update.
     other.cancelScheduledNetworkUpdate();
 

--- a/sdk/main/src/Client.cc
+++ b/sdk/main/src/Client.cc
@@ -121,7 +121,7 @@ Client::Client(Client&& other) noexcept
   moveClient(std::move(other));
 
   // Leave moved-from object in a valid state
-  other.mImpl = std::make_unique<ClientImpl>();
+  other.mImpl = std::make_unique<ClientImpl>(); // NOLINT
 }
 
 //-----
@@ -132,7 +132,7 @@ Client& Client::operator=(Client&& other) noexcept
     moveClient(std::move(other));
 
     // Leave moved-from object in a valid state
-    other.mImpl = std::make_unique<ClientImpl>();
+    other.mImpl = std::make_unique<ClientImpl>(); // NOLINT
   }
 
   return *this;
@@ -436,11 +436,16 @@ void Client::cancelScheduledNetworkUpdate()
 //-----
 void Client::moveClient(Client&& other)
 {
+  cancelScheduledNetworkUpdate();
+
   // If there's a network update thread running in the moved-from Client, it can't be simply moved. Since it still holds
   // a reference to the moved-from Client, the thread must be stopped and restarted in this Client with the remaining
   // time so that the Client reference can be updated to this Client and no longer be pointing to a moved-from Client.
   if (other.mImpl->mNetworkUpdateThread)
   {
+    // Cancel this Client's network update if one exists.
+    cancelScheduledNetworkUpdate();
+
     // Cancel the update.
     other.cancelScheduledNetworkUpdate();
 

--- a/sdk/main/src/Endpoint.cc
+++ b/sdk/main/src/Endpoint.cc
@@ -17,18 +17,18 @@
  * limitations under the License.
  *
  */
-#include "impl/Endpoint.h"
+#include "Endpoint.h"
 #include "impl/Utilities.h"
 
 #include <proto/basic_types.pb.h>
 
-namespace Hedera::internal
+namespace Hedera
 {
 //-----
 Endpoint Endpoint::fromProtobuf(const proto::ServiceEndpoint& protoServiceEndpoint)
 {
   return Endpoint()
-    .setAddress(IPv4Address::fromBytes(Utilities::stringToByteVector(protoServiceEndpoint.ipaddressv4())))
+    .setAddress(IPv4Address::fromBytes(internal::Utilities::stringToByteVector(protoServiceEndpoint.ipaddressv4())))
     .setPort(static_cast<unsigned int>(protoServiceEndpoint.port()));
 }
 
@@ -36,7 +36,7 @@ Endpoint Endpoint::fromProtobuf(const proto::ServiceEndpoint& protoServiceEndpoi
 std::unique_ptr<proto::ServiceEndpoint> Endpoint::toProtobuf() const
 {
   auto proto = std::make_unique<proto::ServiceEndpoint>();
-  proto->set_ipaddressv4(Utilities::byteVectorToString(mAddress.toBytes()));
+  proto->set_ipaddressv4(internal::Utilities::byteVectorToString(mAddress.toBytes()));
   proto->set_port(static_cast<int32_t>(mPort));
   return proto;
 }
@@ -61,4 +61,4 @@ Endpoint& Endpoint::setPort(unsigned int port)
   return *this;
 }
 
-} // namespace Hedera::internal
+} // namespace Hedera

--- a/sdk/main/src/FileId.cc
+++ b/sdk/main/src/FileId.cc
@@ -26,6 +26,15 @@
 namespace Hedera
 {
 //-----
+const FileId FileId::ADDRESS_BOOK = FileId(0ULL, 0ULL, 102ULL);
+
+//-----
+const FileId FileId::FEE_SCHEDULE = FileId(0ULL, 0ULL, 111ULL);
+
+//-----
+const FileId FileId::EXCHANGE_RATES = FileId(0ULL, 0ULL, 112ULL);
+
+//-----
 FileId::FileId(const uint64_t& num)
   : mFileNum(num)
 {

--- a/sdk/main/src/IPv4Address.cc
+++ b/sdk/main/src/IPv4Address.cc
@@ -17,11 +17,11 @@
  * limitations under the License.
  *
  */
-#include "impl/IPv4Address.h"
+#include "IPv4Address.h"
 
 #include <stdexcept>
 
-namespace Hedera::internal
+namespace Hedera
 {
 //-----
 IPv4Address IPv4Address::fromBytes(const std::vector<std::byte>& bytes)
@@ -51,4 +51,4 @@ std::string IPv4Address::toString() const
          std::to_string(std::to_integer<unsigned char>(mAddress.at(3)));
 }
 
-} // namespace Hedera::internal
+} // namespace Hedera

--- a/sdk/main/src/NodeAddress.cc
+++ b/sdk/main/src/NodeAddress.cc
@@ -17,9 +17,9 @@
  * limitations under the License.
  *
  */
-#include "impl/NodeAddress.h"
+#include "NodeAddress.h"
+#include "IPv4Address.h"
 #include "impl/HexConverter.h"
-#include "impl/IPv4Address.h"
 #include "impl/Utilities.h"
 
 #include <iomanip>
@@ -27,7 +27,7 @@
 #include <proto/basic_types.pb.h>
 #include <sstream>
 
-namespace Hedera::internal
+namespace Hedera
 {
 //-----
 NodeAddress NodeAddress::fromProtobuf(const proto::NodeAddress& protoNodeAddress)
@@ -36,7 +36,7 @@ NodeAddress NodeAddress::fromProtobuf(const proto::NodeAddress& protoNodeAddress
   outputNodeAddress.mRSAPublicKey = protoNodeAddress.rsa_pubkey();
   outputNodeAddress.mNodeId = protoNodeAddress.nodeid();
   outputNodeAddress.mNodeAccountId = AccountId::fromProtobuf(protoNodeAddress.nodeaccountid());
-  outputNodeAddress.mNodeCertHash = Utilities::stringToByteVector(protoNodeAddress.nodecerthash());
+  outputNodeAddress.mNodeCertHash = internal::Utilities::stringToByteVector(protoNodeAddress.nodecerthash());
 
   for (int i = 0; i < protoNodeAddress.serviceendpoint_size(); ++i)
   {
@@ -55,7 +55,7 @@ std::unique_ptr<proto::NodeAddress> NodeAddress::toProtobuf() const
   protoNodeAddress->set_rsa_pubkey(mRSAPublicKey);
   protoNodeAddress->set_nodeid(mNodeId);
   protoNodeAddress->set_allocated_nodeaccountid(mNodeAccountId.toProtobuf().release());
-  protoNodeAddress->set_nodecerthash(Utilities::byteVectorToString(mNodeCertHash));
+  protoNodeAddress->set_nodecerthash(internal::Utilities::byteVectorToString(mNodeCertHash));
 
   for (const auto& endpoint : mEndpoints)
   {
@@ -79,7 +79,7 @@ std::string NodeAddress::toString() const
   outputStream << std::setw(columnWidth) << std::right << "Description: " << std::left << mDescription << std::endl;
   outputStream << std::setw(columnWidth) << std::right << "RSA Public Key: " << std::left << mRSAPublicKey << std::endl;
   outputStream << std::setw(columnWidth) << std::right << "Certificate Hash: " << std::left
-               << HexConverter::bytesToHex(mNodeCertHash) << std::endl;
+               << internal::HexConverter::bytesToHex(mNodeCertHash) << std::endl;
   outputStream << std::setw(columnWidth) << std::right << "Endpoints: ";
 
   if (size_t endpointCount = mEndpoints.size(); !endpointCount)
@@ -136,7 +136,7 @@ NodeAddress& NodeAddress::setAccountId(const AccountId& accountId)
 //-----
 NodeAddress& NodeAddress::setCertHash(std::string_view certHash)
 {
-  mNodeCertHash = Utilities::stringToByteVector(certHash);
+  mNodeCertHash = internal::Utilities::stringToByteVector(certHash);
   return *this;
 }
 
@@ -161,4 +161,4 @@ NodeAddress& NodeAddress::setDescription(std::string_view description)
   return *this;
 }
 
-} // namespace Hedera::internal
+} // namespace Hedera

--- a/sdk/main/src/NodeAddressBook.cc
+++ b/sdk/main/src/NodeAddressBook.cc
@@ -17,12 +17,12 @@
  * limitations under the License.
  *
  */
-#include "impl/NodeAddressBook.h"
+#include "NodeAddressBook.h"
 #include "impl/Utilities.h"
 
 #include <proto/basic_types.pb.h>
 
-namespace Hedera::internal
+namespace Hedera
 {
 //-----
 NodeAddressBook NodeAddressBook::fromProtobuf(const proto::NodeAddressBook& proto)
@@ -59,7 +59,7 @@ std::unique_ptr<proto::NodeAddressBook> NodeAddressBook::toProtobuf() const
 //-----
 std::vector<std::byte> NodeAddressBook::toBytes() const
 {
-  return Utilities::stringToByteVector(toProtobuf()->SerializeAsString());
+  return internal::Utilities::stringToByteVector(toProtobuf()->SerializeAsString());
 }
 
 //-----
@@ -69,4 +69,4 @@ NodeAddressBook& NodeAddressBook::setNodeAddresses(const std::vector<NodeAddress
   return *this;
 }
 
-} // namespace Hedera::internal
+} // namespace Hedera

--- a/sdk/main/src/impl/MirrorNode.cc
+++ b/sdk/main/src/impl/MirrorNode.cc
@@ -41,12 +41,18 @@ void MirrorNode::initializeStubs(const std::shared_ptr<grpc::Channel>& channel)
   {
     mConsensusStub = com::hedera::mirror::api::proto::ConsensusService::NewStub(channel);
   }
+
+  if (!mNetworkStub)
+  {
+    mNetworkStub = com::hedera::mirror::api::proto::NetworkService::NewStub(channel);
+  }
 }
 
 //-----
 void MirrorNode::closeStubs()
 {
   mConsensusStub = nullptr;
+  mNetworkStub = nullptr;
 }
 
 } // namespace Hedera::internal

--- a/sdk/main/src/impl/Network.cc
+++ b/sdk/main/src/impl/Network.cc
@@ -19,8 +19,8 @@
  */
 #include "impl/Network.h"
 #include "AccountId.h"
-#include "impl/Endpoint.h"
-#include "impl/NodeAddress.h"
+#include "Endpoint.h"
+#include "NodeAddress.h"
 
 #include <algorithm>
 #include <cmath>
@@ -47,9 +47,9 @@ Network Network::forPreviewnet()
 }
 
 //-----
-Network Network::forNetwork(const std::unordered_map<std::string, AccountId>& networkMap)
+Network Network::forNetwork(const std::unordered_map<std::string, AccountId>& network)
 {
-  return Network(networkMap);
+  return Network(network);
 }
 
 //-----
@@ -146,6 +146,7 @@ Network::Network(const std::unordered_map<std::string, AccountId>& network)
 Network Network::getNetworkForLedgerId(const LedgerId& ledgerId)
 {
   const std::unordered_map<AccountId, NodeAddress> addressBook = getAddressBookForLedgerId(ledgerId);
+
   std::unordered_map<std::string, AccountId> network;
   for (const auto& [accountId, nodeAddress] : addressBook)
   {
@@ -198,7 +199,7 @@ Network& Network::setLedgerIdInternal(const LedgerId& ledgerId,
   // Set the ledger ID.
   BaseNetwork<Network, AccountId, Node>::setLedgerId(ledgerId);
 
-  // Update each Node's address book entry with the new address book.
+  // Update the node certificate hash of each node.
   std::for_each(getNodes().cbegin(),
                 getNodes().cend(),
                 [&addressBook](const std::shared_ptr<Node>& node)

--- a/sdk/tests/integration/AddressBookQueryIntegrationTests.cc
+++ b/sdk/tests/integration/AddressBookQueryIntegrationTests.cc
@@ -1,0 +1,39 @@
+/*-
+ *
+ * Hedera C++ SDK
+ *
+ * Copyright (C) 2020 - 2023 Hedera Hashgraph, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+#include "AddressBookQuery.h"
+#include "BaseIntegrationTest.h"
+#include "FileId.h"
+#include "NodeAddressBook.h"
+
+#include <gtest/gtest.h>
+
+using namespace Hedera;
+
+class AddressBookQueryIntegrationTest : public BaseIntegrationTest
+{
+};
+
+//-----
+TEST_F(AddressBookQueryIntegrationTest, ExecuteAddressBookQuery)
+{
+  // Given / When / Then
+  EXPECT_NO_THROW(const NodeAddressBook nodeAddressBook =
+                    AddressBookQuery().setFileId(FileId::ADDRESS_BOOK).execute(getTestClient()));
+}

--- a/sdk/tests/integration/BaseIntegrationTest.cc
+++ b/sdk/tests/integration/BaseIntegrationTest.cc
@@ -77,6 +77,7 @@ void BaseIntegrationTest::SetUp()
   mClient = Client::forNetwork(networkAccountsMap);
   mClient.setOperator(operatorAccountId, ED25519PrivateKey::fromString(operatorAccountPrivateKey).get());
   mClient.setMirrorNetwork({ "127.0.0.1:5600" });
+  mClient.setNetworkUpdatePeriod(std::chrono::hours(24));
 
   mFileContent = internal::Utilities::stringToByteVector(
     json::parse(std::ifstream(std::filesystem::current_path() / "hello_world.json", std::ios::in))["object"]

--- a/sdk/tests/integration/CMakeLists.txt
+++ b/sdk/tests/integration/CMakeLists.txt
@@ -8,6 +8,7 @@ add_executable(${TEST_PROJECT_NAME}
         AccountRecordsQueryIntegrationTests.cc
         AccountStakersQueryIntegrationTests.cc
         AccountUpdateTransactionIntegrationTest.cc
+        AddressBookQueryIntegrationTests.cc
         BaseIntegrationTest.cc
         ContractBytecodeQueryIntegrationTests.cc
         ContractCallQueryIntegrationTests.cc

--- a/sdk/tests/unit/AddressBookQueryUnitTests.cc
+++ b/sdk/tests/unit/AddressBookQueryUnitTests.cc
@@ -1,0 +1,91 @@
+/*-
+ *
+ * Hedera C++ SDK
+ *
+ * Copyright (C) 2020 - 2022 Hedera Hashgraph, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+#include "AddressBookQuery.h"
+
+#include <gtest/gtest.h>
+
+using namespace Hedera;
+
+class AddressBookQueryTest : public ::testing::Test
+{
+protected:
+  [[nodiscard]] inline const FileId& getTestFileId() const { return mTestFileId; }
+  [[nodiscard]] inline unsigned int getTestLimit() const { return mTestLimit; }
+  [[nodiscard]] inline unsigned int getTestMaxAttempts() const { return mTestMaxAttempts; }
+  [[nodiscard]] inline const std::chrono::duration<double>& getTestMaxBackoff() const { return mTestMaxBackoff; }
+
+private:
+  const FileId mTestFileId = FileId(1ULL, 2ULL, 3ULL);
+  const unsigned int mTestLimit = 4ULL;
+  const unsigned int mTestMaxAttempts = 5ULL;
+  const std::chrono::duration<double> mTestMaxBackoff = std::chrono::seconds(6ULL);
+};
+
+//-----
+TEST_F(AddressBookQueryTest, GetSetAccountId)
+{
+  // Given
+  AddressBookQuery query;
+
+  // When
+  query.setFileId(getTestFileId());
+
+  // Then
+  EXPECT_EQ(query.getFileId(), getTestFileId());
+}
+
+//-----
+TEST_F(AddressBookQueryTest, GetSetLimit)
+{
+  // Given
+  AddressBookQuery query;
+
+  // When
+  query.setLimit(getTestLimit());
+
+  // Then
+  EXPECT_EQ(query.getLimit(), getTestLimit());
+}
+
+//-----
+TEST_F(AddressBookQueryTest, GetSetMaxAttempts)
+{
+  // Given
+  AddressBookQuery query;
+
+  // When
+  query.setMaxAttempts(getTestMaxAttempts());
+
+  // Then
+  EXPECT_EQ(query.getMaxAttempts(), getTestMaxAttempts());
+}
+
+//-----
+TEST_F(AddressBookQueryTest, GetSetMaxBackoff)
+{
+  // Given
+  AddressBookQuery query;
+
+  // When
+  query.setMaxBackoff(getTestMaxBackoff());
+
+  // Then
+  EXPECT_EQ(query.getMaxBackoff(), getTestMaxBackoff());
+}

--- a/sdk/tests/unit/CMakeLists.txt
+++ b/sdk/tests/unit/CMakeLists.txt
@@ -13,6 +13,7 @@ add_executable(${TEST_PROJECT_NAME}
         AccountRecordsTest.cc
         AccountStakersQueryUnitTests.cc
         AccountUpdateTransactionTest.cc
+        AddressBookQueryUnitTests.cc
         AssessedCustomFeesTest.cc
         ChunkedTransactionTest.cc
         ClientTest.cc

--- a/sdk/tests/unit/ClientTest.cc
+++ b/sdk/tests/unit/ClientTest.cc
@@ -37,10 +37,15 @@ class ClientTest : public ::testing::Test
 protected:
   [[nodiscard]] inline const AccountId& getTestAccountId() const { return mAccountId; }
   [[nodiscard]] inline const std::unique_ptr<ED25519PrivateKey>& getTestPrivateKey() const { return mPrivateKey; }
+  [[nodiscard]] inline const std::chrono::duration<double>& getTestNetworkUpdatePeriod() const
+  {
+    return mTestNetworkUpdatePeriod;
+  }
 
 private:
   const AccountId mAccountId = AccountId(10ULL);
   const std::unique_ptr<ED25519PrivateKey> mPrivateKey = ED25519PrivateKey::generatePrivateKey();
+  const std::chrono::duration<double> mTestNetworkUpdatePeriod = std::chrono::seconds(2);
 };
 
 //-----
@@ -89,4 +94,17 @@ TEST_F(ClientTest, SetDefaultMaxTransactionFee)
 
   // Negative value should throw
   EXPECT_THROW(client.setMaxTransactionFee(fee.negated()), std::invalid_argument);
+}
+
+//-----
+TEST_F(ClientTest, SetNetworkUpdatePeriod)
+{
+  // Given
+  Client client;
+
+  // When
+  client.setNetworkUpdatePeriod(getTestNetworkUpdatePeriod());
+
+  // Then
+  EXPECT_EQ(client.getNetworkUpdatePeriod(), getTestNetworkUpdatePeriod());
 }

--- a/sdk/tests/unit/NodeAddressTest.cc
+++ b/sdk/tests/unit/NodeAddressTest.cc
@@ -17,10 +17,10 @@
  * limitations under the License.
  *
  */
-#include "impl/NodeAddress.h"
+#include "NodeAddress.h"
 #include "AccountId.h"
-#include "impl/Endpoint.h"
-#include "impl/IPv4Address.h"
+#include "Endpoint.h"
+#include "IPv4Address.h"
 #include "impl/Utilities.h"
 
 #include <gtest/gtest.h>


### PR DESCRIPTION
**Description**:
This PR adds all processing associated with `AddressBookQuery`. This includes:
- The `AddressBookQuery` and execution processing.
- The automatic `Client` network update.
- The `GetAddressBookExample`

This PR made `NodeAddressBook`, `NodeAddress`, `Endpoint`, and `IPv4Address` part of the SDKs public API as well.

**Related issue(s)**:

Fixes #504 

**Checklist**

- [x] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
