### PR TITLE
Add `TransactionId` argument to `TransactionReceipt::fromProtobuf()`

### DIFF
--- a/sdk/main/include/TransactionReceipt.h
+++ b/sdk/main/include/TransactionReceipt.h
@@ -52,10 +52,13 @@ public:
   /**
    * Construct a TransactionReceipt object from a TransactionGetReceiptResponse protobuf object.
    *
-   * @param proto The TransactionGetReceiptResponse protobuf object from which to construct a TransactionReceipt object.
+   * @param proto         The TransactionGetReceiptResponse protobuf object from which to construct a TransactionReceipt
+   *                      object.
+   * @param transactionId The ID of the transaction to which the constructed TransactionReceipt will correspond.
    * @return The constructed TransactionReceipt object.
    */
-  [[nodiscard]] static TransactionReceipt fromProtobuf(const proto::TransactionGetReceiptResponse& proto);
+  [[nodiscard]] static TransactionReceipt fromProtobuf(const proto::TransactionGetReceiptResponse& proto,
+                                                       const TransactionId& transactionId);
 
   /**
    * Construct a TransactionReceipt object from a TransactionReceipt protobuf object.

--- a/sdk/main/src/TransactionReceipt.cc
+++ b/sdk/main/src/TransactionReceipt.cc
@@ -27,9 +27,11 @@
 namespace Hedera
 {
 //-----
-TransactionReceipt TransactionReceipt::fromProtobuf(const proto::TransactionGetReceiptResponse& proto)
+TransactionReceipt TransactionReceipt::fromProtobuf(const proto::TransactionGetReceiptResponse& proto,
+                                                    const TransactionId& transactionId)
 {
   TransactionReceipt receipt = TransactionReceipt::fromProtobuf(proto.receipt());
+  receipt.mTransactionId = transactionId;
 
   for (int i = 0; i < proto.duplicatetransactionreceipts_size(); ++i)
   {

--- a/sdk/main/src/TransactionReceiptQuery.cc
+++ b/sdk/main/src/TransactionReceiptQuery.cc
@@ -53,7 +53,7 @@ TransactionReceiptQuery& TransactionReceiptQuery::setIncludeDuplicates(bool dupl
 //-----
 TransactionReceipt TransactionReceiptQuery::mapResponse(const proto::Response& response) const
 {
-  return TransactionReceipt::fromProtobuf(response.transactiongetreceipt().receipt(), mTransactionId.value());
+  return TransactionReceipt::fromProtobuf(response.transactiongetreceipt(), mTransactionId.value());
 }
 
 //-----

--- a/sdk/main/src/TransactionReceiptQuery.cc
+++ b/sdk/main/src/TransactionReceiptQuery.cc
@@ -53,7 +53,7 @@ TransactionReceiptQuery& TransactionReceiptQuery::setIncludeDuplicates(bool dupl
 //-----
 TransactionReceipt TransactionReceiptQuery::mapResponse(const proto::Response& response) const
 {
-  return TransactionReceipt::fromProtobuf(response.transactiongetreceipt());
+  return TransactionReceipt::fromProtobuf(response.transactiongetreceipt().receipt(), mTransactionId.value());
 }
 
 //-----

--- a/sdk/tests/integration/TransactionReceiptQueryIntegrationTest.cc
+++ b/sdk/tests/integration/TransactionReceiptQueryIntegrationTest.cc
@@ -56,6 +56,7 @@ TEST_F(TransactionReceiptQueryIntegrationTest, CanGetTransactionReceipt)
   TransactionReceipt txReceipt;
   EXPECT_NO_THROW(
     txReceipt = TransactionReceiptQuery().setTransactionId(testTxResponse.getTransactionId()).execute(getTestClient()));
+  EXPECT_EQ(txReceipt.mTransactionId, testTxResponse.getTransactionId());
 
   // Clean up
   AccountId accountId;


### PR DESCRIPTION
**Description**:
This PR adds a `TransactionId` argument to `TransactionReceipt::fromProtobuf` so that the `TransactionId` can be saved when deserializing a `proto::TransactionGetReceiptResponse`.

**Related issue(s)**:

Fixes #506 

**Checklist**

- [x] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
