### PR TITLE
Fix Windows build

### DIFF
--- a/sdk/main/src/AccountId.cc
+++ b/sdk/main/src/AccountId.cc
@@ -17,6 +17,8 @@
  * limitations under the License.
  *
  */
+#include <proto/basic_types.pb.h>
+
 #include "AccountId.h"
 #include "Client.h"
 #include "LedgerId.h"
@@ -32,7 +34,6 @@
 
 #include <limits>
 #include <nlohmann/json.hpp>
-#include <proto/basic_types.pb.h>
 #include <stdexcept>
 
 using json = nlohmann::json;

--- a/sdk/tests/integration/HttpClientIntegrationTests.cc
+++ b/sdk/tests/integration/HttpClientIntegrationTests.cc
@@ -34,30 +34,30 @@ using namespace Hedera;
 class HttpClientIntegrationTest : public BaseIntegrationTest
 {
 protected:
-  [[nodiscard]] inline const std::string_view& getURL() const { return mUrl; }
-  [[nodiscard]] inline const std::string_view& getJsonMirrorNetworkTag() const { return mJsonMirrorNetworkTag; }
-  [[nodiscard]] inline const std::string_view& getAccountIdStr() const { return mAccountIdStr; }
+  [[nodiscard]] inline const std::string& getURL() const { return mUrl; }
+  [[nodiscard]] inline const std::string& getJsonMirrorNetworkTag() const { return mJsonMirrorNetworkTag; }
+  [[nodiscard]] inline const std::string& getAccountIdStr() const { return mAccountIdStr; }
 
 private:
-  const std::string_view mUrl = "http://127.0.0.1:5551/api/v1/accounts/";
-  const std::string_view mJsonMirrorNetworkTag = "mirrorNetwork";
-  const std::string_view mAccountIdStr = "0.0.3";
+  const std::string mUrl = "http://127.0.0.1:5551/api/v1/accounts/";
+  const std::string mJsonMirrorNetworkTag = "mirrorNetwork";
+  const std::string mAccountIdStr = "0.0.3";
 };
 
 //-----
 TEST_F(HttpClientIntegrationTest, GETAccountFromLocalMirrorNode)
 {
   // Given
-  const std::string_view mirrorNetworkTag = getJsonMirrorNetworkTag();
-  const std::string_view accountIdStr = getAccountIdStr();
-  std::string mUrl (getURL());
+  const std::string& mirrorNetworkTag = getJsonMirrorNetworkTag();
+  const std::string& accountIdStr = getAccountIdStr();
+  std::string mUrl(getURL());
   mUrl += accountIdStr;
 
-  // When 
+  // When
   internal::HttpClient httpClient;
   std::string response;
-  ASSERT_NO_THROW(response = httpClient.invokeREST(mUrl,"GET"));
-  
+  ASSERT_NO_THROW(response = httpClient.invokeREST(mUrl, "GET"));
+
   // Then
   json responseData = json::parse(response);
 


### PR DESCRIPTION
**Description**:
This PR fixes an issue with the Windows build.

**Related issue(s)**:

Fixes #572 

**Notes for reviewer**:
No functional difference, Windows builds for some reason require `#include`s to be in a specific order.

**Checklist**

- [x] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
