### PR TITLE
Add stream overloads for key classes

### DIFF
--- a/sdk/main/include/PrivateKey.h
+++ b/sdk/main/include/PrivateKey.h
@@ -25,6 +25,7 @@
 #include <cstddef>
 #include <cstdint>
 #include <memory>
+#include <ostream>
 #include <string>
 #include <vector>
 
@@ -149,6 +150,15 @@ public:
    * @return A pointer to the PublicKey that corresponds to this PrivateKey.
    */
   [[nodiscard]] std::shared_ptr<PublicKey> getPublicKey() const;
+
+  /**
+   * Write this PrivateKey in DER-encoded hex to an output stream.
+   *
+   * @param os  The output stream.
+   * @param key The PrivateKey to print.
+   * @return The output stream with this PrivateKey written to it.
+   */
+  friend std::ostream& operator<<(std::ostream& os, const PrivateKey& key);
 
 protected:
   /**

--- a/sdk/main/include/PublicKey.h
+++ b/sdk/main/include/PublicKey.h
@@ -23,6 +23,7 @@
 #include "Key.h"
 
 #include <memory>
+#include <ostream>
 #include <string>
 #include <string_view>
 #include <vector>
@@ -152,6 +153,15 @@ public:
    * @return The constructed AccountId.
    */
   [[nodiscard]] AccountId toAccountId(uint64_t shard = 0ULL, uint64_t realm = 0ULL) const;
+
+  /**
+   * Write this PublicKey in DER-encoded hex to an output stream.
+   *
+   * @param os  The output stream.
+   * @param key The PublicKey to print.
+   * @return The output stream with this PublicKey written to it.
+   */
+  friend std::ostream& operator<<(std::ostream& os, const PublicKey& key);
 
 protected:
   /**

--- a/sdk/main/src/PrivateKey.cc
+++ b/sdk/main/src/PrivateKey.cc
@@ -210,6 +210,13 @@ std::shared_ptr<PublicKey> PrivateKey::getPublicKey() const
 }
 
 //-----
+std::ostream& operator<<(std::ostream& os, const PrivateKey& key)
+{
+  os << key.toStringDer();
+  return os;
+}
+
+//-----
 PrivateKey::PrivateKey(const PrivateKey& other)
   : mImpl(std::make_unique<PrivateKeyImpl>(*other.mImpl))
 {

--- a/sdk/main/src/PublicKey.cc
+++ b/sdk/main/src/PublicKey.cc
@@ -107,6 +107,13 @@ AccountId PublicKey::toAccountId(uint64_t shard, uint64_t realm) const
 }
 
 //-----
+std::ostream& operator<<(std::ostream& os, const PublicKey& key)
+{
+  os << key.toStringDer();
+  return os;
+}
+
+//-----
 PublicKey::PublicKey(const PublicKey& other)
   : mImpl(std::make_unique<PublicKeyImpl>(*other.mImpl))
 {


### PR DESCRIPTION
**Description**:
This PR allows `PublicKey` and `PrivateKey` classes to have their DER-encoded hex strings printed directly without having to call `toStringDer()`. This more closely matches how other SDKs can print keys.

**Related issue(s)**:

Fixes #590 

**Checklist**

- [x] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
