### PR TITLE
Upgrade to `v0.44.0` of Hedera C++ Protobuf API

### DIFF
--- a/HederaApi.cmake
+++ b/HederaApi.cmake
@@ -1,5 +1,5 @@
-set(HAPI_LIBRARY_HASH "215bb1f5e6a0848b5c55c99f935b8eef00532c6eadce318668a7cc7546f616b4" CACHE STRING "Use the configured hash to verify the Hedera API protobuf library release")
-set(HAPI_LIBRARY_URL "https://github.com/hashgraph/hedera-protobufs-cpp/releases/download/v0.43.0/hapi-library-8c966204.tar.gz" CACHE STRING "Use the configured URL to download the Hedera API protobuf library package")
+set(HAPI_LIBRARY_HASH "8ff6131cb6b9081747de694a742ab882de05cdc413b004221a2c849fddfb028e" CACHE STRING "Use the configured hash to verify the Hedera API protobuf library release")
+set(HAPI_LIBRARY_URL "https://github.com/hashgraph/hedera-protobufs-cpp/releases/download/v0.44.0/hapi-library-a20c83e2.tar.gz" CACHE STRING "Use the configured URL to download the Hedera API protobuf library package")
 
 set(HAPI_LOCAL_LIBRARY_PATH "" CACHE STRING "Overrides the configured HAPI_LIBRARY_URL setting and instead uses the local path to retrieve the artifacts")
 


### PR DESCRIPTION
**Description**:

This PR updates CMake to pull version `v0.44.0` of the `Hedera Protobuf C++` artefacts.

**Related issue(s)**:

**Fixes**: https://github.com/hashgraph/hedera-sdk-cpp/issues/611

**Notes for reviewer**:

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
