### PR TITLE
Fix Windows build

### DIFF
--- a/sdk/tests/unit/ECDSAsecp256k1PrivateKeyTest.cc
+++ b/sdk/tests/unit/ECDSAsecp256k1PrivateKeyTest.cc
@@ -46,7 +46,8 @@ protected:
 
   [[nodiscard]] inline const std::string& getTestPrivateKeyHexString() const { return mPrivateKeyHexString; }
   [[nodiscard]] inline const std::vector<std::byte>& getTestPrivateKeyBytes() const { return mPrivateKeyBytes; }
-  [[nodiscard]] inline const std::unordered_map<std::string_view, std::pair<std::string_view, std::string_view>>getExpectedPrivateKeyPairs() const
+  [[nodiscard]] inline const std::unordered_map<std::string_view, std::pair<std::string_view, std::string_view>>
+  getExpectedPrivateKeyPairs() const
   {
     return expectedPrivateKeyPairs;
   };
@@ -301,7 +302,7 @@ TEST_F(ECDSAsecp256k1PrivateKeyTest, GetChainCode)
 }
 
 //-----
-TEST_F(ECDSAsecp256k1PrivateKeyTest, ЕCDSACompatibility)
+TEST_F(ECDSAsecp256k1PrivateKeyTest, ECDSACompatibility)
 {
   // Given
   auto expectedKeys = getExpectedPrivateKeyPairs();


### PR DESCRIPTION
**Description**:
There was an issue with the Windows build caused by a new test added in `ECDSAsecp256k1PrivateKeyTest.cc`. It seemed like an errant character of some sort, but rewriting the names solved the issue. No functionality changed.

**Related issue(s)**:

Fixes #613 

**Checklist**

- [x] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
