### PR TITLE
Add `GenerateKeyExample`

### DIFF
--- a/sdk/examples/CMakeLists.txt
+++ b/sdk/examples/CMakeLists.txt
@@ -14,6 +14,7 @@ set(DELETE_ACCOUNT_EXAMPLE_NAME ${PROJECT_NAME}-delete-account-example)
 set(DELETE_FILE_EXAMPLE_NAME ${PROJECT_NAME}-delete-file-example)
 set(EXEMPT_CUSTOM_FEES_EXAMPLE_NAME ${PROJECT_NAME}-exempt-custom-fees-example)
 set(FILE_APPEND_CHUNKED_EXAMPLE_NAME ${PROJECT_NAME}-file-append-chunked-example)
+set(GENERATE_KEY_EXAMPLE_NAME ${PROJECT_NAME}-generate-key-example)
 set(GENERATE_PRIVATE_KEY_FROM_MNEMONIC_EXAMPLE_NAME ${PROJECT_NAME}-generate-private-key-from-mnemonic-example)
 set(GET_ACCOUNT_BALANCE_EXAMPLE_NAME ${PROJECT_NAME}-get-account-balance-example)
 set(GET_ADDRESS_BOOK_EXAMPLE_NAME ${PROJECT_NAME}-get-address-book-example)
@@ -46,6 +47,7 @@ add_executable(${DELETE_ACCOUNT_EXAMPLE_NAME} DeleteAccountExample.cc)
 add_executable(${DELETE_FILE_EXAMPLE_NAME} DeleteFileExample.cc)
 add_executable(${EXEMPT_CUSTOM_FEES_EXAMPLE_NAME} ExemptCustomFeesExample.cc)
 add_executable(${FILE_APPEND_CHUNKED_EXAMPLE_NAME} FileAppendChunkedExample.cc)
+add_executable(${GENERATE_KEY_EXAMPLE_NAME} GenerateKeyExample.cc)
 add_executable(${GENERATE_PRIVATE_KEY_FROM_MNEMONIC_EXAMPLE_NAME} GeneratePrivateKeyFromMnemonic.cc)
 add_executable(${GET_ACCOUNT_BALANCE_EXAMPLE_NAME} GetAccountBalanceExample.cc)
 add_executable(${GET_ADDRESS_BOOK_EXAMPLE_NAME} GetAddressBookExample.cc)
@@ -96,6 +98,7 @@ target_link_libraries(${DELETE_ACCOUNT_EXAMPLE_NAME} PUBLIC ${PROJECT_NAME})
 target_link_libraries(${DELETE_FILE_EXAMPLE_NAME} PUBLIC ${PROJECT_NAME})
 target_link_libraries(${EXEMPT_CUSTOM_FEES_EXAMPLE_NAME} PUBLIC ${PROJECT_NAME})
 target_link_libraries(${FILE_APPEND_CHUNKED_EXAMPLE_NAME} PUBLIC ${PROJECT_NAME})
+target_link_libraries(${GENERATE_KEY_EXAMPLE_NAME} PUBLIC ${PROJECT_NAME})
 target_link_libraries(${GENERATE_PRIVATE_KEY_FROM_MNEMONIC_EXAMPLE_NAME} PUBLIC ${PROJECT_NAME})
 target_link_libraries(${GET_ACCOUNT_BALANCE_EXAMPLE_NAME} PUBLIC ${PROJECT_NAME})
 target_link_libraries(${GET_ADDRESS_BOOK_EXAMPLE_NAME} PUBLIC ${PROJECT_NAME})
@@ -131,6 +134,7 @@ install(TARGETS
         ${DELETE_FILE_EXAMPLE_NAME}
         ${EXEMPT_CUSTOM_FEES_EXAMPLE_NAME}
         ${FILE_APPEND_CHUNKED_EXAMPLE_NAME}
+        ${GENERATE_KEY_EXAMPLE_NAME}
         ${GENERATE_PRIVATE_KEY_FROM_MNEMONIC_EXAMPLE_NAME}
         ${GET_ACCOUNT_BALANCE_EXAMPLE_NAME}
         ${GET_ADDRESS_BOOK_EXAMPLE_NAME}

--- a/sdk/examples/GenerateKeyExample.cc
+++ b/sdk/examples/GenerateKeyExample.cc
@@ -1,0 +1,40 @@
+/*-
+ *
+ * Hedera C++ SDK
+ *
+ * Copyright (C) 2020 - 2023 Hedera Hashgraph, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+#include "ECDSAsecp256k1PrivateKey.h"
+#include "ED25519PrivateKey.h"
+#include "PrivateKey.h"
+#include "PublicKey.h"
+
+#include <iostream>
+
+using namespace Hedera;
+
+int main(int argc, char** argv)
+{
+  const std::unique_ptr<PrivateKey> ed25519Key = ED25519PrivateKey::generatePrivateKey();
+  const std::unique_ptr<PrivateKey> ecdsaKey = ECDSAsecp256k1PrivateKey::generatePrivateKey();
+
+  std::cout << "Generated ED25519PrivateKey: " << ed25519Key->toStringRaw() << std::endl;
+  std::cout << "Generated ED25519PublicKey: " << ed25519Key->getPublicKey()->toStringRaw() << std::endl;
+  std::cout << "Generated ECDSAsecp256k1PrivateKey: " << ecdsaKey->toStringRaw() << std::endl;
+  std::cout << "Generated ECDSAsecp256k1PublicKey: " << ecdsaKey->getPublicKey()->toStringRaw() << std::endl;
+
+  return 0;
+}


### PR DESCRIPTION
**Description**:
This PR adds the `GenerateKeyExample`, which shows users how to generate keys.

**Related issue(s)**:

Fixes #531

**Checklist**

- [x] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
