### PR TITLE
Full implementation of `Executable`

### DIFF
--- a/sdk/main/include/AccountCreateTransaction.h
+++ b/sdk/main/include/AccountCreateTransaction.h
@@ -129,7 +129,7 @@ public:
    * @return A reference to this AccountCreateTransaction object with the newly-set auto renew period.
    * @throws IllegalStateException If this AccountCreateTransaction is frozen.
    */
-  AccountCreateTransaction& setAutoRenewPeriod(const std::chrono::duration<double>& autoRenewPeriod);
+  AccountCreateTransaction& setAutoRenewPeriod(const std::chrono::system_clock::duration& autoRenewPeriod);
 
   /**
    * Set a memo for the new account.
@@ -217,7 +217,7 @@ public:
    *
    * @return The auto renew period for the new account.
    */
-  [[nodiscard]] inline std::chrono::duration<double> getAutoRenewPeriod() const { return mAutoRenewPeriod; }
+  [[nodiscard]] inline std::chrono::system_clock::duration getAutoRenewPeriod() const { return mAutoRenewPeriod; }
 
   /**
    * Get the desired memo for the new account.
@@ -333,7 +333,7 @@ private:
    * extends as long as possible. If the balance is zero when it expires, then the account is deleted. Defaults to 90
    * days (2160 hours).
    */
-  std::chrono::duration<double> mAutoRenewPeriod = DEFAULT_AUTO_RENEW_PERIOD;
+  std::chrono::system_clock::duration mAutoRenewPeriod = DEFAULT_AUTO_RENEW_PERIOD;
 
   /**
    * The memo to be associated with the account (UTF-8 encoding max 100 bytes).

--- a/sdk/main/include/AccountInfo.h
+++ b/sdk/main/include/AccountInfo.h
@@ -101,7 +101,7 @@ public:
    * The duration of time the queried account uses to automatically extend its expiration period. It it doesn't have
    * enough balance, it extends as long as possible. If it is empty when it expires, then it is deleted.
    */
-  std::chrono::duration<double> mAutoRenewPeriod;
+  std::chrono::system_clock::duration mAutoRenewPeriod;
 
   /**
    * The queried account's memo.

--- a/sdk/main/include/AccountUpdateTransaction.h
+++ b/sdk/main/include/AccountUpdateTransaction.h
@@ -104,7 +104,7 @@ public:
    * @return A reference to this AccountUpdateTransaction object with the newly-set auto renew period.
    * @throws IllegalStateException If this AccountUpdateTransaction is frozen.
    */
-  AccountUpdateTransaction& setAutoRenewPeriod(const std::chrono::duration<double>& autoRenewPeriod);
+  AccountUpdateTransaction& setAutoRenewPeriod(const std::chrono::system_clock::duration& autoRenewPeriod);
 
   /**
    * Set a new expiration time for the account.
@@ -215,7 +215,7 @@ public:
    *
    * @return The new auto renew period for the new account.
    */
-  [[nodiscard]] inline std::optional<std::chrono::duration<double>> getAutoRenewPeriod() const
+  [[nodiscard]] inline std::optional<std::chrono::system_clock::duration> getAutoRenewPeriod() const
   {
     return mAutoRenewPeriod;
   }
@@ -338,7 +338,7 @@ private:
    * The new duration to use for the account to automatically extend its expiration period. It it doesn't have enough
    * balance, it extends as long as possible. If it is empty when it expires, then it is deleted.
    */
-  std::optional<std::chrono::duration<double>> mAutoRenewPeriod;
+  std::optional<std::chrono::system_clock::duration> mAutoRenewPeriod;
 
   /**
    * The new expiration time to which to extend this account.

--- a/sdk/main/include/AddressBookQuery.h
+++ b/sdk/main/include/AddressBookQuery.h
@@ -67,7 +67,7 @@ public:
    * @throws PrecheckStatusException      If this AddressBookQuery fails its pre-check.
    * @throws UninitializedException       If the input Client has not yet been initialized.
    */
-  NodeAddressBook execute(const Client& client, const std::chrono::duration<double>& timeout);
+  NodeAddressBook execute(const Client& client, const std::chrono::system_clock::duration& timeout);
 
   /**
    * Set the ID of the file of which to request the address book.
@@ -100,7 +100,7 @@ public:
    * @return A reference to this Client with the newly-set maximum backoff time.
    * @throws std::invalid_argument If the desired maximum backoff duration is shorter than DEFAULT_MIN_BACKOFF.
    */
-  AddressBookQuery& setMaxBackoff(const std::chrono::duration<double>& backoff);
+  AddressBookQuery& setMaxBackoff(const std::chrono::system_clock::duration& backoff);
 
   /**
    * Get the ID of the file of which this query is currently configured to get the address book.
@@ -128,7 +128,7 @@ public:
    *
    * @return The the maximum amount of time to wait before attempting to resubmit this AddressBookQuery.
    */
-  [[nodiscard]] inline std::chrono::duration<double> getMaxBackoff() const { return mMaxBackoff; }
+  [[nodiscard]] inline std::chrono::system_clock::duration getMaxBackoff() const { return mMaxBackoff; }
 
 private:
   /**
@@ -156,7 +156,7 @@ private:
   /**
    * The the maximum amount of time to wait before attempting to resubmit this AddressBookQuery.
    */
-  std::chrono::duration<double> mMaxBackoff = DEFAULT_MAX_BACKOFF;
+  std::chrono::system_clock::duration mMaxBackoff = DEFAULT_MAX_BACKOFF;
 };
 
 } // namespace Hedera

--- a/sdk/main/include/ChunkedTransaction.h
+++ b/sdk/main/include/ChunkedTransaction.h
@@ -73,7 +73,7 @@ public:
    * @throws PrecheckStatusException      If this Executable fails its pre-check.
    * @throws UninitializedException       If the input Client has not yet been initialized.
    */
-  TransactionResponse execute(const Client& client, const std::chrono::duration<double>& timeout) override;
+  TransactionResponse execute(const Client& client, const std::chrono::system_clock::duration& timeout) override;
 
   /**
    * Execute all chunks of this ChunkedTransaction.
@@ -98,7 +98,7 @@ public:
    * @throws PrecheckStatusException      If this Executable fails its pre-check.
    * @throws UninitializedException       If the input Client has not yet been initialized.
    */
-  std::vector<TransactionResponse> executeAll(const Client& client, const std::chrono::duration<double>& timeout);
+  std::vector<TransactionResponse> executeAll(const Client& client, const std::chrono::system_clock::duration& timeout);
 
   /**
    * Derived from Transaction. Add a signature to this ChunkedTransaction.

--- a/sdk/main/include/Client.h
+++ b/sdk/main/include/Client.h
@@ -244,6 +244,17 @@ public:
   Client& setMaxBackoff(const std::chrono::duration<double>& backoff);
 
   /**
+   * Set the maximum amount of time this Client should spend trying to execute a request before giving up on that
+   * request attempt. Every request submitted with this Client will have its gRPC deadline overwritten by this Client's
+   * gRPC deadline if and only if it has not been set manually in the request itself.
+   *
+   * @param deadline The desired maximum amount of time this requests submitted by this Client should spend trying to
+   *                 execute.
+   * @return A reference to this Client with the newly-set gRPC deadline.
+   */
+  Client& setGrpcDeadline(const std::chrono::system_clock::duration& deadline);
+
+  /**
    * Set the period of time this Client wait between updating its network. This will immediately cancel any scheduled
    * network updates and start a new waiting period.
    *
@@ -354,6 +365,15 @@ public:
    *         not previously set.
    */
   [[nodiscard]] std::optional<std::chrono::duration<double>> getMaxBackoff() const;
+
+  /**
+   * Get the maximum amount of time this Client should spend trying to execute a request before giving up on that
+   * request attempt.
+   *
+   * @return  The maximum amount of time this requests submitted by this Client should spend trying to execute.
+   *          Uninitialized value if not previously set.
+   */
+  [[nodiscard]] std::optional<std::chrono::system_clock::duration> getGrpcDeadline() const;
 
   /**
    * Get the period of time this Client wait between updating its network.

--- a/sdk/main/include/Client.h
+++ b/sdk/main/include/Client.h
@@ -172,7 +172,7 @@ public:
    * @param timeout The desired timeout for requests submitted by this Client.
    * @return A reference to this Client object with the newly-set request timeout.
    */
-  Client& setRequestTimeout(const std::chrono::duration<double>& timeout);
+  Client& setRequestTimeout(const std::chrono::system_clock::duration& timeout);
 
   /**
    * Set the maximum transaction fee willing to be paid for transactions executed by this Client. Every request
@@ -228,7 +228,7 @@ public:
    * @throws std::invalid_argument If the desired minimum backoff duration is longer than the set maximum backoff time
    *                               (DEFAULT_MAX_BACKOFF if the maximum backoff time has not been set).
    */
-  Client& setMinBackoff(const std::chrono::duration<double>& backoff);
+  Client& setMinBackoff(const std::chrono::system_clock::duration& backoff);
 
   /**
    * Set the maximum amount of time this Client should wait before attempting to resubmit a previously failed request to
@@ -241,7 +241,7 @@ public:
    * @throws std::invalid_argument If the desired maximum backoff duration is shorter than the set minimum backoff time
    *                               (DEFAULT_MIN_BACKOFF if the minimum backoff time has not been set).
    */
-  Client& setMaxBackoff(const std::chrono::duration<double>& backoff);
+  Client& setMaxBackoff(const std::chrono::system_clock::duration& backoff);
 
   /**
    * Set the maximum amount of time this Client should spend trying to execute a request before giving up on that
@@ -261,7 +261,7 @@ public:
    * @param update The period of time this Client wait between updating its network.
    * @return A reference to this Client with the newly-set network update period.
    */
-  Client& setNetworkUpdatePeriod(const std::chrono::duration<double>& update);
+  Client& setNetworkUpdatePeriod(const std::chrono::system_clock::duration& update);
 
   /**
    * Set the automatic entity checksum validation policy.
@@ -315,7 +315,7 @@ public:
    * @return The request timeout duration. Defaults to 2 minutes if this value has not been set with
    *         setRequestTimeout().
    */
-  [[nodiscard]] std::chrono::duration<double> getRequestTimeout() const;
+  [[nodiscard]] std::chrono::system_clock::duration getRequestTimeout() const;
 
   /**
    * Get the maximum transaction fee willing to be paid for transactions submitted by this Client.
@@ -355,7 +355,7 @@ public:
    * @return The minimum backoff time for Nodes for unsuccessful requests sent by this Client. Uninitialized value if
    *         not previously set.
    */
-  [[nodiscard]] std::optional<std::chrono::duration<double>> getMinBackoff() const;
+  [[nodiscard]] std::optional<std::chrono::system_clock::duration> getMinBackoff() const;
 
   /**
    * Get the maximum amount of time this Client should wait before attempting to resubmit a previously failed request to
@@ -364,7 +364,7 @@ public:
    * @return The maximum backoff time for Nodes for unsuccessful requests sent by this Client. Uninitialized value if
    *         not previously set.
    */
-  [[nodiscard]] std::optional<std::chrono::duration<double>> getMaxBackoff() const;
+  [[nodiscard]] std::optional<std::chrono::system_clock::duration> getMaxBackoff() const;
 
   /**
    * Get the maximum amount of time this Client should spend trying to execute a request before giving up on that
@@ -380,7 +380,7 @@ public:
    *
    * @return The period of time this Client wait between updating its network.
    */
-  [[nodiscard]] std::chrono::duration<double> getNetworkUpdatePeriod() const;
+  [[nodiscard]] std::chrono::system_clock::duration getNetworkUpdatePeriod() const;
 
   /**
    * Is automatic entity checksum validation turned on for this Client?
@@ -410,7 +410,7 @@ private:
    *
    * @param period The period of time to wait before a network update is performed.
    */
-  void startNetworkUpdateThread(const std::chrono::duration<double>& period);
+  void startNetworkUpdateThread(const std::chrono::system_clock::duration& period);
 
   /**
    * Schedule a network update.

--- a/sdk/main/include/ContractCreateFlow.h
+++ b/sdk/main/include/ContractCreateFlow.h
@@ -75,7 +75,7 @@ public:
    * @throws PrecheckStatusException      If this Executable fails its pre-check.
    * @throws UninitializedException       If the input Client has not yet been initialized.
    */
-  TransactionResponse execute(const Client& client, const std::chrono::duration<double>& timeout);
+  TransactionResponse execute(const Client& client, const std::chrono::system_clock::duration& timeout);
 
   /**
    * Set the bytes of the smart contract bytecode. If the bytecode is large (>5K), then it must be stored in a file.
@@ -124,7 +124,7 @@ public:
    * @param autoRenewPeriod The desired auto renew period for the new smart contract instance.
    * @return A reference to this ContractCreateFlow object with the newly-set auto renew period.
    */
-  ContractCreateFlow& setAutoRenewPeriod(const std::chrono::duration<double>& autoRenewPeriod);
+  ContractCreateFlow& setAutoRenewPeriod(const std::chrono::system_clock::duration& autoRenewPeriod);
 
   /**
    * Set the parameters to pass to the new smart contract instance's constructor.
@@ -282,7 +282,7 @@ public:
    *
    * @return The auto renew period for the new smart contract instance.
    */
-  [[nodiscard]] inline std::chrono::duration<double> getAutoRenewPeriod() const { return mAutoRenewPeriod; }
+  [[nodiscard]] inline std::chrono::system_clock::duration getAutoRenewPeriod() const { return mAutoRenewPeriod; }
 
   /**
    * Get the parameters to pass to the new smart contract instance's constructor.
@@ -386,7 +386,7 @@ private:
    * enough balance, it extends as long as possible. If the balance is zero when it expires, then the smart contract
    * instance is deleted.
    */
-  std::chrono::duration<double> mAutoRenewPeriod = DEFAULT_AUTO_RENEW_PERIOD;
+  std::chrono::system_clock::duration mAutoRenewPeriod = DEFAULT_AUTO_RENEW_PERIOD;
 
   /**
    * The parameters to pass to the new smart contract instance's constructor.

--- a/sdk/main/include/ContractCreateTransaction.h
+++ b/sdk/main/include/ContractCreateTransaction.h
@@ -176,7 +176,7 @@ public:
    * @return A reference to this ContractCreateTransaction object with the newly-set auto renew period.
    * @throws IllegalStateException If this ContractCreateTransaction is frozen.
    */
-  ContractCreateTransaction& setAutoRenewPeriod(const std::chrono::duration<double>& autoRenewPeriod);
+  ContractCreateTransaction& setAutoRenewPeriod(const std::chrono::system_clock::duration& autoRenewPeriod);
 
   /**
    * Set the parameters to pass to the new smart contract instance's constructor.
@@ -292,7 +292,7 @@ public:
    *
    * @return The auto renew period for the new smart contract instance.
    */
-  [[nodiscard]] inline std::chrono::duration<double> getAutoRenewPeriod() const { return mAutoRenewPeriod; }
+  [[nodiscard]] inline std::chrono::system_clock::duration getAutoRenewPeriod() const { return mAutoRenewPeriod; }
 
   /**
    * Get the parameters to pass to the new smart contract instance's constructor.
@@ -426,7 +426,7 @@ private:
    * enough balance, it extends as long as possible. If the balance is zero when it expires, then the smart contract
    * instance is deleted.
    */
