### PR TITLE
Upgrade to `v0.42.0` of Hedera C++ Protobuf API (PR)

### DIFF
--- a/HederaApi.cmake
+++ b/HederaApi.cmake
@@ -1,5 +1,5 @@
-set(HAPI_LIBRARY_HASH "29f23820c613a756f8de46e0a83971d168e39a9d3dab8a064271ec88d489ec90" CACHE STRING "Use the configured hash to verify the Hedera API protobuf library release")
-set(HAPI_LIBRARY_URL "https://github.com/hashgraph/hedera-protobufs-cpp/releases/download/v0.41.0/hapi-library-30ee152c.tar.gz" CACHE STRING "Use the configured URL to download the Hedera API protobuf library package")
+set(HAPI_LIBRARY_HASH "4d280012d9ea0782e685cd712c8e189d17f8255de821285df77aba0af7a2ef10" CACHE STRING "Use the configured hash to verify the Hedera API protobuf library release")
+set(HAPI_LIBRARY_URL "https://github.com/hashgraph/hedera-protobufs-cpp/releases/download/v0.42.0/hapi-library-675cf1cf.tar.gz" CACHE STRING "Use the configured URL to download the Hedera API protobuf library package")
 
 set(HAPI_LOCAL_LIBRARY_PATH "" CACHE STRING "Overrides the configured HAPI_LIBRARY_URL setting and instead uses the local path to retrieve the artifacts")
 

--- a/HederaApi.cmake
+++ b/HederaApi.cmake
@@ -1,4 +1,4 @@
-set(HAPI_LIBRARY_HASH "4d280012d9ea0782e685cd712c8e189d17f8255de821285df77aba0af7a2ef10" CACHE STRING "Use the configured hash to verify the Hedera API protobuf library release")
+set(HAPI_LIBRARY_HASH "7fd7683e0326780e60db4a5a325e7ab93b09bd8e7363bd2c411c5a37b0906dbf" CACHE STRING "Use the configured hash to verify the Hedera API protobuf library release")
 set(HAPI_LIBRARY_URL "https://github.com/hashgraph/hedera-protobufs-cpp/releases/download/v0.42.0/hapi-library-675cf1cf.tar.gz" CACHE STRING "Use the configured URL to download the Hedera API protobuf library package")
 
 set(HAPI_LOCAL_LIBRARY_PATH "" CACHE STRING "Overrides the configured HAPI_LIBRARY_URL setting and instead uses the local path to retrieve the artifacts")


### PR DESCRIPTION
**Description**:
This PR updates CMake to pull version `v0.42.0` of the `Hedera Protobuf C++` artefacts.

**Related issue(s)**:

**Fixes**: https://github.com/hashgraph/hedera-sdk-cpp/issues/588

**Notes for reviewer**:

**Checklist**:

- [x] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
