### PR TITLE
Add missing APIs for `CustomFee`s and derived classes

### DIFF
--- a/sdk/main/include/CustomFee.h
+++ b/sdk/main/include/CustomFee.h
@@ -22,7 +22,9 @@
 
 #include "AccountId.h"
 
+#include <cstddef>
 #include <memory>
+#include <vector>
 
 namespace proto
 {
@@ -55,6 +57,14 @@ public:
   [[nodiscard]] static std::unique_ptr<CustomFee> fromProtobuf(const proto::CustomFee& proto);
 
   /**
+   * Create a CustomFee object from a byte array.
+   *
+   * @param bytes The byte array from which to create an CustomFee object.
+   * @return A pointer to the constructed CustomFee object.
+   */
+  [[nodiscard]] static std::unique_ptr<CustomFee> fromBytes(const std::vector<std::byte>& bytes);
+
+  /**
    * Create a clone of this CustomFee object.
    *
    * @return A pointer to the created clone of this CustomFee.
@@ -75,6 +85,13 @@ public:
    * @throws BadEntityException This CustomFee's checksums are not valid.
    */
   virtual void validateChecksums(const Client& client) const;
+
+  /**
+   * Construct a byte array from this CustomFee object.
+   *
+   * @return A byte array filled with this CustomFee object's data.
+   */
+  [[nodiscard]] std::vector<std::byte> toBytes() const;
 
   /**
    * Get the ID of the desired fee collector account.

--- a/sdk/tests/unit/CustomFixedFeeTest.cc
+++ b/sdk/tests/unit/CustomFixedFeeTest.cc
@@ -20,6 +20,7 @@
 #include "CustomFixedFee.h"
 #include "AccountId.h"
 #include "TokenId.h"
+#include "impl/Utilities.h"
 
 #include <gtest/gtest.h>
 #include <proto/custom_fees.pb.h>
@@ -55,6 +56,30 @@ TEST_F(CustomFixedFeeTest, FromProtobuf)
   // Then
   EXPECT_EQ(customFixedFee.getAmount(), getTestAmount());
   EXPECT_EQ(customFixedFee.getDenominatingTokenId(), getTestTokenId());
+}
+
+//-----
+TEST_F(CustomFixedFeeTest, FromBytes)
+{
+  // Given
+  proto::CustomFee protoFee;
+  protoFee.set_allocated_fee_collector_account_id(getTestFeeCollectorAccountId().toProtobuf().release());
+  protoFee.set_all_collectors_are_exempt(getTestAllCollectorsAreExempt());
+  protoFee.mutable_fixed_fee()->set_amount(static_cast<int64_t>(getTestAmount()));
+  protoFee.mutable_fixed_fee()->set_allocated_denominating_token_id(getTestTokenId().toProtobuf().release());
+
+  // When
+  std::unique_ptr<CustomFee> customFee =
+    CustomFee::fromBytes(internal::Utilities::stringToByteVector(protoFee.SerializeAsString()));
+
+  // Then
+  ASSERT_NE(dynamic_cast<CustomFixedFee*>(customFee.get()), nullptr);
+
+  const std::unique_ptr<CustomFixedFee> customFixedFee(dynamic_cast<CustomFixedFee*>(customFee.release()));
+  EXPECT_EQ(customFixedFee->getFeeCollectorAccountId(), getTestFeeCollectorAccountId());
+  EXPECT_EQ(customFixedFee->getAllCollectorsAreExempt(), getTestAllCollectorsAreExempt());
+  EXPECT_EQ(customFixedFee->getAmount(), getTestAmount());
+  EXPECT_EQ(customFixedFee->getDenominatingTokenId(), getTestTokenId());
 }
 
 //-----


### PR DESCRIPTION
**Description**:
This PR adds a few missing APIs for the `CustomFee` class hierarchy.

**Related issue(s)**:

Fixes #365 

**Checklist**

- [x] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