-  std::chrono::duration<double> mAutoRenewPeriod = DEFAULT_AUTO_RENEW_PERIOD;
+  std::chrono::system_clock::duration mAutoRenewPeriod = DEFAULT_AUTO_RENEW_PERIOD;
 
   /**
    * The parameters to pass to the new smart contract instance's constructor.

--- a/sdk/main/include/ContractInfo.h
+++ b/sdk/main/include/ContractInfo.h
@@ -84,7 +84,7 @@ public:
   /**
    * The duration of time the queried contract uses to automatically extend its expiration period.
    */
-  std::chrono::duration<double> mAutoRenewPeriod;
+  std::chrono::system_clock::duration mAutoRenewPeriod;
 
   /**
    * Get the number of bytes of storage the queried contract is using (which affects the cost to extend the expiration

--- a/sdk/main/include/ContractUpdateTransaction.h
+++ b/sdk/main/include/ContractUpdateTransaction.h
@@ -109,7 +109,7 @@ public:
    * @return A reference to this ContractUpdateTransaction object with the newly-set auto renew period.
    * @throws IllegalStateException If this ContractUpdateTransaction is frozen.
    */
-  ContractUpdateTransaction& setAutoRenewPeriod(const std::chrono::duration<double>& autoRenewPeriod);
+  ContractUpdateTransaction& setAutoRenewPeriod(const std::chrono::system_clock::duration& autoRenewPeriod);
 
   /**
    * Set a new memo for the contract.
@@ -202,7 +202,7 @@ public:
    * @return The new auto renew period for the new contract. Returns uninitialized if a new auto-renew period has not
    *         yet been set.
    */
-  [[nodiscard]] inline std::optional<std::chrono::duration<double>> getAutoRenewPeriod() const
+  [[nodiscard]] inline std::optional<std::chrono::system_clock::duration> getAutoRenewPeriod() const
   {
     return mAutoRenewPeriod;
   }
@@ -323,7 +323,7 @@ private:
   /**
    * The new auto renew period for the contract.
    */
-  std::optional<std::chrono::duration<double>> mAutoRenewPeriod;
+  std::optional<std::chrono::system_clock::duration> mAutoRenewPeriod;
 
   /**
    * The new memo for the contract (UTF-8 encoding max 100 bytes).

--- a/sdk/main/include/Defaults.h
+++ b/sdk/main/include/Defaults.h
@@ -39,6 +39,10 @@ constexpr auto DEFAULT_MIN_BACKOFF = std::chrono::milliseconds(250);
  */
 constexpr auto DEFAULT_MAX_BACKOFF = std::chrono::seconds(8);
 /**
+ * The default maximum amount of time to spend on one execution attempt
+ */
+constexpr auto DEFAULT_GRPC_DEADLINE = std::chrono::seconds(10);
+/**
  * The default maximum number of times a node is allowed to return a bad gRPC status before it is permanently removed
  * from a network. 0 indicates there's no maximum.
  */

--- a/sdk/main/include/EthereumFlow.h
+++ b/sdk/main/include/EthereumFlow.h
@@ -66,7 +66,7 @@ public:
    * @throws PrecheckStatusException      If any Transaction fails its pre-check.
    * @throws UninitializedException       If the input Client has not yet been initialized.
    */
-  TransactionResponse execute(const Client& client, const std::chrono::duration<double>& timeout);
+  TransactionResponse execute(const Client& client, const std::chrono::system_clock::duration& timeout);
 
   /**
    * Set the bytes of the raw EthereumTransaction (RLP encoded type 0, 1, or 2).

--- a/sdk/main/include/Executable.h
+++ b/sdk/main/include/Executable.h
@@ -467,11 +467,6 @@ private:
    * Client's set gRPC deadline, or DEFAULT_GRPC_DEADLINE.
    */
   std::chrono::system_clock::duration mCurrentGrpcDeadline = DEFAULT_GRPC_DEADLINE;
-
-  /**
-   * This Executable's mutex in a std::shared_ptr to allow copying.
-   */
-  // mutable std::mutex mMutex;
 };
 
 } // namespace Hedera

--- a/sdk/main/include/Executable.h
+++ b/sdk/main/include/Executable.h
@@ -25,8 +25,11 @@
 
 #include <chrono>
 #include <functional>
+#include <future>
 #include <memory>
+#include <mutex>
 #include <optional>
+#include <stdexcept>
 #include <vector>
 
 namespace Hedera
@@ -79,7 +82,78 @@ public:
    * @throws PrecheckStatusException      If this Executable fails its pre-check.
    * @throws UninitializedException       If the input Client has not yet been initialized.
    */
-  virtual SdkResponseType execute(const Client& client, const std::chrono::duration<double>& timeout);
+  virtual SdkResponseType execute(const Client& client, const std::chrono::system_clock::duration& timeout);
+
+  /**
+   * Submit this Executable to a Hedera network asynchronously.
+   *
+   * @param client The Client to use to submit this Executable.
+   * @return The future SdkResponseType object sent from the Hedera network that contains the result of the request.
+   * @throws MaxAttemptsExceededException If this Executable attempts to execute past the number of allowable attempts.
+   * @throws PrecheckStatusException      If this Executable fails its pre-check.
+   * @throws UninitializedException       If the input Client has not yet been initialized.
+   */
+  std::future<SdkResponseType> executeAsync(const Client& client);
+
+  /**
+   * Submit this Executable to a Hedera network asynchronously with a specific timeout.
+   *
+   * @param client  The Client to use to submit this Executable.
+   * @param timeout The desired timeout for the execution of this Executable.
+   * @return The future SdkResponseType object sent from the Hedera network that contains the result of the request.
+   * @throws MaxAttemptsExceededException If this Executable attempts to execute past the number of allowable attempts.
+   * @throws PrecheckStatusException      If this Executable fails its pre-check.
+   * @throws UninitializedException       If the input Client has not yet been initialized.
+   */
+  std::future<SdkResponseType> executeAsync(const Client& client, const std::chrono::system_clock::duration& timeout);
+
+  /**
+   * Submit this Executable to a Hedera network asynchronously and consume the response and/or exception with a
+   * callback.
+   *
+   * @param client   The Client to use to submit this Executable.
+   * @param callback The callback that should consume the response/exception.
+   */
+  void executeAsync(const Client& client,
+                    const std::function<void(const SdkResponseType&, const std::exception&)>& callback);
+
+  /**
+   * Submit this Executable to a Hedera network asynchronously with a specific timeout and consume the response and/or
+   * exception with a callback.
+   *
+   * @param client   The Client to use to submit this Executable.
+   * @param timeout  The desired timeout for the execution of this Executable.
+   * @param callback The callback that should consume the response/exception.
+   */
+  void executeAsync(const Client& client,
+                    const std::chrono::system_clock::duration& timeout,
+                    const std::function<void(const SdkResponseType&, const std::exception&)>& callback);
+
+  /**
+   * Submit this Executable to a Hedera network asynchronously and consume the response and/or exception with separate
+   * callbacks.
+   *
+   * @param client            The Client to use to submit this Executable.
+   * @param responseCallback  The callback that should consume the response/exception.
+   * @param exceptionCallback The callback that should consume the exception.
+   */
+  void executeAsync(const Client& client,
+                    const std::function<void(const SdkResponseType&)>& responseCallback,
+                    const std::function<void(const std::exception&)>& exceptionCallback);
+
+  /**
+   * Submit this Executable to a Hedera network asynchronously with a specific timeout and consume the response and/or
+   * exception with separate callbacks.
+   *
+   * @param client            The Client to use to submit this Executable.
+   * @param timeout           The desired timeout for the execution of this Executable.
+   * @param responseCallback  The callback that should consume the response/exception.
+   * @param exceptionCallback The callback that should consume the exception.
+   */
+  void executeAsync(const Client& client,
+                    const std::chrono::system_clock::duration& timeout,
+                    const std::function<void(const SdkResponseType&)>& responseCallback,
+                    const std::function<void(const std::exception&)>& exceptionCallback);
 
   /**
    * Set the desired account IDs of nodes to which this request will be submitted.
@@ -129,7 +203,7 @@ public:
    * @throws std::invalid_argument If the desired minimum backoff duration is longer than the set maximum backoff time
    *                               (DEFAULT_MAX_BACKOFF if the maximum backoff time has not been set).
    */
-  SdkRequestType& setMinBackoff(const std::chrono::duration<double>& backoff);
+  SdkRequestType& setMinBackoff(const std::chrono::system_clock::duration& backoff);
 
   /**
    * Set the maximum amount of time a Node should wait after this Executable failed to execute before being willing to
@@ -141,7 +215,7 @@ public:
    * @throws std::invalid_argument If the desired maximum backoff duration is shorter than the set minimum backoff time
    *                               (DEFAULT_MIN_BACKOFF if the minimum backoff time has not been set).
    */
-  SdkRequestType& setMaxBackoff(const std::chrono::duration<double>& backoff);
+  SdkRequestType& setMaxBackoff(const std::chrono::system_clock::duration& backoff);
 
   /**
    * Set the maximum amount of time this Executable should spend trying to execute a request before giving up on that
@@ -174,7 +248,7 @@ public:
    * @return The minimum backoff time for Nodes for execution attempts of this Executable. Uninitialized value if not
    *         previously set.
    */
-  [[nodiscard]] inline std::optional<std::chrono::duration<double>> getMinBackoff() const { return mMinBackoff; }
+  [[nodiscard]] inline std::optional<std::chrono::system_clock::duration> getMinBackoff() const { return mMinBackoff; }
 
   /**
    * Get the maximum amount of time a Node should wait after this Executable failed to execute before being willing to
@@ -183,7 +257,7 @@ public:
    * @return The maximum backoff time for Nodes for execution attempts of this Executable. Uninitialized value if not
    *         previously set.
    */
-  [[nodiscard]] inline std::optional<std::chrono::duration<double>> getMaxBackoff() const { return mMaxBackoff; }
+  [[nodiscard]] inline std::optional<std::chrono::system_clock::duration> getMaxBackoff() const { return mMaxBackoff; }
 
   /**
    * Set the maximum amount of time this Executable should spend trying to execute a request before giving up on that
@@ -349,13 +423,13 @@ private:
    * The minimum amount of time to wait between submission attempts. If not set, a submission will use the Client's set
    * minimum backoff. If that's not set, DEFAULT_MIN_BACKOFF will be used.
    */
-  std::optional<std::chrono::duration<double>> mMinBackoff;
+  std::optional<std::chrono::system_clock::duration> mMinBackoff;
 
   /**
    * The maximum amount of time to wait between submission attempts. If not set, a submission will use the Client's set
    * maximum backoff. If that's not set, DEFAULT_MAX_BACKOFF will be used.
    */
-  std::optional<std::chrono::duration<double>> mMaxBackoff;
+  std::optional<std::chrono::system_clock::duration> mMaxBackoff;
 
   /**
    * The timeout for one single execution attempt. If not set, a submission will use the Client's set gRPC deadline. If
@@ -373,26 +447,31 @@ private:
    * The minimum backoff to be used for an execution. This may be this Executable's mMinBackoff, the Client's set
    * minimum backoff, or DEFAULT_MIN_BACKOFF.
    */
-  std::chrono::duration<double> mCurrentMinBackoff = DEFAULT_MIN_BACKOFF;
+  std::chrono::system_clock::duration mCurrentMinBackoff = DEFAULT_MIN_BACKOFF;
 
   /**
    * The maximum backoff to be used for an execution. This may be this Executable's mMaxBackoff, the Client's set
    * maximum backoff, or DEFAULT_MAX_BACKOFF.
    */
-  std::chrono::duration<double> mCurrentMaxBackoff = DEFAULT_MAX_BACKOFF;
+  std::chrono::system_clock::duration mCurrentMaxBackoff = DEFAULT_MAX_BACKOFF;
 
   /**
    * The current backoff time being used during the current execution. Every failed submission attempt waits a certain
    * amount of time that is double the previous amount of time this Executable waited for its previous submission
    * attempt, up to the specified maximum backoff time, at which point the execution is considered a failure.
    */
-  std::chrono::duration<double> mCurrentBackoff = DEFAULT_MIN_BACKOFF;
+  std::chrono::system_clock::duration mCurrentBackoff = DEFAULT_MIN_BACKOFF;
 
   /**
    * The current gRPC deadline being used for the current execution. This may be the Executable's mGrpcDeadline, the
    * Client's set gRPC deadline, or DEFAULT_GRPC_DEADLINE.
    */
   std::chrono::system_clock::duration mCurrentGrpcDeadline = DEFAULT_GRPC_DEADLINE;
+
+  /**
+   * This Executable's mutex in a std::shared_ptr to allow copying.
+   */
+  // mutable std::mutex mMutex;
 };
 
 } // namespace Hedera

--- a/sdk/main/include/Query.h
+++ b/sdk/main/include/Query.h
@@ -87,7 +87,7 @@ public:
    * @param timeout The timeout to use to get the cost.
    * @return The expected cost of this Query.
    */
-  [[nodiscard]] Hbar getCost(const Client& client, const std::chrono::duration<double>& timeout);
+  [[nodiscard]] Hbar getCost(const Client& client, const std::chrono::system_clock::duration& timeout);
 
 protected:
   /**

--- a/sdk/main/include/TokenCreateTransaction.h
+++ b/sdk/main/include/TokenCreateTransaction.h
@@ -191,7 +191,7 @@ public:
    * @param period The desired auto-renew period for the new token.
    * @return A reference to this TokenCreateTransaction with the newly-set auto-renew period.
    */
-  TokenCreateTransaction& setAutoRenewPeriod(const std::chrono::duration<double>& period);
+  TokenCreateTransaction& setAutoRenewPeriod(const std::chrono::system_clock::duration& period);
 
   /**
    * Set the desired memo for the new token.
@@ -348,7 +348,7 @@ public:
    *
    * @return The desired auto-renew period for the new token.
    */
-  [[nodiscard]] inline std::chrono::duration<double> getAutoRenewPeriod() const { return mAutoRenewPeriod; }
+  [[nodiscard]] inline std::chrono::system_clock::duration getAutoRenewPeriod() const { return mAutoRenewPeriod; }
 
   /**
    * Get the desired memo for the new token.
@@ -529,7 +529,7 @@ private:
   /**
    * The interval at which the auto-renew account will be charged to extend the token's expiry.
    */
-  std::chrono::duration<double> mAutoRenewPeriod = DEFAULT_AUTO_RENEW_PERIOD;
+  std::chrono::system_clock::duration mAutoRenewPeriod = DEFAULT_AUTO_RENEW_PERIOD;
 
   /**
    * The memo associated with the token (UTF-8 encoding max 100 bytes).

--- a/sdk/main/include/TokenInfo.h
+++ b/sdk/main/include/TokenInfo.h
@@ -164,7 +164,7 @@ public:
   /**
    * The interval at which the auto-renew account will be charged to extend the token's expiry.
    */
-  std::chrono::duration<double> mAutoRenewPeriod;
+  std::chrono::system_clock::duration mAutoRenewPeriod;
 
   /**
    * The epoch second at which the token should expire.

--- a/sdk/main/include/TokenUpdateTransaction.h
+++ b/sdk/main/include/TokenUpdateTransaction.h
@@ -158,7 +158,7 @@ public:
    * @param period The new auto-renew period for the token.
    * @return A reference to this TokenUpdateTransaction with the newly-set auto-renew period.
    */
-  TokenUpdateTransaction& setAutoRenewPeriod(const std::chrono::duration<double>& period);
+  TokenUpdateTransaction& setAutoRenewPeriod(const std::chrono::system_clock::duration& period);
 
   /**
    * Set a new expiration time for the token.
@@ -269,7 +269,7 @@ public:
    *
    * @return The new auto-renew period for the token. Returns uninitialized if no new auto-renew period has been set.
    */
-  [[nodiscard]] inline std::optional<std::chrono::duration<double>> getAutoRenewPeriod() const
+  [[nodiscard]] inline std::optional<std::chrono::system_clock::duration> getAutoRenewPeriod() const
   {
     return mAutoRenewPeriod;
   }
@@ -413,7 +413,7 @@ private:
   /**
    * The new interval at which the auto-renew account will be charged to extend the token's expiry.
    */
-  std::optional<std::chrono::duration<double>> mAutoRenewPeriod;
+  std::optional<std::chrono::system_clock::duration> mAutoRenewPeriod;
 
   /**
    * The new expiration time of the token. Expiration time can be updated even if the admin key is not set. If the

--- a/sdk/main/include/TopicCreateTransaction.h
+++ b/sdk/main/include/TopicCreateTransaction.h
@@ -109,7 +109,7 @@ public:
    * @return A reference to this TopicCreateTransaction object with the newly-set auto-renew period.
    * @throws IllegalStateException If this TopicCreateTransaction is frozen.
    */
-  TopicCreateTransaction& setAutoRenewPeriod(const std::chrono::duration<double>& autoRenew);
+  TopicCreateTransaction& setAutoRenewPeriod(const std::chrono::system_clock::duration& autoRenew);
 
   /**
    * Set the ID of the desired auto-renew account for the new topic.
@@ -146,7 +146,7 @@ public:
    *
    * @return The desired auto-renew period for the new topic.
    */
-  [[nodiscard]] inline std::chrono::duration<double> getAutoRenewPeriod() const { return mAutoRenewPeriod; }
+  [[nodiscard]] inline std::chrono::system_clock::duration getAutoRenewPeriod() const { return mAutoRenewPeriod; }
 
   /**
    * Get the ID of the desired auto-renew account for the new topic.
@@ -225,7 +225,7 @@ private:
   /**
    * The amount of time by which to attempt to extend the new topic's lifetime automatically at its expiration time.
    */
-  std::chrono::duration<double> mAutoRenewPeriod = DEFAULT_AUTO_RENEW_PERIOD;
+  std::chrono::system_clock::duration mAutoRenewPeriod = DEFAULT_AUTO_RENEW_PERIOD;
 
   /**
    * The account that should be charged to extend the lifetime of the new topic at its expiration time.

--- a/sdk/main/include/TopicInfo.h
+++ b/sdk/main/include/TopicInfo.h
@@ -115,7 +115,7 @@ public:
   /**
    * The amount of time by which to attempt to extend the topic's lifetime automatically at its expiration time.
    */
-  std::optional<std::chrono::duration<double>> mAutoRenewPeriod;
+  std::optional<std::chrono::system_clock::duration> mAutoRenewPeriod;
 
   /**
    * The ID of the account that should be charged to extend the lifetime of the new topic at its expiration time.

--- a/sdk/main/include/TopicMessageQuery.h
+++ b/sdk/main/include/TopicMessageQuery.h
@@ -112,7 +112,7 @@ public:
    * @param backoff The maximum amount of time to wait between submission attempts.
    * @return A reference to this TopicMessageQuery object with the newly-set maximum backoff.
    */
-  TopicMessageQuery& setMaxBackoff(const std::chrono::duration<double>& backoff);
+  TopicMessageQuery& setMaxBackoff(const std::chrono::system_clock::duration& backoff);
 
   /**
    * Set the function to run if there's an error with gRPC communication.
@@ -178,7 +178,7 @@ public:
    *
    * @return The maximum amount of time to wait between submission attempts.
    */
-  [[nodiscard]] std::chrono::duration<double> getMaxBackoff() const;
+  [[nodiscard]] std::chrono::system_clock::duration getMaxBackoff() const;
 
 private:
   /**

--- a/sdk/main/include/TopicUpdateTransaction.h
+++ b/sdk/main/include/TopicUpdateTransaction.h
@@ -122,7 +122,7 @@ public:
    * @return A reference to this TopicUpdateTransaction object with the newly-set auto-renew period.
    * @throws IllegalStateException If this TopicUpdateTransaction is frozen.
    */
-  TopicUpdateTransaction& setAutoRenewPeriod(const std::chrono::duration<double>& autoRenew);
+  TopicUpdateTransaction& setAutoRenewPeriod(const std::chrono::system_clock::duration& autoRenew);
 
   /**
    * Set the ID of a new auto-renew account for the topic.
@@ -204,7 +204,7 @@ public:
    *
    * @return The new auto-renew period for the topic. Returns uninitialized if the auto-renew period has not been set.
    */
-  [[nodiscard]] inline std::optional<std::chrono::duration<double>> getAutoRenewPeriod() const
+  [[nodiscard]] inline std::optional<std::chrono::system_clock::duration> getAutoRenewPeriod() const
   {
     return mAutoRenewPeriod;
   }
@@ -293,7 +293,7 @@ private:
   /**
    * The new amount of time by which to attempt to extend the topic's lifetime automatically at its expiration time.
    */
-  std::optional<std::chrono::duration<double>> mAutoRenewPeriod;
+  std::optional<std::chrono::system_clock::duration> mAutoRenewPeriod;
 
   /**
    * The ID of the new account that should be charged to extend the lifetime of the topic at its expiration time.

--- a/sdk/main/include/Transaction.h
+++ b/sdk/main/include/Transaction.h
@@ -239,7 +239,7 @@ public:
    * @return A reference to this derived Transaction object with the newly-set valid duration.
    * @throws IllegalStateException If this Transaction is frozen.
    */
-  SdkRequestType& setValidTransactionDuration(const std::chrono::duration<double>& duration);
+  SdkRequestType& setValidTransactionDuration(const std::chrono::system_clock::duration& duration);
 
   /**
    * Set the memo for this Transaction.
@@ -287,7 +287,7 @@ public:
    *
    * @return The length of time this Transaction will remain valid.
    */
-  [[nodiscard]] std::chrono::duration<double> getValidTransactionDuration() const;
+  [[nodiscard]] std::chrono::system_clock::duration getValidTransactionDuration() const;
 
   /**
    * Get the memo for this Transaction.

--- a/sdk/main/include/TransactionResponse.h
+++ b/sdk/main/include/TransactionResponse.h
@@ -85,7 +85,7 @@ public:
    *                                      TransactionResponse is configured to throw.
    * @throws UninitializedException       If the input Client has not yet been initialized.
    */
-  TransactionReceipt getReceipt(const Client& client, const std::chrono::duration<double>& timeout) const;
+  TransactionReceipt getReceipt(const Client& client, const std::chrono::system_clock::duration& timeout) const;
 
   /**
    * Get a TransactionRecord for the Transaction to which this TransactionResponse is responding.
@@ -110,7 +110,8 @@ public:
    * @throws PrecheckStatusException      If this TransactionRecordQuery fails its pre-check.
    * @throws UninitializedException       If the input Client has not yet been initialized.
    */
-  [[nodiscard]] TransactionRecord getRecord(const Client& client, const std::chrono::duration<double>& timeout) const;
+  [[nodiscard]] TransactionRecord getRecord(const Client& client,
+                                            const std::chrono::system_clock::duration& timeout) const;
 
   /**
    * Set this TransactionResponse's TransactionReceipt validation policy.

--- a/sdk/main/include/impl/BaseNetwork.h
+++ b/sdk/main/include/impl/BaseNetwork.h
@@ -92,7 +92,7 @@ public:
    * @param backoff The minimum backoff time to use for a NodeType after a bad gRPC status is received.
    * @return A reference to this derived BaseNetwork object with the newly-set minimum backoff.
    */
-  NetworkType& setMinNodeBackoff(const std::chrono::duration<double>& backoff);
+  NetworkType& setMinNodeBackoff(const std::chrono::system_clock::duration& backoff);
 
   /**
    * Set the maximum amount of time to backoff from a NodeType after a bad gRPC status is received.
@@ -100,7 +100,7 @@ public:
    * @param backoff The maximum backoff time to use for a NodeType after a bad gRPC status is received.
    * @return A reference to this derived BaseNetwork object with the newly-set maximum backoff.
    */
-  NetworkType& setMaxNodeBackoff(const std::chrono::duration<double>& backoff);
+  NetworkType& setMaxNodeBackoff(const std::chrono::system_clock::duration& backoff);
 
   /**
    * Set the minimum amount of time to wait before readmitting NodeTypes as "healthy".
@@ -108,7 +108,7 @@ public:
    * @param time The minimum amount of time to wait before readmitting NodeTypes as "healthy".
    * @return A reference to this derived BaseNetwork object with the newly-set minimum node readmit time.
    */
-  NetworkType& setMinNodeReadmitTime(const std::chrono::duration<double>& time);
+  NetworkType& setMinNodeReadmitTime(const std::chrono::system_clock::duration& time);
 
   /**
    * Set the maximum amount of time to wait before readmitting NodeTypes as "healthy".
@@ -116,7 +116,7 @@ public:
    * @param time The maximum amount of time to wait before readmitting NodeTypes as "healthy".
    * @return A reference to this derived BaseNetwork object with the newly-set maximum node readmit time.
    */
-  NetworkType& setMaxNodeReadmitTime(const std::chrono::duration<double>& time);
+  NetworkType& setMaxNodeReadmitTime(const std::chrono::system_clock::duration& time);
 
   /**
    * Set the amount of time to allow gRPC connections on this BaseNetwork to close gracefully before forcibly
@@ -125,7 +125,7 @@ public:
    * @param timeout The amount of time to allow gRPC connections on this BaseNetwork to close gracefully.
    * @return A reference to this derived BaseNetwork object with the newly-set close timeout.
    */
-  NetworkType& setCloseTimeout(const std::chrono::duration<double>& timeout);
+  NetworkType& setCloseTimeout(const std::chrono::system_clock::duration& timeout);
 
   /**
    * Set the ledger ID of this BaseNetwork.
@@ -154,28 +154,28 @@ public:
    *
    * @return The minimum amount of time to backoff from a NodeType after a bad gRPC status is received.
    */
-  [[nodiscard]] inline std::chrono::duration<double> getMinNodeBackoff() const { return mMinNodeBackoff; }
+  [[nodiscard]] inline std::chrono::system_clock::duration getMinNodeBackoff() const { return mMinNodeBackoff; }
 
   /**
    * Get the maximum amount of time to backoff from a NodeType after a bad gRPC status is received.
    *
    * @return The maximum amount of time to backoff from a NodeType after a bad gRPC status is received.
    */
-  [[nodiscard]] inline std::chrono::duration<double> getMaxNodeBackoff() const { return mMaxNodeBackoff; }
+  [[nodiscard]] inline std::chrono::system_clock::duration getMaxNodeBackoff() const { return mMaxNodeBackoff; }
 
   /**
    * Get the minimum amount of time to wait before readmitting NodeTypes as "healthy".
    *
    * @return The minimum amount of time to wait before readmitting NodeTypes as "healthy".
    */
-  [[nodiscard]] inline std::chrono::duration<double> getMinNodeReadmitTime() const { return mMinNodeReadmitTime; }
+  [[nodiscard]] inline std::chrono::system_clock::duration getMinNodeReadmitTime() const { return mMinNodeReadmitTime; }
 
   /**
    * Get the maximum amount of time to wait before readmitting NodeTypes as "healthy".
    *
    * @return The maximum amount of time to wait before readmitting NodeTypes as "healthy".
    */
-  [[nodiscard]] inline std::chrono::duration<double> getMaxNodeReadmitTime() const { return mMaxNodeReadmitTime; }
+  [[nodiscard]] inline std::chrono::system_clock::duration getMaxNodeReadmitTime() const { return mMaxNodeReadmitTime; }
 
   /**
    * Get the amount of time to allow gRPC connections on this BaseNetwork to close gracefully before forcibly
@@ -184,7 +184,7 @@ public:
    * @return The amount of time to allow gRPC connections on this BaseNetwork to close gracefully before forcibly
    *         terminating them.
    */
-  [[nodiscard]] inline std::chrono::duration<double> getCloseTimeout() const { return mCloseTimeout; }
+  [[nodiscard]] inline std::chrono::system_clock::duration getCloseTimeout() const { return mCloseTimeout; }
 
   /**
    * Get the ledger ID of this Network.
@@ -300,22 +300,22 @@ private:
   /**
    * The minimum amount of time to wait to use a NodeType after it has received a bad gRPC status.
    */
-  std::chrono::duration<double> mMinNodeBackoff = DEFAULT_MIN_NODE_BACKOFF;
+  std::chrono::system_clock::duration mMinNodeBackoff = DEFAULT_MIN_NODE_BACKOFF;
 
   /**
    * The maximum amount of time to wait to use a NodeType after it has received a bad gRPC status.
    */
-  std::chrono::duration<double> mMaxNodeBackoff = DEFAULT_MAX_NODE_BACKOFF;
+  std::chrono::system_clock::duration mMaxNodeBackoff = DEFAULT_MAX_NODE_BACKOFF;
 
   /**
    * The minimum time to wait before attempting to readmit nodes.
    */
-  std::chrono::duration<double> mMinNodeReadmitTime = DEFAULT_MIN_NODE_BACKOFF;
+  std::chrono::system_clock::duration mMinNodeReadmitTime = DEFAULT_MIN_NODE_BACKOFF;
 
   /**
    * The maximum time to wait before attempting to readmit nodes.
    */
-  std::chrono::duration<double> mMaxNodeReadmitTime = DEFAULT_MAX_NODE_BACKOFF;
+  std::chrono::system_clock::duration mMaxNodeReadmitTime = DEFAULT_MAX_NODE_BACKOFF;
 
   /**
    * The earliest time that a node should be readmitted.
@@ -325,7 +325,7 @@ private:
   /**
    * The timeout for closing either a single node when setting a new network, or closing the entire network.
    */
-  std::chrono::duration<double> mCloseTimeout = DEFAULT_CLOSE_TIMEOUT;
+  std::chrono::system_clock::duration mCloseTimeout = DEFAULT_CLOSE_TIMEOUT;
 
   /**
    * The ledger ID of the network.

--- a/sdk/main/include/impl/BaseNode.h
+++ b/sdk/main/include/impl/BaseNode.h
@@ -77,7 +77,7 @@ public:
    *
    * @return The remaining amount of time this BaseNode has in its backoff.
    */
-  [[nodiscard]] std::chrono::duration<double> getRemainingTimeForBackoff() const;
+  [[nodiscard]] std::chrono::system_clock::duration getRemainingTimeForBackoff() const;
 
   /**
    * Set the minimum amount of time for this BaseNode to backoff after a bad gRPC status is received.
@@ -85,7 +85,7 @@ public:
    * @param backoff The minimum backoff time for this BaseNode after a bad gRPC status is received.
    * @return A reference to this derived BaseNode object with the newly-set minimum backoff.
    */
-  NodeType& setMinNodeBackoff(const std::chrono::duration<double>& backoff);
+  NodeType& setMinNodeBackoff(const std::chrono::system_clock::duration& backoff);
 
   /**
    * Set the maximum amount of time for this BaseNode to backoff after a bad gRPC status is received.
@@ -93,7 +93,7 @@ public:
    * @param backoff The maximum backoff time for this BaseNode after a bad gRPC status is received.
    * @return A reference to this derived BaseNode object with the newly-set minimum backoff.
    */
-  NodeType& setMaxNodeBackoff(const std::chrono::duration<double>& backoff);
+  NodeType& setMaxNodeBackoff(const std::chrono::system_clock::duration& backoff);
 
   /**
    * Get this BaseNode's BaseNodeAddress.
@@ -111,7 +111,7 @@ public:
    *
    * @return The minimum amount of time for this BaseNode to backoff after a bad gRPC status is received.
    */
-  [[nodiscard]] inline std::chrono::duration<double> getMinNodeBackoff() const
+  [[nodiscard]] inline std::chrono::system_clock::duration getMinNodeBackoff() const
   {
     std::unique_lock lock(*mMutex);
     return mMinNodeBackoff;
@@ -122,7 +122,7 @@ public:
    *
    * @return The maximum amount of time for this BaseNode to backoff after a bad gRPC status is received.
    */
-  [[nodiscard]] inline std::chrono::duration<double> getMaxNodeBackoff() const
+  [[nodiscard]] inline std::chrono::system_clock::duration getMaxNodeBackoff() const
   {
     std::unique_lock lock(*mMutex);
     return mMaxNodeBackoff;
@@ -238,18 +238,18 @@ private:
   /**
    * The minimum amount of time to wait to use this BaseNode after it has received a bad gRPC status.
    */
-  std::chrono::duration<double> mMinNodeBackoff = DEFAULT_MIN_NODE_BACKOFF;
+  std::chrono::system_clock::duration mMinNodeBackoff = DEFAULT_MIN_NODE_BACKOFF;
 
   /**
    * The maximum amount of time to wait to use this BaseNode after it has received a bad gRPC status.
    */
-  std::chrono::duration<double> mMaxNodeBackoff = DEFAULT_MAX_NODE_BACKOFF;
+  std::chrono::system_clock::duration mMaxNodeBackoff = DEFAULT_MAX_NODE_BACKOFF;
 
   /**
    * The current amount of time to wait to use this BaseNode after it has received a bad gRPC status. This will increase
    * exponentially until mMaxNodeBackoff is reached.
    */
-  std::chrono::duration<double> mCurrentBackoff = DEFAULT_MIN_NODE_BACKOFF;
+  std::chrono::system_clock::duration mCurrentBackoff = DEFAULT_MIN_NODE_BACKOFF;
 
   /**
    * The time at which this BaseNode will be considered "healthy".

--- a/sdk/main/include/impl/DurationConverter.h
+++ b/sdk/main/include/impl/DurationConverter.h
@@ -44,7 +44,7 @@ std::chrono::seconds fromProtobuf(const proto::Duration& duration);
  * @param duration The duration object from which to create a Duration protobuf object.
  * @return A pointer to the created Duration protobuf object.
  */
-proto::Duration* toProtobuf(const std::chrono::duration<double>& duration);
+proto::Duration* toProtobuf(const std::chrono::system_clock::duration& duration);
 
 } // namespace Hedera::internal::DurationConverter
 

--- a/sdk/main/src/AccountCreateTransaction.cc
+++ b/sdk/main/src/AccountCreateTransaction.cc
@@ -84,7 +84,7 @@ AccountCreateTransaction& AccountCreateTransaction::setReceiverSignatureRequired
 
 //-----
 AccountCreateTransaction& AccountCreateTransaction::setAutoRenewPeriod(
-  const std::chrono::duration<double>& autoRenewPeriod)
+  const std::chrono::system_clock::duration& autoRenewPeriod)
 {
   requireNotFrozen();
 
@@ -240,8 +240,7 @@ proto::CryptoCreateTransactionBody* AccountCreateTransaction::build() const
 
   body->set_initialbalance(mInitialBalance.toTinybars());
   body->set_receiversigrequired(mReceiverSignatureRequired);
-  body->set_allocated_autorenewperiod(
-    internal::DurationConverter::toProtobuf(std::chrono::duration_cast<std::chrono::seconds>(mAutoRenewPeriod)));
+  body->set_allocated_autorenewperiod(internal::DurationConverter::toProtobuf(mAutoRenewPeriod));
   body->set_memo(mAccountMemo);
   body->set_max_automatic_token_associations(static_cast<int32_t>(mMaxAutomaticTokenAssociations));
 

--- a/sdk/main/src/AccountUpdateTransaction.cc
+++ b/sdk/main/src/AccountUpdateTransaction.cc
@@ -72,7 +72,7 @@ AccountUpdateTransaction& AccountUpdateTransaction::setReceiverSignatureRequired
 
 //-----
 AccountUpdateTransaction& AccountUpdateTransaction::setAutoRenewPeriod(
-  const std::chrono::duration<double>& autoRenewPeriod)
+  const std::chrono::system_clock::duration& autoRenewPeriod)
 {
   requireNotFrozen();
 

--- a/sdk/main/src/AddressBookQuery.cc
+++ b/sdk/main/src/AddressBookQuery.cc
@@ -38,10 +38,9 @@ NodeAddressBook AddressBookQuery::execute(const Client& client)
 }
 
 //-----
-NodeAddressBook AddressBookQuery::execute(const Client& client, const std::chrono::duration<double>& timeout)
+NodeAddressBook AddressBookQuery::execute(const Client& client, const std::chrono::system_clock::duration& timeout)
 {
-  const std::chrono::system_clock::time_point timeoutTime =
-    std::chrono::system_clock::now() + std::chrono::duration_cast<std::chrono::system_clock::duration>(timeout);
+  const std::chrono::system_clock::time_point timeoutTime = std::chrono::system_clock::now() + timeout;
 
   for (unsigned int attempt = 0U;; ++attempt)
   {
@@ -81,10 +80,9 @@ NodeAddressBook AddressBookQuery::execute(const Client& client, const std::chron
                                                                 errorCode == grpc::StatusCode::INTERNAL)
     {
       // Sleep and retry.
-      std::this_thread::sleep_for(
-        std::min(std::chrono::duration_cast<std::chrono::system_clock::duration>(
-                   DEFAULT_MIN_BACKOFF * pow(static_cast<double>(attempt), 2.0)),
-                 std::chrono::duration_cast<std::chrono::system_clock::duration>(mMaxBackoff)));
+      std::this_thread::sleep_for(std::min(std::chrono::duration_cast<std::chrono::system_clock::duration>(
+                                             DEFAULT_MIN_BACKOFF * pow(static_cast<double>(attempt), 2.0)),
+                                           mMaxBackoff));
       continue;
     }
 
@@ -114,7 +112,7 @@ AddressBookQuery& AddressBookQuery::setMaxAttempts(unsigned int attempts)
 }
 
 //-----
-AddressBookQuery& AddressBookQuery::setMaxBackoff(const std::chrono::duration<double>& backoff)
+AddressBookQuery& AddressBookQuery::setMaxBackoff(const std::chrono::system_clock::duration& backoff)
 {
   mMaxBackoff = backoff;
   return *this;

--- a/sdk/main/src/ChunkedTransaction.cc
+++ b/sdk/main/src/ChunkedTransaction.cc
@@ -70,7 +70,7 @@ TransactionResponse ChunkedTransaction<SdkRequestType>::execute(const Client& cl
 //-----
 template<typename SdkRequestType>
 TransactionResponse ChunkedTransaction<SdkRequestType>::execute(const Client& client,
-                                                                const std::chrono::duration<double>& timeout)
+                                                                const std::chrono::system_clock::duration& timeout)
 {
   return executeAll(client, timeout).at(0);
 }
@@ -86,7 +86,7 @@ std::vector<TransactionResponse> ChunkedTransaction<SdkRequestType>::executeAll(
 template<typename SdkRequestType>
 std::vector<TransactionResponse> ChunkedTransaction<SdkRequestType>::executeAll(
   const Client& client,
-  const std::chrono::duration<double>& timeout)
+  const std::chrono::system_clock::duration& timeout)
 {
   // Determine how many chunks are going to be required to send this whole ChunkedTransaction and make sure it's within
   // the set limit.

--- a/sdk/main/src/Client.cc
+++ b/sdk/main/src/Client.cc
@@ -80,6 +80,10 @@ struct Client::ClientImpl
   // again after a failure to the same Node. A manually-set maximum backoff in the request will override this.
   std::optional<std::chrono::duration<double>> mMaxBackoff;
 
+  // The maximum amount of time this Client should spend trying to execute a request before giving up on that request
+  // attempt. A manually-set gRPC deadline in the request will override this.
+  std::optional<std::chrono::system_clock::duration> mGrpcDeadline;
+
   // The period of time to wait between network updates.
   std::chrono::duration<double> mNetworkUpdatePeriod = DEFAULT_NETWORK_UPDATE_PERIOD;
 
@@ -497,6 +501,13 @@ Client& Client::setMaxBackoff(const std::chrono::duration<double>& backoff)
 }
 
 //-----
+Client& Client::setGrpcDeadline(const std::chrono::system_clock::duration& deadline)
+{
+  mImpl->mGrpcDeadline = deadline;
+  return *this;
+}
+
+//-----
 Client& Client::setNetworkUpdatePeriod(const std::chrono::duration<double>& update)
 {
   // Cancel any previous network updates and wait for the thread to complete.
@@ -597,6 +608,12 @@ std::optional<std::chrono::duration<double>> Client::getMinBackoff() const
 std::optional<std::chrono::duration<double>> Client::getMaxBackoff() const
 {
   return mImpl->mMaxBackoff;
+}
+
+//-----
+std::optional<std::chrono::system_clock::duration> Client::getGrpcDeadline() const
+{
+  return mImpl->mGrpcDeadline;
 }
 
 //-----

--- a/sdk/main/src/ContractCreateFlow.cc
+++ b/sdk/main/src/ContractCreateFlow.cc
@@ -39,7 +39,8 @@ TransactionResponse ContractCreateFlow::execute(const Client& client)
 }
 
 //-----
-TransactionResponse ContractCreateFlow::execute(const Client& client, const std::chrono::duration<double>& timeout)
+TransactionResponse ContractCreateFlow::execute(const Client& client,
+                                                const std::chrono::system_clock::duration& timeout)
 {
   // First determine if the input bytecode needs to be split.
   std::vector<std::byte> appendedByteCode;
@@ -176,7 +177,7 @@ ContractCreateFlow& ContractCreateFlow::setInitialBalance(const Hbar& initialBal
 }
 
 //-----
-ContractCreateFlow& ContractCreateFlow::setAutoRenewPeriod(const std::chrono::duration<double>& autoRenewPeriod)
+ContractCreateFlow& ContractCreateFlow::setAutoRenewPeriod(const std::chrono::system_clock::duration& autoRenewPeriod)
 {
   mAutoRenewPeriod = autoRenewPeriod;
   return *this;

--- a/sdk/main/src/ContractCreateTransaction.cc
+++ b/sdk/main/src/ContractCreateTransaction.cc
@@ -98,7 +98,7 @@ ContractCreateTransaction& ContractCreateTransaction::setInitialBalance(const Hb
 
 //-----
 ContractCreateTransaction& ContractCreateTransaction::setAutoRenewPeriod(
-  const std::chrono::duration<double>& autoRenewPeriod)
+  const std::chrono::system_clock::duration& autoRenewPeriod)
 {
   requireNotFrozen();
   mAutoRenewPeriod = autoRenewPeriod;

--- a/sdk/main/src/ContractUpdateTransaction.cc
+++ b/sdk/main/src/ContractUpdateTransaction.cc
@@ -71,7 +71,7 @@ ContractUpdateTransaction& ContractUpdateTransaction::setAdminKey(const std::sha
 
 //-----
 ContractUpdateTransaction& ContractUpdateTransaction::setAutoRenewPeriod(
-  const std::chrono::duration<double>& autoRenewPeriod)
+  const std::chrono::system_clock::duration& autoRenewPeriod)
 {
   requireNotFrozen();
   mAutoRenewPeriod = autoRenewPeriod;

--- a/sdk/main/src/EthereumFlow.cc
+++ b/sdk/main/src/EthereumFlow.cc
@@ -35,7 +35,7 @@ TransactionResponse EthereumFlow::execute(const Client& client)
 }
 
 //-----
-TransactionResponse EthereumFlow::execute(const Client& client, const std::chrono::duration<double>& timeout)
+TransactionResponse EthereumFlow::execute(const Client& client, const std::chrono::system_clock::duration& timeout)
 {
   // Make sure the ethereum data has been set. There is nothing to do if there is no ethereum data.
   if (!mEthereumData)

--- a/sdk/main/src/Executable.cc
+++ b/sdk/main/src/Executable.cc
@@ -398,48 +398,6 @@ SdkRequestType& Executable<SdkRequestType, ProtoRequestType, ProtoResponseType, 
 }
 
 //-----
-/*template<typename SdkRequestType, typename ProtoRequestType, typename ProtoResponseType, typename SdkResponseType>
-Executable<SdkRequestType, ProtoRequestType, ProtoResponseType, SdkResponseType>::Executable(
-  const Executable<SdkRequestType, ProtoRequestType, ProtoResponseType, SdkResponseType>& other)
-{
-  std::unique_lock lock(other.mMutex);
-  mNodeAccountIds = other.mNodeAccountIds;
-  mRequestListener = other.mRequestListener;
-  mResponseListener = other.mResponseListener;
-  mMaxAttempts = other.mMaxAttempts;
-  mMinBackoff = other.mMinBackoff;
-  mMaxBackoff = other.mMaxBackoff;
-  mGrpcDeadline = other.mGrpcDeadline;
-  // Don't bother copying `mCurrent*` variables as those are reset every execution and only used there.
-}
-
-//-----
-template<typename SdkRequestType, typename ProtoRequestType, typename ProtoResponseType, typename SdkResponseType>
-Executable<SdkRequestType, ProtoRequestType, ProtoResponseType, SdkResponseType>&
-Executable<SdkRequestType, ProtoRequestType, ProtoResponseType, SdkResponseType>::operator=(
-  const Executable<SdkRequestType, ProtoRequestType, ProtoResponseType, SdkResponseType>& other)
-{
-  if (this != &other)
-  {
-    // Lock both Executables and prevent deadlocks.
-    std::lock(mMutex, other.mMutex);
-    std::lock_guard myLock(mMutex, std::adopt_lock);
-    std::lock_guard otherLock(other.mMutex, std::adopt_lock);
-
-    mNodeAccountIds = other.mNodeAccountIds;
-    mRequestListener = other.mRequestListener;
-    mResponseListener = other.mResponseListener;
-    mMaxAttempts = other.mMaxAttempts;
-    mMinBackoff = other.mMinBackoff;
-    mMaxBackoff = other.mMaxBackoff;
-    mGrpcDeadline = other.mGrpcDeadline;
-    // Don't bother copying `mCurrent*` variables as those are reset every execution and only used there.
-  }
-
-  return *this;
-}*/
-
-//-----
 template<typename SdkRequestType, typename ProtoRequestType, typename ProtoResponseType, typename SdkResponseType>
 typename Executable<SdkRequestType, ProtoRequestType, ProtoResponseType, SdkResponseType>::ExecutionStatus
 Executable<SdkRequestType, ProtoRequestType, ProtoResponseType, SdkResponseType>::determineStatus(

--- a/sdk/main/src/PrivateKey.cc
+++ b/sdk/main/src/PrivateKey.cc
@@ -190,6 +190,7 @@ std::vector<std::byte> PrivateKey::signTransaction(WrappedTransaction& transacti
     case TRANSFER_TRANSACTION:
       return signTransaction(*transaction.getTransaction<TransferTransaction>());
     case UNKNOWN_TRANSACTION:
+    default:
     {
       throw std::invalid_argument("Unrecognized TransactionType");
     }

--- a/sdk/main/src/Query.cc
+++ b/sdk/main/src/Query.cc
@@ -109,7 +109,8 @@ Hbar Query<SdkRequestType, SdkResponseType>::getCost(const Client& client)
 
 //-----
 template<typename SdkRequestType, typename SdkResponseType>
-Hbar Query<SdkRequestType, SdkResponseType>::getCost(const Client& client, const std::chrono::duration<double>& timeout)
+Hbar Query<SdkRequestType, SdkResponseType>::getCost(const Client& client,
+                                                     const std::chrono::system_clock::duration& timeout)
 {
   // Configure this Query to get the cost.
   mImpl->mGetCost = true;

--- a/sdk/main/src/TokenCreateTransaction.cc
+++ b/sdk/main/src/TokenCreateTransaction.cc
@@ -160,7 +160,7 @@ TokenCreateTransaction& TokenCreateTransaction::setAutoRenewAccountId(const Acco
 }
 
 //-----
-TokenCreateTransaction& TokenCreateTransaction::setAutoRenewPeriod(const std::chrono::duration<double>& period)
+TokenCreateTransaction& TokenCreateTransaction::setAutoRenewPeriod(const std::chrono::system_clock::duration& period)
 {
   requireNotFrozen();
   mAutoRenewPeriod = period;

--- a/sdk/main/src/TokenUpdateTransaction.cc
+++ b/sdk/main/src/TokenUpdateTransaction.cc
@@ -126,7 +126,7 @@ TokenUpdateTransaction& TokenUpdateTransaction::setAutoRenewAccountId(const Acco
 }
 
 //-----
-TokenUpdateTransaction& TokenUpdateTransaction::setAutoRenewPeriod(const std::chrono::duration<double>& period)
+TokenUpdateTransaction& TokenUpdateTransaction::setAutoRenewPeriod(const std::chrono::system_clock::duration& period)
 {
   requireNotFrozen();
   mAutoRenewPeriod = period;

--- a/sdk/main/src/TopicCreateTransaction.cc
+++ b/sdk/main/src/TopicCreateTransaction.cc
@@ -68,7 +68,7 @@ TopicCreateTransaction& TopicCreateTransaction::setSubmitKey(const std::shared_p
 }
 
 //-----
-TopicCreateTransaction& TopicCreateTransaction::setAutoRenewPeriod(const std::chrono::duration<double>& autoRenew)
+TopicCreateTransaction& TopicCreateTransaction::setAutoRenewPeriod(const std::chrono::system_clock::duration& autoRenew)
 {
   requireNotFrozen();
   mAutoRenewPeriod = autoRenew;

--- a/sdk/main/src/TopicMessageQuery.cc
+++ b/sdk/main/src/TopicMessageQuery.cc
@@ -71,7 +71,7 @@ void startSubscription(
   std::function<void(void)> completionHandler,
   std::function<void(const TopicMessage&)> onNext,
   uint32_t maxAttempts,
-  std::chrono::duration<double> maxBackoff,
+  std::chrono::system_clock::duration maxBackoff,
   SubscriptionHandle* handle)
 {
   // Grab moved objects.
@@ -85,7 +85,7 @@ void startSubscription(
   com::hedera::mirror::api::proto::ConsensusTopicResponse response;
   std::unordered_map<TransactionId, std::vector<com::hedera::mirror::api::proto::ConsensusTopicResponse>>
     pendingMessages;
-  std::chrono::duration<double> backoff = DEFAULT_MIN_BACKOFF;
+  std::chrono::system_clock::duration backoff = DEFAULT_MIN_BACKOFF;
   grpc::Status grpcStatus;
   uint64_t attempt = 0ULL;
   bool complete = false;
@@ -262,7 +262,7 @@ struct TopicMessageQuery::TopicMessageQueryImpl
   uint32_t mMaxAttempts = DEFAULT_MAX_ATTEMPTS;
 
   // The maximum amount of time to wait between submission attempts.
-  std::chrono::duration<double> mMaxBackoff = DEFAULT_MAX_BACKOFF;
+  std::chrono::system_clock::duration mMaxBackoff = DEFAULT_MAX_BACKOFF;
 
   // The function to run when there's an error.
   std::function<void(grpc::Status)> mErrorHandler = [](const grpc::Status& status)
@@ -406,7 +406,7 @@ TopicMessageQuery& TopicMessageQuery::setMaxAttempts(uint32_t attempts)
 }
 
 //-----
-TopicMessageQuery& TopicMessageQuery::setMaxBackoff(const std::chrono::duration<double>& backoff)
+TopicMessageQuery& TopicMessageQuery::setMaxBackoff(const std::chrono::system_clock::duration& backoff)
 {
   mImpl->mMaxBackoff = backoff;
   return *this;
@@ -464,7 +464,7 @@ uint32_t TopicMessageQuery::getMaxAttempts() const
 }
 
 //-----
-std::chrono::duration<double> TopicMessageQuery::getMaxBackoff() const
+std::chrono::system_clock::duration TopicMessageQuery::getMaxBackoff() const
 {
   return mImpl->mMaxBackoff;
 }

--- a/sdk/main/src/TopicUpdateTransaction.cc
+++ b/sdk/main/src/TopicUpdateTransaction.cc
@@ -86,7 +86,7 @@ TopicUpdateTransaction& TopicUpdateTransaction::setSubmitKey(const std::shared_p
 }
 
 //-----
-TopicUpdateTransaction& TopicUpdateTransaction::setAutoRenewPeriod(const std::chrono::duration<double>& autoRenew)
+TopicUpdateTransaction& TopicUpdateTransaction::setAutoRenewPeriod(const std::chrono::system_clock::duration& autoRenew)
 {
   requireNotFrozen();
   mAutoRenewPeriod = autoRenew;

--- a/sdk/main/src/Transaction.cc
+++ b/sdk/main/src/Transaction.cc
@@ -129,7 +129,7 @@ struct Transaction<SdkRequestType>::TransactionImpl
   Hbar mDefaultMaxTransactionFee = DEFAULT_MAX_TRANSACTION_FEE;
 
   // The length of time this Transaction will remain valid.
-  std::chrono::duration<double> mTransactionValidDuration = DEFAULT_TRANSACTION_VALID_DURATION;
+  std::chrono::system_clock::duration mTransactionValidDuration = DEFAULT_TRANSACTION_VALID_DURATION;
 
   // The memo to be associated with this Transaction.
   std::string mTransactionMemo;
@@ -542,7 +542,8 @@ SdkRequestType& Transaction<SdkRequestType>::setMaxTransactionFee(const Hbar& fe
 
 //-----
 template<typename SdkRequestType>
-SdkRequestType& Transaction<SdkRequestType>::setValidTransactionDuration(const std::chrono::duration<double>& duration)
+SdkRequestType& Transaction<SdkRequestType>::setValidTransactionDuration(
+  const std::chrono::system_clock::duration& duration)
 {
   requireNotFrozen();
   mImpl->mTransactionValidDuration = duration;
@@ -595,7 +596,7 @@ Hbar Transaction<SdkRequestType>::getDefaultMaxTransactionFee() const
 
 //-----
 template<typename SdkRequestType>
-std::chrono::duration<double> Transaction<SdkRequestType>::getValidTransactionDuration() const
+std::chrono::system_clock::duration Transaction<SdkRequestType>::getValidTransactionDuration() const
 {
   return mImpl->mTransactionValidDuration;
 }

--- a/sdk/main/src/TransactionResponse.cc
+++ b/sdk/main/src/TransactionResponse.cc
@@ -46,7 +46,7 @@ TransactionReceipt TransactionResponse::getReceipt(const Client& client) const
 
 //-----
 TransactionReceipt TransactionResponse::getReceipt(const Client& client,
-                                                   const std::chrono::duration<double>& timeout) const
+                                                   const std::chrono::system_clock::duration& timeout) const
 {
   TransactionReceipt txReceipt = TransactionReceiptQuery().setTransactionId(mTransactionId).execute(client, timeout);
 
@@ -66,7 +66,7 @@ TransactionRecord TransactionResponse::getRecord(const Client& client) const
 
 //-----
 TransactionRecord TransactionResponse::getRecord(const Client& client,
-                                                 const std::chrono::duration<double>& timeout) const
+                                                 const std::chrono::system_clock::duration& timeout) const
 {
   return TransactionRecordQuery().setTransactionId(mTransactionId).execute(client, timeout);
 }

--- a/sdk/main/src/impl/BaseNetwork.cc
+++ b/sdk/main/src/impl/BaseNetwork.cc
@@ -160,7 +160,7 @@ NetworkType& BaseNetwork<NetworkType, KeyType, NodeType>::setMaxNodeAttempts(uns
 //-----
 template<typename NetworkType, typename KeyType, typename NodeType>
 NetworkType& BaseNetwork<NetworkType, KeyType, NodeType>::setMinNodeBackoff(
-  const std::chrono::duration<double>& backoff)
+  const std::chrono::system_clock::duration& backoff)
 {
   std::unique_lock lock(*mMutex);
   mMinNodeBackoff = backoff;
@@ -170,7 +170,7 @@ NetworkType& BaseNetwork<NetworkType, KeyType, NodeType>::setMinNodeBackoff(
 //-----
 template<typename NetworkType, typename KeyType, typename NodeType>
 NetworkType& BaseNetwork<NetworkType, KeyType, NodeType>::setMaxNodeBackoff(
-  const std::chrono::duration<double>& backoff)
+  const std::chrono::system_clock::duration& backoff)
 {
   std::unique_lock lock(*mMutex);
   mMaxNodeBackoff = backoff;
@@ -180,7 +180,7 @@ NetworkType& BaseNetwork<NetworkType, KeyType, NodeType>::setMaxNodeBackoff(
 //-----
 template<typename NetworkType, typename KeyType, typename NodeType>
 NetworkType& BaseNetwork<NetworkType, KeyType, NodeType>::setMinNodeReadmitTime(
-  const std::chrono::duration<double>& time)
+  const std::chrono::system_clock::duration& time)
 {
   std::unique_lock lock(*mMutex);
   mMinNodeReadmitTime = time;
@@ -190,7 +190,7 @@ NetworkType& BaseNetwork<NetworkType, KeyType, NodeType>::setMinNodeReadmitTime(
 //-----
 template<typename NetworkType, typename KeyType, typename NodeType>
 NetworkType& BaseNetwork<NetworkType, KeyType, NodeType>::setMaxNodeReadmitTime(
-  const std::chrono::duration<double>& time)
+  const std::chrono::system_clock::duration& time)
 {
   std::unique_lock lock(*mMutex);
   mMaxNodeReadmitTime = time;
@@ -199,7 +199,8 @@ NetworkType& BaseNetwork<NetworkType, KeyType, NodeType>::setMaxNodeReadmitTime(
 
 //-----
 template<typename NetworkType, typename KeyType, typename NodeType>
-NetworkType& BaseNetwork<NetworkType, KeyType, NodeType>::setCloseTimeout(const std::chrono::duration<double>& timeout)
+NetworkType& BaseNetwork<NetworkType, KeyType, NodeType>::setCloseTimeout(
+  const std::chrono::system_clock::duration& timeout)
 {
   std::unique_lock lock(*mMutex);
   mCloseTimeout = timeout;
@@ -281,8 +282,7 @@ void BaseNetwork<NetworkType, KeyType, NodeType>::readmitNodes()
   }
 
   // Determine the next earliest readmit time.
-  std::chrono::system_clock::time_point nextEarliestReadmitTime =
-    now + std::chrono::duration_cast<std::chrono::system_clock::duration>(mMaxNodeReadmitTime);
+  std::chrono::system_clock::time_point nextEarliestReadmitTime = now + mMaxNodeReadmitTime;
 
   for (const auto& node : mNodes)
   {

--- a/sdk/main/src/impl/BaseNode.cc
+++ b/sdk/main/src/impl/BaseNode.cc
@@ -44,8 +44,7 @@ void BaseNode<NodeType, KeyType>::increaseBackoff()
 {
   std::unique_lock lock(*mMutex);
   ++mBadGrpcStatusCount;
-  mReadmitTime =
-    std::chrono::system_clock::now() + std::chrono::duration_cast<std::chrono::system_clock::duration>(mCurrentBackoff);
+  mReadmitTime = std::chrono::system_clock::now() + mCurrentBackoff;
   mCurrentBackoff *= 2.0;
 
   // Make sure the current backoff doesn't go over the max backoff.
@@ -95,7 +94,7 @@ bool BaseNode<NodeType, KeyType>::channelFailedToConnect()
 
 //-----
 template<typename NodeType, typename KeyType>
-std::chrono::duration<double> BaseNode<NodeType, KeyType>::getRemainingTimeForBackoff() const
+std::chrono::system_clock::duration BaseNode<NodeType, KeyType>::getRemainingTimeForBackoff() const
 {
   std::unique_lock lock(*mMutex);
   return mReadmitTime - std::chrono::system_clock::now();
@@ -103,7 +102,7 @@ std::chrono::duration<double> BaseNode<NodeType, KeyType>::getRemainingTimeForBa
 
 //-----
 template<typename NodeType, typename KeyType>
-NodeType& BaseNode<NodeType, KeyType>::setMinNodeBackoff(const std::chrono::duration<double>& backoff)
+NodeType& BaseNode<NodeType, KeyType>::setMinNodeBackoff(const std::chrono::system_clock::duration& backoff)
 {
   std::unique_lock lock(*mMutex);
   if (mCurrentBackoff == mMinNodeBackoff)
@@ -117,7 +116,7 @@ NodeType& BaseNode<NodeType, KeyType>::setMinNodeBackoff(const std::chrono::dura
 
 //-----
 template<typename NodeType, typename KeyType>
-NodeType& BaseNode<NodeType, KeyType>::setMaxNodeBackoff(const std::chrono::duration<double>& backoff)
+NodeType& BaseNode<NodeType, KeyType>::setMaxNodeBackoff(const std::chrono::system_clock::duration& backoff)
 {
   std::unique_lock lock(*mMutex);
   mMaxNodeBackoff = backoff;

--- a/sdk/main/src/impl/DurationConverter.cc
+++ b/sdk/main/src/impl/DurationConverter.cc
@@ -30,7 +30,7 @@ std::chrono::seconds fromProtobuf(const proto::Duration& duration)
 }
 
 //-----
-proto::Duration* toProtobuf(const std::chrono::duration<double>& duration)
+proto::Duration* toProtobuf(const std::chrono::system_clock::duration& duration)
 {
   auto proto = std::make_unique<proto::Duration>();
   proto->set_seconds(std::chrono::duration_cast<std::chrono::seconds>(duration).count());

--- a/sdk/tests/integration/AccountCreateTransactionIntegrationTest.cc
+++ b/sdk/tests/integration/AccountCreateTransactionIntegrationTest.cc
@@ -56,7 +56,7 @@ TEST_F(AccountCreateTransactionIntegrationTest, ExecuteAccountCreateTransaction)
     std::dynamic_pointer_cast<ECDSAsecp256k1PublicKey>(testPrivateKey->getPublicKey());
   const EvmAddress testEvmAddress = testPublicKey->toEvmAddress();
   const Hbar testInitialBalance(1000LL, HbarUnit::TINYBAR());
-  const std::chrono::duration<double> testAutoRenewPeriod = std::chrono::seconds(2592000);
+  const std::chrono::system_clock::duration testAutoRenewPeriod = std::chrono::seconds(2592000);
   const std::string testMemo = "test account memo";
   const uint32_t testMaxAutomaticTokenAssociations = 4U;
 

--- a/sdk/tests/integration/AccountUpdateTransactionIntegrationTest.cc
+++ b/sdk/tests/integration/AccountUpdateTransactionIntegrationTest.cc
@@ -48,7 +48,7 @@ TEST_F(AccountUpdateTransactionIntegrationTest, ExecuteAccountUpdateTransaction)
   const std::shared_ptr<PrivateKey> initialPrivateKey = ED25519PrivateKey::generatePrivateKey();
   const std::shared_ptr<PrivateKey> newPrivateKey = ECDSAsecp256k1PrivateKey::generatePrivateKey();
   const bool newReceiverSignatureRequired = true;
-  const std::chrono::duration<double> newAutoRenewPeriod = std::chrono::seconds(8000000);
+  const std::chrono::system_clock::duration newAutoRenewPeriod = std::chrono::seconds(8000000);
   const std::chrono::system_clock::time_point newExpirationTime =
     std::chrono::system_clock::now() + std::chrono::seconds(3000000);
   const std::string newAccountMemo = "New Account Memo!";
@@ -203,7 +203,7 @@ TEST_F(AccountUpdateTransactionIntegrationTest, InvalidAutoRenewPeriod)
 {
   // Given
   const std::shared_ptr<PrivateKey> privateKey = ED25519PrivateKey::generatePrivateKey();
-  const std::chrono::duration<double> invalidAutoRenewPeriod = std::chrono::seconds(777600000);
+  const std::chrono::system_clock::duration invalidAutoRenewPeriod = std::chrono::seconds(777600000);
 
   AccountId accountId;
   ASSERT_NO_THROW(accountId = AccountCreateTransaction()

--- a/sdk/tests/integration/CMakeLists.txt
+++ b/sdk/tests/integration/CMakeLists.txt
@@ -20,6 +20,7 @@ add_executable(${TEST_PROJECT_NAME}
         ContractUpdateTransactionIntegrationTests.cc
         ClientIntegrationTest.cc
         ContractInfoQueryIntegrationTests.cc
+        ExecutableIntegrationTests.cc
         FileAppendTransactionIntegrationTests.cc
         FileContentsQueryIntegrationTest.cc
         FileCreateTransactionIntegrationTests.cc

--- a/sdk/tests/integration/ContractCreateTransactionIntegrationTests.cc
+++ b/sdk/tests/integration/ContractCreateTransactionIntegrationTests.cc
@@ -51,7 +51,7 @@ TEST_F(ContractCreateTransactionIntegrationTest, ExecuteContractCreateTransactio
   const std::unique_ptr<PrivateKey> operatorKey = ED25519PrivateKey::fromString(
     "302e020100300506032b65700422042091132178e72057a1d7528025956fe39b0b847f200ab59b2fdd367017f3087137");
   const std::string memo = "[e2e::ContractCreateTransaction]";
-  const std::chrono::duration<double> autoRenewPeriod = std::chrono::hours(2016);
+  const std::chrono::system_clock::duration autoRenewPeriod = std::chrono::hours(2016);
   FileId fileId;
   ASSERT_NO_THROW(fileId = FileCreateTransaction()
                              .setKeys({ operatorKey->getPublicKey() })
@@ -105,7 +105,7 @@ TEST_F(ContractCreateTransactionIntegrationTest, CreateContractWithNoAdminKey)
   const std::unique_ptr<PrivateKey> operatorKey = ED25519PrivateKey::fromString(
     "302e020100300506032b65700422042091132178e72057a1d7528025956fe39b0b847f200ab59b2fdd367017f3087137");
   const std::string memo = "[e2e::ContractCreateTransaction]";
-  const std::chrono::duration<double> autoRenewPeriod = std::chrono::hours(2016);
+  const std::chrono::system_clock::duration autoRenewPeriod = std::chrono::hours(2016);
   FileId fileId;
   ASSERT_NO_THROW(fileId = FileCreateTransaction()
                              .setKeys({ operatorKey->getPublicKey() })

--- a/sdk/tests/integration/ExecutableIntegrationTests.cc
+++ b/sdk/tests/integration/ExecutableIntegrationTests.cc
@@ -1,0 +1,252 @@
+/*-
+ *
+ * Hedera C++ SDK
+ *
+ * Copyright (C) 2020 - 2023 Hedera Hashgraph, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+#include "AccountAllowanceApproveTransaction.h"
+#include "AccountAllowanceDeleteTransaction.h"
+#include "AccountBalance.h"
+#include "AccountBalanceQuery.h"
+#include "AccountCreateTransaction.h"
+#include "AccountDeleteTransaction.h"
+#include "AccountInfo.h"
+#include "AccountInfoQuery.h"
+#include "AccountRecords.h"
+#include "AccountRecordsQuery.h"
+#include "AccountStakersQuery.h"
+#include "AccountUpdateTransaction.h"
+#include "BaseIntegrationTest.h"
+#include "ContractByteCodeQuery.h"
+#include "ContractCallQuery.h"
+#include "ContractCreateTransaction.h"
+#include "ContractDeleteTransaction.h"
+#include "ContractExecuteTransaction.h"
+#include "ContractFunctionResult.h"
+#include "ContractInfo.h"
+#include "ContractInfoQuery.h"
+#include "ContractUpdateTransaction.h"
+#include "EthereumTransaction.h"
+#include "FileAppendTransaction.h"
+#include "FileContentsQuery.h"
+#include "FileCreateTransaction.h"
+#include "FileDeleteTransaction.h"
+#include "FileInfo.h"
+#include "FileInfoQuery.h"
+#include "FileUpdateTransaction.h"
+#include "FreezeTransaction.h"
+#include "NetworkVersionInfo.h"
+#include "NetworkVersionInfoQuery.h"
+#include "PrngTransaction.h"
+#include "ScheduleCreateTransaction.h"
+#include "ScheduleDeleteTransaction.h"
+#include "ScheduleInfo.h"
+#include "ScheduleInfoQuery.h"
+#include "ScheduleSignTransaction.h"
+#include "SystemDeleteTransaction.h"
+#include "SystemUndeleteTransaction.h"
+#include "TokenAssociateTransaction.h"
+#include "TokenBurnTransaction.h"
+#include "TokenCreateTransaction.h"
+#include "TokenDeleteTransaction.h"
+#include "TokenDissociateTransaction.h"
+#include "TokenFeeScheduleUpdateTransaction.h"
+#include "TokenFreezeTransaction.h"
+#include "TokenGrantKycTransaction.h"
+#include "TokenInfo.h"
+#include "TokenInfoQuery.h"
+#include "TokenMintTransaction.h"
+#include "TokenNftInfo.h"
+#include "TokenNftInfoQuery.h"
+#include "TokenPauseTransaction.h"
+#include "TokenRevokeKycTransaction.h"
+#include "TokenUnfreezeTransaction.h"
+#include "TokenUnpauseTransaction.h"
+#include "TokenUpdateTransaction.h"
+#include "TokenWipeTransaction.h"
+#include "TopicCreateTransaction.h"
+#include "TopicDeleteTransaction.h"
+#include "TopicInfo.h"
+#include "TopicInfoQuery.h"
+#include "TopicMessageSubmitTransaction.h"
+#include "TopicUpdateTransaction.h"
+#include "TransactionReceipt.h"
+#include "TransactionReceiptQuery.h"
+#include "TransactionRecord.h"
+#include "TransactionRecordQuery.h"
+#include "TransactionResponse.h"
+#include "TransferTransaction.h"
+#include "exceptions/PrecheckStatusException.h"
+
+#include <chrono>
+#include <functional>
+#include <future>
+#include <stdexcept>
+#include <thread>
+
+using namespace Hedera;
+
+template<typename T>
+class ExecutableIntegrationTests : public BaseIntegrationTest
+{
+};
+
+using ExecutableTypes = ::testing::Types<std::tuple<AccountAllowanceApproveTransaction, TransactionResponse>,
+                                         std::tuple<AccountAllowanceDeleteTransaction, TransactionResponse>,
+                                         std::tuple<AccountBalanceQuery, AccountBalance>,
+                                         std::tuple<AccountCreateTransaction, TransactionResponse>,
+                                         std::tuple<AccountDeleteTransaction, TransactionResponse>,
+                                         std::tuple<AccountInfoQuery, AccountInfo>,
+                                         std::tuple<AccountRecordsQuery, AccountRecords>,
+                                         std::tuple<AccountStakersQuery, AccountStakers>,
+                                         std::tuple<AccountUpdateTransaction, TransactionResponse>,
+                                         std::tuple<ContractByteCodeQuery, ContractByteCode>,
+                                         std::tuple<ContractCallQuery, ContractFunctionResult>,
+                                         std::tuple<ContractCreateTransaction, TransactionResponse>,
+                                         std::tuple<ContractDeleteTransaction, TransactionResponse>,
+                                         std::tuple<ContractExecuteTransaction, TransactionResponse>,
+                                         std::tuple<ContractInfoQuery, ContractInfo>,
+                                         std::tuple<ContractUpdateTransaction, TransactionResponse>,
+                                         std::tuple<EthereumTransaction, TransactionResponse>,
+                                         // std::tuple<FileAppendTransaction, TransactionResponse>,
+                                         std::tuple<FileContentsQuery, FileContents>,
+                                         std::tuple<FileCreateTransaction, TransactionResponse>,
+                                         std::tuple<FileDeleteTransaction, TransactionResponse>,
+                                         std::tuple<FileInfoQuery, FileInfo>,
+                                         std::tuple<FileUpdateTransaction, TransactionResponse>,
+                                         std::tuple<FreezeTransaction, TransactionResponse>,
+                                         std::tuple<NetworkVersionInfoQuery, NetworkVersionInfo>,
+                                         std::tuple<PrngTransaction, TransactionResponse>,
+                                         std::tuple<ScheduleCreateTransaction, TransactionResponse>,
+                                         std::tuple<ScheduleDeleteTransaction, TransactionResponse>,
+                                         std::tuple<ScheduleInfoQuery, ScheduleInfo>,
+                                         std::tuple<ScheduleSignTransaction, TransactionResponse>,
+                                         std::tuple<SystemDeleteTransaction, TransactionResponse>,
+                                         std::tuple<SystemUndeleteTransaction, TransactionResponse>,
+                                         std::tuple<TokenAssociateTransaction, TransactionResponse>,
+                                         std::tuple<TokenBurnTransaction, TransactionResponse>,
+                                         std::tuple<TokenCreateTransaction, TransactionResponse>,
+                                         std::tuple<TokenDeleteTransaction, TransactionResponse>,
+                                         std::tuple<TokenDissociateTransaction, TransactionResponse>,
+                                         std::tuple<TokenFeeScheduleUpdateTransaction, TransactionResponse>,
+                                         std::tuple<TokenFreezeTransaction, TransactionResponse>,
+                                         std::tuple<TokenGrantKycTransaction, TransactionResponse>,
+                                         std::tuple<TokenInfoQuery, TokenInfo>,
+                                         std::tuple<TokenMintTransaction, TransactionResponse>,
+                                         std::tuple<TokenNftInfoQuery, TokenNftInfo>,
+                                         std::tuple<TokenPauseTransaction, TransactionResponse>,
+                                         std::tuple<TokenRevokeKycTransaction, TransactionResponse>,
+                                         std::tuple<TokenUnfreezeTransaction, TransactionResponse>,
+                                         std::tuple<TokenUnpauseTransaction, TransactionResponse>,
+                                         std::tuple<TokenUpdateTransaction, TransactionResponse>,
+                                         std::tuple<TokenWipeTransaction, TransactionResponse>,
+                                         std::tuple<TopicCreateTransaction, TransactionResponse>,
+                                         std::tuple<TopicDeleteTransaction, TransactionResponse>,
+                                         std::tuple<TopicInfoQuery, TopicInfo>,
+                                         // std::tuple<TopicMessageSubmitTransaction, TransactionResponse>,
+                                         std::tuple<TopicUpdateTransaction, TransactionResponse>,
+                                         std::tuple<TransactionReceiptQuery, TransactionReceipt>,
+                                         std::tuple<TransactionRecordQuery, TransactionRecord>,
+                                         std::tuple<TransferTransaction, TransactionResponse>>;
+TYPED_TEST_SUITE(ExecutableIntegrationTests, ExecutableTypes);
+
+//-----
+TYPED_TEST(ExecutableIntegrationTests, ExecuteAsync)
+{
+  // Given
+  using ExecutableType = typename std::tuple_element<0, TypeParam>::type;
+  using ResponseType = typename std::tuple_element<1, TypeParam>::type;
+
+  ExecutableType executable;
+  std::future<ResponseType> response;
+
+  // When
+  EXPECT_NO_THROW(response = executable.executeAsync(ExecutableIntegrationTests<ExecutableType>::getTestClient()));
+
+  // Then
+  try
+  {
+    response.get();
+  }
+  catch (const PrecheckStatusException&)
+  {
+    // PrecheckStatusExceptions are fine since the Executable is not being filled with any data.
+    EXPECT_TRUE(true);
+  }
+  catch (...)
+  {
+    // Other exceptions constitute a failure.
+    EXPECT_TRUE(false);
+  }
+
+  // No exception is fine.
+  EXPECT_TRUE(true);
+}
+
+//-----
+TYPED_TEST(ExecutableIntegrationTests, ExecuteAsyncWithSingleCallback)
+{
+  // Given
+  using ExecutableType = typename std::tuple_element<0, TypeParam>::type;
+  using ResponseType = typename std::tuple_element<1, TypeParam>::type;
+
+  bool completed = false;
+  const std::function<void(const ResponseType&, const std::exception&)> callback =
+    [&completed](const ResponseType&, const std::exception&) { completed = true; };
+
+  ExecutableType executable;
+
+  // When
+  EXPECT_NO_THROW(executable.executeAsync(ExecutableIntegrationTests<ExecutableType>::getTestClient(), callback));
+
+  // Then
+  const std::chrono::system_clock::time_point timeout = std::chrono::system_clock::now() + std::chrono::seconds(10);
+  while (!completed && std::chrono::system_clock::now() < timeout)
+  {
+    std::this_thread::sleep_for(std::chrono::milliseconds(100));
+  }
+
+  EXPECT_TRUE(completed);
+}
+
+//-----
+TYPED_TEST(ExecutableIntegrationTests, ExecuteAsyncWithCallbacks)
+{
+  // Given
+  using ExecutableType = typename std::tuple_element<0, TypeParam>::type;
+  using ResponseType = typename std::tuple_element<1, TypeParam>::type;
+
+  bool completed = false;
+  const std::function<void(const ResponseType&)> responseCallback = [&completed](const ResponseType&)
+  { completed = true; };
+  const std::function<void(const std::exception&)> exceptionCallback = [&completed](const std::exception&)
+  { completed = true; };
+
+  ExecutableType executable;
+
+  // When
+  EXPECT_NO_THROW(executable.executeAsync(
+    ExecutableIntegrationTests<ExecutableType>::getTestClient(), responseCallback, exceptionCallback));
+
+  // Then
+  const std::chrono::system_clock::time_point timeout = std::chrono::system_clock::now() + std::chrono::seconds(10);
+  while (!completed && std::chrono::system_clock::now() < timeout)
+  {
+    std::this_thread::sleep_for(std::chrono::milliseconds(100));
+  }
+
+  EXPECT_TRUE(completed);
+}

--- a/sdk/tests/integration/ExecutableIntegrationTests.cc
+++ b/sdk/tests/integration/ExecutableIntegrationTests.cc
@@ -174,7 +174,7 @@ TYPED_TEST(ExecutableIntegrationTests, ExecuteAsync)
   std::future<ResponseType> response;
 
   // When
-  EXPECT_NO_THROW(response = executable.executeAsync(ExecutableIntegrationTests<ExecutableType>::getTestClient()));
+  EXPECT_NO_THROW(response = executable.executeAsync(BaseIntegrationTest::getTestClient()));
 
   // Then
   try
@@ -210,7 +210,7 @@ TYPED_TEST(ExecutableIntegrationTests, ExecuteAsyncWithSingleCallback)
   ExecutableType executable;
 
   // When
-  EXPECT_NO_THROW(executable.executeAsync(ExecutableIntegrationTests<ExecutableType>::getTestClient(), callback));
+  EXPECT_NO_THROW(executable.executeAsync(BaseIntegrationTest::getTestClient(), callback));
 
   // Then
   const std::chrono::system_clock::time_point timeout = std::chrono::system_clock::now() + std::chrono::seconds(10);
@@ -238,8 +238,7 @@ TYPED_TEST(ExecutableIntegrationTests, ExecuteAsyncWithCallbacks)
   ExecutableType executable;
 
   // When
-  EXPECT_NO_THROW(executable.executeAsync(
-    ExecutableIntegrationTests<ExecutableType>::getTestClient(), responseCallback, exceptionCallback));
+  EXPECT_NO_THROW(executable.executeAsync(BaseIntegrationTest::getTestClient(), responseCallback, exceptionCallback));
 
   // Then
   const std::chrono::system_clock::time_point timeout = std::chrono::system_clock::now() + std::chrono::seconds(10);

--- a/sdk/tests/integration/TopicCreateTransactionIntegrationTests.cc
+++ b/sdk/tests/integration/TopicCreateTransactionIntegrationTests.cc
@@ -44,7 +44,7 @@ TEST_F(TopicCreateTransactionIntegrationTest, ExecuteTopicCreateTransaction)
 {
   // Given
   const std::string memo = "topic create test memo";
-  const std::chrono::duration<double> autoRenewPeriod = DEFAULT_AUTO_RENEW_PERIOD + std::chrono::hours(10);
+  const std::chrono::system_clock::duration autoRenewPeriod = DEFAULT_AUTO_RENEW_PERIOD + std::chrono::hours(10);
 
   std::shared_ptr<PrivateKey> operatorKey;
   ASSERT_NO_THROW(

--- a/sdk/tests/integration/TopicInfoQueryIntegrationTests.cc
+++ b/sdk/tests/integration/TopicInfoQueryIntegrationTests.cc
@@ -43,7 +43,7 @@ TEST_F(TopicInfoQueryIntegrationTest, ExecuteTopicInfoQuery)
 {
   // Given
   const std::string memo = "test memo";
-  const std::chrono::duration<double> autoRenewPeriod = std::chrono::hours(2200);
+  const std::chrono::system_clock::duration autoRenewPeriod = std::chrono::hours(2200);
 
   std::shared_ptr<PrivateKey> operatorKey;
   ASSERT_NO_THROW(

--- a/sdk/tests/integration/TopicUpdateTransactionIntegrationTests.cc
+++ b/sdk/tests/integration/TopicUpdateTransactionIntegrationTests.cc
@@ -44,7 +44,7 @@ TEST_F(TopicUpdateTransactionIntegrationTest, ExecuteTopicUpdateTransaction)
 {
   // Given
   const std::string newMemo = "new topic create test memo";
-  const std::chrono::duration<double> newAutoRenewPeriod = DEFAULT_AUTO_RENEW_PERIOD + std::chrono::hours(10);
+  const std::chrono::system_clock::duration newAutoRenewPeriod = DEFAULT_AUTO_RENEW_PERIOD + std::chrono::hours(10);
 
   std::shared_ptr<PrivateKey> operatorKey;
   std::shared_ptr<PrivateKey> newKey;

--- a/sdk/tests/integration/TransactionIntegrationTest.cc
+++ b/sdk/tests/integration/TransactionIntegrationTest.cc
@@ -44,7 +44,10 @@ protected:
   [[nodiscard]] inline const std::shared_ptr<PublicKey>& getTestPublicKey() const { return mPublicKey; }
   [[nodiscard]] inline const Hbar& getTestInitialBalance() const { return mInitialBalance; }
   [[nodiscard]] inline bool getTestReceiverSignatureRequired() const { return mReceiverSignatureRequired; }
-  [[nodiscard]] inline const std::chrono::duration<double>& getTestAutoRenewPeriod() const { return mAutoRenewPeriod; }
+  [[nodiscard]] inline const std::chrono::system_clock::duration& getTestAutoRenewPeriod() const
+  {
+    return mAutoRenewPeriod;
+  }
   [[nodiscard]] inline const std::string& getTestAccountMemo() const { return mAccountMemo; }
   [[nodiscard]] inline uint32_t getTestMaximumTokenAssociations() const { return mMaxTokenAssociations; }
   [[nodiscard]] inline bool getTestDeclineStakingReward() const { return mDeclineStakingReward; }
@@ -54,7 +57,7 @@ private:
   const std::shared_ptr<PublicKey> mPublicKey = ED25519PrivateKey::generatePrivateKey()->getPublicKey();
   const Hbar mInitialBalance = Hbar(1000ULL, HbarUnit::TINYBAR());
   const bool mReceiverSignatureRequired = true;
-  const std::chrono::duration<double> mAutoRenewPeriod = std::chrono::hours(3);
+  const std::chrono::system_clock::duration mAutoRenewPeriod = std::chrono::hours(3);
   const std::string mAccountMemo = "Test Account Memo";
   const uint32_t mMaxTokenAssociations = 3U;
 

--- a/sdk/tests/unit/AccountCreateTransactionTest.cc
+++ b/sdk/tests/unit/AccountCreateTransactionTest.cc
@@ -38,7 +38,10 @@ protected:
   [[nodiscard]] inline const std::shared_ptr<PublicKey>& getTestPublicKey() const { return mPublicKey; }
   [[nodiscard]] inline const Hbar& getTestInitialBalance() const { return mInitialBalance; }
   [[nodiscard]] inline bool getTestReceiverSignatureRequired() const { return mReceiverSignatureRequired; }
-  [[nodiscard]] inline const std::chrono::duration<double>& getTestAutoRenewPeriod() const { return mAutoRenewPeriod; }
+  [[nodiscard]] inline const std::chrono::system_clock::duration& getTestAutoRenewPeriod() const
+  {
+    return mAutoRenewPeriod;
+  }
   [[nodiscard]] inline const std::string& getTestAccountMemo() const { return mAccountMemo; }
   [[nodiscard]] inline uint32_t getTestMaximumTokenAssociations() const { return mMaxTokenAssociations; }
   [[nodiscard]] inline const AccountId& getTestAccountId() const { return mAccountId; }
@@ -50,7 +53,7 @@ private:
   const std::shared_ptr<PublicKey> mPublicKey = ED25519PrivateKey::generatePrivateKey()->getPublicKey();
   const Hbar mInitialBalance = Hbar(1LL);
   const bool mReceiverSignatureRequired = true;
-  const std::chrono::duration<double> mAutoRenewPeriod = std::chrono::hours(2);
+  const std::chrono::system_clock::duration mAutoRenewPeriod = std::chrono::hours(2);
   const std::string mAccountMemo = "test account memo";
   const uint32_t mMaxTokenAssociations = 3U;
   const AccountId mAccountId = AccountId(4ULL);

--- a/sdk/tests/unit/AccountInfoTest.cc
+++ b/sdk/tests/unit/AccountInfoTest.cc
@@ -48,7 +48,7 @@ protected:
   {
     return mTestExpirationTime;
   }
-  [[nodiscard]] inline const std::chrono::duration<double>& getTestAutoRenewPeriod() const
+  [[nodiscard]] inline const std::chrono::system_clock::duration& getTestAutoRenewPeriod() const
   {
     return mTestAutoRenewPeriod;
   }
@@ -76,7 +76,7 @@ private:
   const Hbar mTestBalance = Hbar(3LL);
   const bool mTestReceiverSignatureRequired = true;
   const std::chrono::system_clock::time_point mTestExpirationTime = std::chrono::system_clock::now();
-  const std::chrono::duration<double> mTestAutoRenewPeriod = std::chrono::hours(4);
+  const std::chrono::system_clock::duration mTestAutoRenewPeriod = std::chrono::hours(4);
   const std::string mTestMemo = "test memo";
   const uint64_t mTestOwnedNfts = 5ULL;
   const uint32_t mMaxAutomaticTokenAssociations = 6U;

--- a/sdk/tests/unit/AccountUpdateTransactionTest.cc
+++ b/sdk/tests/unit/AccountUpdateTransactionTest.cc
@@ -37,7 +37,10 @@ protected:
   [[nodiscard]] inline const AccountId& getTestAccountId() const { return mAccountId; }
   [[nodiscard]] inline const std::shared_ptr<PublicKey>& getTestPublicKey() const { return mPublicKey; }
   [[nodiscard]] inline bool getTestReceiverSignatureRequired() const { return mReceiverSignatureRequired; }
-  [[nodiscard]] inline const std::chrono::duration<double>& getTestAutoRenewPeriod() const { return mAutoRenewPeriod; }
+  [[nodiscard]] inline const std::chrono::system_clock::duration& getTestAutoRenewPeriod() const
+  {
+    return mAutoRenewPeriod;
+  }
   [[nodiscard]] inline const std::chrono::system_clock::time_point& getTestExpirationTime() const
   {
     return mExpirationTime;
@@ -52,7 +55,7 @@ private:
   const AccountId mAccountId = AccountId(1ULL);
   const std::shared_ptr<PublicKey> mPublicKey = ECDSAsecp256k1PrivateKey::generatePrivateKey()->getPublicKey();
   const bool mReceiverSignatureRequired = true;
-  const std::chrono::duration<double> mAutoRenewPeriod = std::chrono::hours(2);
+  const std::chrono::system_clock::duration mAutoRenewPeriod = std::chrono::hours(2);
   const std::chrono::system_clock::time_point mExpirationTime = std::chrono::system_clock::now();
   const std::string mAccountMemo = "test account memo";
   const uint32_t mMaxTokenAssociations = 3U;

--- a/sdk/tests/unit/AddressBookQueryUnitTests.cc
+++ b/sdk/tests/unit/AddressBookQueryUnitTests.cc
@@ -29,13 +29,13 @@ protected:
   [[nodiscard]] inline const FileId& getTestFileId() const { return mTestFileId; }
   [[nodiscard]] inline unsigned int getTestLimit() const { return mTestLimit; }
   [[nodiscard]] inline unsigned int getTestMaxAttempts() const { return mTestMaxAttempts; }
-  [[nodiscard]] inline const std::chrono::duration<double>& getTestMaxBackoff() const { return mTestMaxBackoff; }
+  [[nodiscard]] inline const std::chrono::system_clock::duration& getTestMaxBackoff() const { return mTestMaxBackoff; }
 
 private:
   const FileId mTestFileId = FileId(1ULL, 2ULL, 3ULL);
   const unsigned int mTestLimit = 4ULL;
   const unsigned int mTestMaxAttempts = 5ULL;
-  const std::chrono::duration<double> mTestMaxBackoff = std::chrono::seconds(6ULL);
+  const std::chrono::system_clock::duration mTestMaxBackoff = std::chrono::seconds(6ULL);
 };
 
 //-----

--- a/sdk/tests/unit/ClientTest.cc
+++ b/sdk/tests/unit/ClientTest.cc
@@ -32,7 +32,7 @@ class ClientTest : public ::testing::Test
 protected:
   [[nodiscard]] inline const AccountId& getTestAccountId() const { return mAccountId; }
   [[nodiscard]] inline const std::shared_ptr<ED25519PrivateKey>& getTestPrivateKey() const { return mPrivateKey; }
-  [[nodiscard]] inline const std::chrono::duration<double>& getTestNetworkUpdatePeriod() const
+  [[nodiscard]] inline const std::chrono::system_clock::duration& getTestNetworkUpdatePeriod() const
   {
     return mTestNetworkUpdatePeriod;
   }
@@ -45,7 +45,7 @@ protected:
 private:
   const AccountId mAccountId = AccountId(10ULL);
   const std::shared_ptr<ED25519PrivateKey> mPrivateKey = ED25519PrivateKey::generatePrivateKey();
-  const std::chrono::duration<double> mTestNetworkUpdatePeriod = std::chrono::seconds(2);
+  const std::chrono::system_clock::duration mTestNetworkUpdatePeriod = std::chrono::seconds(2);
 
   const std::chrono::milliseconds mNegativeBackoffTime = std::chrono::milliseconds(-1);
   const std::chrono::milliseconds mZeroBackoffTime = std::chrono::milliseconds(0);

--- a/sdk/tests/unit/ContractCreateFlowTest.cc
+++ b/sdk/tests/unit/ContractCreateFlowTest.cc
@@ -43,7 +43,7 @@ protected:
   [[nodiscard]] inline const std::shared_ptr<PublicKey>& getTestAdminKey() const { return mTestAdminKey; }
   [[nodiscard]] inline const uint64_t& getTestGas() const { return mTestGas; }
   [[nodiscard]] inline const Hbar& getTestInitialBalance() const { return mTestInitialBalance; }
-  [[nodiscard]] inline const std::chrono::duration<double>& getTestAutoRenewPeriod() const
+  [[nodiscard]] inline const std::chrono::system_clock::duration& getTestAutoRenewPeriod() const
   {
     return mTestAutoRenewPeriod;
   }
@@ -67,7 +67,7 @@ private:
     "302A300506032B6570032100BCAF3153262A767B281CC8C888DB3E097C83D690AEF01B8C1BE64D3DE11AACC3");
   const uint64_t mTestGas = 5ULL;
   const Hbar mTestInitialBalance = Hbar(6LL);
-  const std::chrono::duration<double> mTestAutoRenewPeriod = std::chrono::hours(7);
+  const std::chrono::system_clock::duration mTestAutoRenewPeriod = std::chrono::hours(7);
   const std::vector<std::byte> mTestConstructorParameters = { std::byte(0x08), std::byte(0x09), std::byte(0x10) };
   const std::string mTestMemo = "test smart contract memo";
   const uint32_t mTestMaxTokenAssociations = 11U;

--- a/sdk/tests/unit/ContractCreateTransactionTest.cc
+++ b/sdk/tests/unit/ContractCreateTransactionTest.cc
@@ -42,7 +42,7 @@ protected:
   [[nodiscard]] inline const std::shared_ptr<PublicKey>& getTestAdminKey() const { return mTestAdminKey; }
   [[nodiscard]] inline const uint64_t& getTestGas() const { return mTestGas; }
   [[nodiscard]] inline const Hbar& getTestInitialBalance() const { return mTestInitialBalance; }
-  [[nodiscard]] inline const std::chrono::duration<double>& getTestAutoRenewPeriod() const
+  [[nodiscard]] inline const std::chrono::system_clock::duration& getTestAutoRenewPeriod() const
   {
     return mTestAutoRenewPeriod;
   }
@@ -64,7 +64,7 @@ private:
     "302A300506032B6570032100BCAF3153262A767B281CC8C888DB3E097C83D690AEF01B8C1BE64D3DE11AACC3");
   const uint64_t mTestGas = 5ULL;
   const Hbar mTestInitialBalance = Hbar(6LL);
-  const std::chrono::duration<double> mTestAutoRenewPeriod = std::chrono::hours(7);
+  const std::chrono::system_clock::duration mTestAutoRenewPeriod = std::chrono::hours(7);
   const std::vector<std::byte> mTestConstructorParameters = { std::byte(0x08), std::byte(0x09), std::byte(0x10) };
   const std::string mTestMemo = "test smart contract memo";
   const uint32_t mTestMaxTokenAssociations = 11U;

--- a/sdk/tests/unit/ContractInfoTest.cc
+++ b/sdk/tests/unit/ContractInfoTest.cc
@@ -38,7 +38,7 @@ protected:
   {
     return mTestExpirationTime;
   }
-  [[nodiscard]] inline const std::chrono::duration<double>& getTestAutoRenewPeriod() const
+  [[nodiscard]] inline const std::chrono::system_clock::duration& getTestAutoRenewPeriod() const
   {
     return mTestAutoRenewPeriod;
   }
@@ -65,7 +65,7 @@ private:
   const std::shared_ptr<PublicKey> mTestAdminKey = PublicKey::fromStringDer(
     "302A300506032B6570032100D75A980182B10AB7D54BFED3C964073A0EE172f3DAA62325AF021A68F707511A");
   const std::chrono::system_clock::time_point mTestExpirationTime = std::chrono::system_clock::now();
-  const std::chrono::duration<double> mTestAutoRenewPeriod = std::chrono::hours(3);
+  const std::chrono::system_clock::duration mTestAutoRenewPeriod = std::chrono::hours(3);
   const uint64_t mTestStorage = 40000ULL;
   const std::string mTestMemo = "test memo";
   const Hbar mTestBalance = Hbar(5LL);

--- a/sdk/tests/unit/ContractUpdateTransactionTest.cc
+++ b/sdk/tests/unit/ContractUpdateTransactionTest.cc
@@ -41,7 +41,7 @@ protected:
     return mTestExpirationTime;
   }
   [[nodiscard]] inline const std::shared_ptr<PublicKey>& getTestAdminKey() const { return mTestAdminKey; }
-  [[nodiscard]] inline const std::chrono::duration<double>& getTestAutoRenewPeriod() const
+  [[nodiscard]] inline const std::chrono::system_clock::duration& getTestAutoRenewPeriod() const
   {
     return mTestAutoRenewPeriod;
   }
@@ -59,7 +59,7 @@ private:
   const ContractId mTestContractId = ContractId(1ULL);
   const std::chrono::system_clock::time_point mTestExpirationTime = std::chrono::system_clock::now();
   const std::shared_ptr<PublicKey> mTestAdminKey = ECDSAsecp256k1PrivateKey::generatePrivateKey()->getPublicKey();
-  const std::chrono::duration<double> mTestAutoRenewPeriod = std::chrono::hours(2);
+  const std::chrono::system_clock::duration mTestAutoRenewPeriod = std::chrono::hours(2);
   const std::string mTestContractMemo = "test contract memo";
   const uint32_t mTestMaximumAutomaticTokenAssociations = 3U;
   const AccountId mTestAutoRenewAccountId = AccountId(4ULL);

--- a/sdk/tests/unit/TokenCreateTransactionTest.cc
+++ b/sdk/tests/unit/TokenCreateTransactionTest.cc
@@ -60,7 +60,7 @@ protected:
     return mTestExpirationTime;
   }
   [[nodiscard]] inline const AccountId& getTestAutoRenewAccountId() const { return mTestAutoRenewAccountId; }
-  [[nodiscard]] inline const std::chrono::duration<double>& getTestAutoRenewPeriod() const
+  [[nodiscard]] inline const std::chrono::system_clock::duration& getTestAutoRenewPeriod() const
   {
     return mTestAutoRenewPeriod;
   }
@@ -89,7 +89,7 @@ private:
   const bool mTestFreezeDefault = true;
   const std::chrono::system_clock::time_point mTestExpirationTime = std::chrono::system_clock::now();
   const AccountId mTestAutoRenewAccountId = AccountId(6ULL, 7ULL, 8ULL);
-  const std::chrono::duration<double> mTestAutoRenewPeriod = std::chrono::hours(9);
+  const std::chrono::system_clock::duration mTestAutoRenewPeriod = std::chrono::hours(9);
   const std::string mTestTokenMemo = "test memo";
   const TokenType mTestTokenType = TokenType::NON_FUNGIBLE_UNIQUE;
   const TokenSupplyType mTestTokenSupplyType = TokenSupplyType::FINITE;

--- a/sdk/tests/unit/TokenInfoUnitTests.cc
+++ b/sdk/tests/unit/TokenInfoUnitTests.cc
@@ -56,7 +56,7 @@ protected:
     return mTestExpirationTime;
   }
   [[nodiscard]] inline const AccountId& getTestAutoRenewAccountId() const { return mTestAutoRenewAccountId; }
-  [[nodiscard]] inline const std::chrono::duration<double>& getTestAutoRenewPeriod() const
+  [[nodiscard]] inline const std::chrono::system_clock::duration& getTestAutoRenewPeriod() const
   {
     return mTestAutoRenewPeriod;
   }
@@ -90,7 +90,7 @@ private:
   const bool mTestIsDeleted = true;
   const std::chrono::system_clock::time_point mTestExpirationTime = std::chrono::system_clock::now();
   const AccountId mTestAutoRenewAccountId = AccountId(9ULL, 10ULL, 11ULL);
-  const std::chrono::duration<double> mTestAutoRenewPeriod = std::chrono::hours(12);
+  const std::chrono::system_clock::duration mTestAutoRenewPeriod = std::chrono::hours(12);
   const std::string mTestTokenMemo = "test memo";
   const TokenType mTestTokenType = TokenType::NON_FUNGIBLE_UNIQUE;
   const TokenSupplyType mTestTokenSupplyType = TokenSupplyType::FINITE;

--- a/sdk/tests/unit/TokenUpdateTransactionUnitTests.cc
+++ b/sdk/tests/unit/TokenUpdateTransactionUnitTests.cc
@@ -52,7 +52,7 @@ protected:
   [[nodiscard]] inline const std::shared_ptr<PublicKey>& getTestWipeKey() const { return mTestWipeKey; }
   [[nodiscard]] inline const std::shared_ptr<PublicKey>& getTestSupplyKey() const { return mTestSupplyKey; }
   [[nodiscard]] inline const AccountId& getTestAutoRenewAccountId() const { return mTestAutoRenewAccountId; }
-  [[nodiscard]] inline const std::chrono::duration<double>& getTestAutoRenewPeriod() const
+  [[nodiscard]] inline const std::chrono::system_clock::duration& getTestAutoRenewPeriod() const
   {
     return mTestAutoRenewPeriod;
   }
@@ -75,7 +75,7 @@ private:
   const std::shared_ptr<PublicKey> mTestWipeKey = ECDSAsecp256k1PrivateKey::generatePrivateKey()->getPublicKey();
   const std::shared_ptr<PublicKey> mTestSupplyKey = ECDSAsecp256k1PrivateKey::generatePrivateKey()->getPublicKey();
   const AccountId mTestAutoRenewAccountId = AccountId(7ULL, 8ULL, 9ULL);
-  const std::chrono::duration<double> mTestAutoRenewPeriod = std::chrono::hours(10);
+  const std::chrono::system_clock::duration mTestAutoRenewPeriod = std::chrono::hours(10);
   const std::chrono::system_clock::time_point mTestExpirationTime = std::chrono::system_clock::now();
   const std::string mTestTokenMemo = "test memo";
   const std::shared_ptr<PublicKey> mTestFeeScheduleKey = ECDSAsecp256k1PrivateKey::generatePrivateKey()->getPublicKey();

--- a/sdk/tests/unit/TopicCreateTransactionUnitTests.cc
+++ b/sdk/tests/unit/TopicCreateTransactionUnitTests.cc
@@ -36,7 +36,7 @@ protected:
   [[nodiscard]] inline const std::string& getTestTopicMemo() const { return mTestTopicMemo; }
   [[nodiscard]] inline const std::shared_ptr<ED25519PrivateKey>& getTestAdminKey() const { return mTestAdminKey; }
   [[nodiscard]] inline const std::shared_ptr<ED25519PrivateKey>& getTestSubmitKey() const { return mTestSubmitKey; }
-  [[nodiscard]] inline const std::chrono::duration<double>& getTestAutoRenewPeriod() const
+  [[nodiscard]] inline const std::chrono::system_clock::duration& getTestAutoRenewPeriod() const
   {
     return mTestAutoRenewPeriod;
   }
@@ -46,7 +46,7 @@ private:
   const std::string mTestTopicMemo = "test topic memo";
   const std::shared_ptr<ED25519PrivateKey> mTestAdminKey = ED25519PrivateKey::generatePrivateKey();
   const std::shared_ptr<ED25519PrivateKey> mTestSubmitKey = ED25519PrivateKey::generatePrivateKey();
-  const std::chrono::duration<double> mTestAutoRenewPeriod = std::chrono::hours(1);
+  const std::chrono::system_clock::duration mTestAutoRenewPeriod = std::chrono::hours(1);
   const AccountId mTestAutoRenewAccountId = AccountId(2ULL, 3ULL, 4ULL);
 };
 

--- a/sdk/tests/unit/TopicInfoUnitTests.cc
+++ b/sdk/tests/unit/TopicInfoUnitTests.cc
@@ -42,7 +42,7 @@ protected:
   }
   [[nodiscard]] inline const std::shared_ptr<PublicKey>& getTestAdminKey() const { return mTestAdminKey; }
   [[nodiscard]] inline const std::shared_ptr<PublicKey>& getTestSubmitKey() const { return mTestSubmitKey; }
-  [[nodiscard]] inline const std::chrono::duration<double>& getTestAutoRenewPeriod() const
+  [[nodiscard]] inline const std::chrono::system_clock::duration& getTestAutoRenewPeriod() const
   {
     return mTestAutoRenewPeriod;
   }
@@ -57,7 +57,7 @@ private:
   const std::chrono::system_clock::time_point mTestExpirationTime = std::chrono::system_clock::now();
   const std::shared_ptr<PublicKey> mTestAdminKey = ECDSAsecp256k1PrivateKey::generatePrivateKey()->getPublicKey();
   const std::shared_ptr<PublicKey> mTestSubmitKey = ECDSAsecp256k1PrivateKey::generatePrivateKey()->getPublicKey();
-  const std::chrono::duration<double> mTestAutoRenewPeriod = std::chrono::hours(8);
+  const std::chrono::system_clock::duration mTestAutoRenewPeriod = std::chrono::hours(8);
   const AccountId mTestAutoRenewAccountId = AccountId(9ULL, 10ULL, 11ULL);
   const LedgerId mTestLedgerId = LedgerId({ std::byte(0x0C), std::byte(0x0D) });
 };

--- a/sdk/tests/unit/TopicMessageQueryUnitTests.cc
+++ b/sdk/tests/unit/TopicMessageQueryUnitTests.cc
@@ -35,7 +35,7 @@ protected:
   [[nodiscard]] inline const std::chrono::system_clock::time_point& getTestEndTime() const { return mTestEndTime; }
   [[nodiscard]] inline uint64_t getTestLimit() const { return mTestLimit; }
   [[nodiscard]] inline uint32_t getTestMaxAttempts() const { return mTestMaxAttempts; }
-  [[nodiscard]] inline const std::chrono::duration<double>& getTestMaxBackoff() const { return mTestMaxBackoff; }
+  [[nodiscard]] inline const std::chrono::system_clock::duration& getTestMaxBackoff() const { return mTestMaxBackoff; }
 
 private:
   const TopicId mTestTopicId = TopicId(1ULL, 2ULL, 3ULL);
@@ -43,7 +43,7 @@ private:
   const std::chrono::system_clock::time_point mTestEndTime = mTestStartTime + std::chrono::seconds(4);
   const uint64_t mTestLimit = 5ULL;
   const uint32_t mTestMaxAttempts = 6ULL;
-  const std::chrono::duration<double> mTestMaxBackoff = std::chrono::seconds(7);
+  const std::chrono::system_clock::duration mTestMaxBackoff = std::chrono::seconds(7);
 };
 
 //-----

--- a/sdk/tests/unit/TopicUpdateTransactionUnitTests.cc
+++ b/sdk/tests/unit/TopicUpdateTransactionUnitTests.cc
@@ -42,7 +42,7 @@ protected:
   }
   [[nodiscard]] inline const std::shared_ptr<ED25519PrivateKey>& getTestAdminKey() const { return mTestAdminKey; }
   [[nodiscard]] inline const std::shared_ptr<ED25519PrivateKey>& getTestSubmitKey() const { return mTestSubmitKey; }
-  [[nodiscard]] inline const std::chrono::duration<double>& getTestAutoRenewPeriod() const
+  [[nodiscard]] inline const std::chrono::system_clock::duration& getTestAutoRenewPeriod() const
   {
     return mTestAutoRenewPeriod;
   }
@@ -54,7 +54,7 @@ private:
   const std::chrono::system_clock::time_point mTestExpirationTime = std::chrono::system_clock::now();
   const std::shared_ptr<ED25519PrivateKey> mTestAdminKey = ED25519PrivateKey::generatePrivateKey();
   const std::shared_ptr<ED25519PrivateKey> mTestSubmitKey = ED25519PrivateKey::generatePrivateKey();
-  const std::chrono::duration<double> mTestAutoRenewPeriod = std::chrono::hours(4);
+  const std::chrono::system_clock::duration mTestAutoRenewPeriod = std::chrono::hours(4);
   const AccountId mTestAutoRenewAccountId = AccountId(5ULL, 6ULL, 7ULL);
 };
 


### PR DESCRIPTION
**Description**:
This PR fills out the remaining APIs of the `Executable` base class, primarily the `executeAsync` calls. It also changes all `std::chrono::duration<double>` instances over to `std::chrono::system_clock::duration`, which still provides the desired generality and causes less need for `duration_cast` calls. 

**Related issue(s)**:

Fixes #566 

**Notes for reviewer**:
This adds a good amount of integration tests that may slow down builds on GitHub by a couple of minutes.

**Checklist**

- [x] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
