### PR TITLE
Add `toString()` method and `operator<<` overload to query responses

### DIFF
--- a/sdk/examples/AccountAliasExample.cc
+++ b/sdk/examples/AccountAliasExample.cc
@@ -101,8 +101,7 @@ int main(int argc, char** argv)
             << std::endl;
 
   std::cout << "Balance of the created account: "
-            << AccountBalanceQuery().setAccountId(aliasAccountId).execute(client).getBalance().toTinybars()
-            << HbarUnit::TINYBAR().getSymbol() << std::endl;
+            << AccountBalanceQuery().setAccountId(aliasAccountId).execute(client).mBalance.toString() << std::endl;
 
   /*
    * Note that once an account exists in the ledger, it is assigned a normal AccountId, which can be retrieved via an

--- a/sdk/examples/AccountAllowanceExample.cc
+++ b/sdk/examples/AccountAllowanceExample.cc
@@ -69,8 +69,7 @@ int main(int argc, char** argv)
                                      .getReceipt(client)
                                      .mAccountId.value();
   std::cout << "Generated Alice account ID " << aliceAccountId.toString() << " and initialized with "
-            << AccountBalanceQuery().setAccountId(aliceAccountId).execute(client).getBalance().toTinybars()
-            << HbarUnit::TINYBAR().getSymbol() << std::endl;
+            << AccountBalanceQuery().setAccountId(aliceAccountId).execute(client).mBalance.toString() << std::endl;
 
   const AccountId bobAccountId = AccountCreateTransaction()
                                    .setKey(bobPublicKey)
@@ -79,8 +78,7 @@ int main(int argc, char** argv)
                                    .getReceipt(client)
                                    .mAccountId.value();
   std::cout << "Generated Bob account ID " << bobAccountId.toString() << " and initialized with "
-            << AccountBalanceQuery().setAccountId(bobAccountId).execute(client).getBalance().toTinybars()
-            << HbarUnit::TINYBAR().getSymbol() << std::endl;
+            << AccountBalanceQuery().setAccountId(bobAccountId).execute(client).mBalance.toString() << std::endl;
 
   const AccountId charlieAccountId = AccountCreateTransaction()
                                        .setKey(charliePublicKey)
@@ -89,8 +87,7 @@ int main(int argc, char** argv)
                                        .getReceipt(client)
                                        .mAccountId.value();
   std::cout << "Generated Charlie account ID " << charlieAccountId.toString() << " and initialized with "
-            << AccountBalanceQuery().setAccountId(charlieAccountId).execute(client).getBalance().toTinybars()
-            << HbarUnit::TINYBAR().getSymbol() << std::endl
+            << AccountBalanceQuery().setAccountId(charlieAccountId).execute(client).mBalance.toString() << std::endl
             << std::endl;
 
   std::cout << "Alice is now going to try and approve Bob to spend 2 of her Hbar" << std::endl;
@@ -169,14 +166,11 @@ int main(int argc, char** argv)
             << std::endl;
 
   std::cout << "Alice's final account balance: "
-            << AccountBalanceQuery().setAccountId(aliceAccountId).execute(client).getBalance().toTinybars()
-            << HbarUnit::TINYBAR().getSymbol() << std::endl;
+            << AccountBalanceQuery().setAccountId(aliceAccountId).execute(client).mBalance.toString() << std::endl;
   std::cout << "Bob's final account balance: "
-            << AccountBalanceQuery().setAccountId(bobAccountId).execute(client).getBalance().toTinybars()
-            << HbarUnit::TINYBAR().getSymbol() << std::endl;
+            << AccountBalanceQuery().setAccountId(bobAccountId).execute(client).mBalance.toString() << std::endl;
   std::cout << "Charlie's final account balance: "
-            << AccountBalanceQuery().setAccountId(charlieAccountId).execute(client).getBalance().toTinybars()
-            << HbarUnit::TINYBAR().getSymbol() << std::endl
+            << AccountBalanceQuery().setAccountId(charlieAccountId).execute(client).mBalance.toString() << std::endl
             << std::endl;
 
   std::cout << "Now going to attempt to delete Bob's allowance" << std::endl;

--- a/sdk/examples/ContractHelper.h
+++ b/sdk/examples/ContractHelper.h
@@ -215,7 +215,7 @@ public:
       if (validatorFunc(result))
       {
         std::cout << "Step " << step
-                  << " completed and returned a valid result. TransactionId=" << txRecord.mTransactionID->toString()
+                  << " completed and returned a valid result. TransactionId=" << txRecord.mTransactionId->toString()
                   << std::endl;
       }
       else

--- a/sdk/examples/CreateAccountThresholdKeyExample.cc
+++ b/sdk/examples/CreateAccountThresholdKeyExample.cc
@@ -77,8 +77,7 @@ int main(int argc, char** argv)
 
   // Get the account balance.
   std::cout << "New account balance: "
-            << AccountBalanceQuery().setAccountId(newAccountId).execute(client).getBalance().toTinybars()
-            << HbarUnit::TINYBAR().getSymbol() << std::endl;
+            << AccountBalanceQuery().setAccountId(newAccountId).execute(client).mBalance.toString() << std::endl;
 
   return 0;
 }

--- a/sdk/examples/CustomFeesExample.cc
+++ b/sdk/examples/CustomFeesExample.cc
@@ -151,8 +151,7 @@ int main(int argc, char** argv)
 
   // Get Alice's Hbar balance before Bob transfers 20 tokens to Charlie, so that we can see how much Hbar she made.
   std::cout << "Alice's Hbar balance before Bob transfers 20 tokens to Charlie: "
-            << AccountBalanceQuery().setAccountId(aliceAccountId).execute(client).getBalance().toTinybars()
-            << HbarUnit::TINYBAR().getSymbol() << std::endl;
+            << AccountBalanceQuery().setAccountId(aliceAccountId).execute(client).mBalance.toString() << std::endl;
 
   // Transfer 20 tokens to Charlie.
   std::cout << "Bob transfer 20 tokens to Charlie: ";
@@ -167,8 +166,7 @@ int main(int argc, char** argv)
 
   // Get Alice's Hbar balance after the transfer.
   std::cout << "Alice's Hbar balance after Bob transfers 20 tokens to Charlie: "
-            << AccountBalanceQuery().setAccountId(aliceAccountId).execute(client).getBalance().toTinybars()
-            << HbarUnit::TINYBAR().getSymbol() << std::endl;
+            << AccountBalanceQuery().setAccountId(aliceAccountId).execute(client).mBalance.toString() << std::endl;
 
   // Look at the assessed custom fees in the TransactionRecord.
   std::cout << "Assessed fees: " << std::endl;

--- a/sdk/examples/ExemptCustomFeesExample.cc
+++ b/sdk/examples/ExemptCustomFeesExample.cc
@@ -158,7 +158,6 @@ int main(int argc, char** argv)
                                  .sign(secondAccountPrivateKey)
                                  .execute(client)
                                  .getRecord(client);
-  std::cout << txRecord << std::endl;
   std::cout << gStatusToString.at(txRecord.mReceipt->mStatus) << std::endl;
 
   /**

--- a/sdk/examples/ExemptCustomFeesExample.cc
+++ b/sdk/examples/ExemptCustomFeesExample.cc
@@ -158,6 +158,7 @@ int main(int argc, char** argv)
                                  .sign(secondAccountPrivateKey)
                                  .execute(client)
                                  .getRecord(client);
+  std::cout << txRecord << std::endl;
   std::cout << gStatusToString.at(txRecord.mReceipt->mStatus) << std::endl;
 
   /**

--- a/sdk/examples/GetAccountBalanceExample.cc
+++ b/sdk/examples/GetAccountBalanceExample.cc
@@ -41,10 +41,9 @@ int main(int argc, char** argv)
   Client client = Client::forTestnet();
 
   // Because AccountBalanceQuery is a free query, we can make it without setting an operator on the client.
-  Hbar balance = AccountBalanceQuery().setAccountId(accountId).execute(client).getBalance();
+  Hbar balance = AccountBalanceQuery().setAccountId(accountId).execute(client).mBalance;
 
-  std::cout << "Balance of account " << accountId.toString() << " is " << balance.toTinybars()
-            << HbarUnit::TINYBAR().getSymbol() << std::endl;
+  std::cout << "Balance of account " << accountId.toString() << " is " << balance.toString() << std::endl;
 
   return 0;
 }

--- a/sdk/examples/MultiAppTransferExample.cc
+++ b/sdk/examples/MultiAppTransferExample.cc
@@ -110,11 +110,9 @@ int main(int argc, char** argv)
 
   // Get the balances.
   std::cout << "Balance of user account: "
-            << AccountBalanceQuery().setAccountId(userAccountId).execute(client).getBalance().toTinybars()
-            << HbarUnit::TINYBAR().getSymbol() << std::endl;
+            << AccountBalanceQuery().setAccountId(userAccountId).execute(client).mBalance.toString() << std::endl;
   std::cout << "Balance of exchange account: "
-            << AccountBalanceQuery().setAccountId(exchangeAccountId).execute(client).getBalance().toTinybars()
-            << HbarUnit::TINYBAR().getSymbol() << std::endl;
+            << AccountBalanceQuery().setAccountId(exchangeAccountId).execute(client).mBalance.toString() << std::endl;
 
   return 0;
 }

--- a/sdk/examples/MultiSigOfflineExample.cc
+++ b/sdk/examples/MultiSigOfflineExample.cc
@@ -86,8 +86,7 @@ int main(int argc, char** argv)
 
   // Get the balance of the multi-sig account.
   std::cout << "Balance of multi-sign account (should be 3 Hbar): "
-            << AccountBalanceQuery().setAccountId(accountId).execute(client).getBalance().toTinybars()
-            << HbarUnit::TINYBAR().getSymbol() << std::endl;
+            << AccountBalanceQuery().setAccountId(accountId).execute(client).mBalance.toString() << std::endl;
 
   return 0;
 }

--- a/sdk/examples/ScheduleTransferExample.cc
+++ b/sdk/examples/ScheduleTransferExample.cc
@@ -84,8 +84,8 @@ int main(int argc, char** argv)
   std::cout << "Account generated with ID: " << accountId.toString() << std::endl;
 
   // Verify the balance of the created account.
-  Hbar balance = AccountBalanceQuery().setAccountId(accountId).execute(client).getBalance();
-  std::cout << "Balance of created account: " << balance.toTinybars() << HbarUnit::TINYBAR().getSymbol() << std::endl;
+  Hbar balance = AccountBalanceQuery().setAccountId(accountId).execute(client).mBalance;
+  std::cout << "Balance of created account: " << balance.toString() << std::endl;
 
   // The payerAccountId is the account that will be charged the fee for executing the scheduled transaction if/when it
   // is executed. That fee is separate from the fee that will pay to execute the ScheduleCreateTransaction itself.
@@ -109,9 +109,8 @@ int main(int argc, char** argv)
   std::cout << "Scheduled transfer with ID: " << scheduleId.toString() << std::endl;
 
   // Verify the transaction has not executed and that the created account's balance hasn't changed.
-  balance = AccountBalanceQuery().setAccountId(accountId).execute(client).getBalance();
-  std::cout << "Balance of account (should be same as before): " << balance.toTinybars()
-            << HbarUnit::TINYBAR().getSymbol() << std::endl;
+  balance = AccountBalanceQuery().setAccountId(accountId).execute(client).mBalance;
+  std::cout << "Balance of account (should be same as before): " << balance.toString() << std::endl;
 
   // Once the operator has communicated the schedule ID to the created account, it can query for information about the
   // scheduled transaction.

--- a/sdk/examples/SignTransactionExample.cc
+++ b/sdk/examples/SignTransactionExample.cc
@@ -76,8 +76,7 @@ int main(int argc, char** argv)
 
   // Get the balance of the multi-sig account.
   std::cout << "Balance of multi-sign account (should be 3 Hbar): "
-            << AccountBalanceQuery().setAccountId(accountId).execute(client).getBalance().toTinybars()
-            << HbarUnit::TINYBAR().getSymbol() << std::endl;
+            << AccountBalanceQuery().setAccountId(accountId).execute(client).mBalance.toString() << std::endl;
 
   return 0;
 }

--- a/sdk/examples/StakingExample.cc
+++ b/sdk/examples/StakingExample.cc
@@ -63,8 +63,8 @@ int main(int argc, char** argv)
   // Query the account info, it should show the staked account ID to be 0.0.3.
   const AccountInfo accountInfo = AccountInfoQuery().setAccountId(newAccountId).execute(client);
   std::cout << "Account ID " << newAccountId.toString() << " is staked to: "
-            << ((accountInfo.mStakingInfo.getStakedAccountId().has_value())
-                  ? accountInfo.mStakingInfo.getStakedAccountId()->toString()
+            << ((accountInfo.mStakingInfo.mStakedAccountId.has_value())
+                  ? accountInfo.mStakingInfo.mStakedAccountId->toString()
                   : "NOT STAKED")
             << std::endl;
 

--- a/sdk/examples/StakingWithUpdateExample.cc
+++ b/sdk/examples/StakingWithUpdateExample.cc
@@ -64,8 +64,8 @@ int main(int argc, char** argv)
   // Query the account info, it should show the staked account ID to be 0.0.3.
   AccountInfo accountInfo = AccountInfoQuery().setAccountId(newAccountId).execute(client);
   std::cout << "Account ID " << newAccountId.toString() << " is staked to: "
-            << ((accountInfo.mStakingInfo.getStakedAccountId().has_value())
-                  ? accountInfo.mStakingInfo.getStakedAccountId()->toString()
+            << ((accountInfo.mStakingInfo.mStakedAccountId.has_value())
+                  ? accountInfo.mStakingInfo.mStakedAccountId->toString()
                   : "NOT STAKED")
             << std::endl;
 
@@ -84,8 +84,8 @@ int main(int argc, char** argv)
   // Query the account info, it should no longer be staked.
   accountInfo = AccountInfoQuery().setAccountId(newAccountId).execute(client);
   std::cout << "Account ID " << newAccountId.toString() << " is staked to: "
-            << ((accountInfo.mStakingInfo.getStakedAccountId().has_value())
-                  ? accountInfo.mStakingInfo.getStakedAccountId()->toString()
+            << ((accountInfo.mStakingInfo.mStakedAccountId.has_value())
+                  ? accountInfo.mStakingInfo.mStakedAccountId->toString()
                   : "NOT STAKED")
             << std::endl;
   return 0;

--- a/sdk/examples/TransferCryptoExample.cc
+++ b/sdk/examples/TransferCryptoExample.cc
@@ -46,13 +46,11 @@ int main(int argc, char** argv)
   const auto recipientId = AccountId(3ULL);
   const Hbar amount(10000ULL, HbarUnit::TINYBAR());
 
-  const Hbar senderBalanceBefore = AccountBalanceQuery().setAccountId(operatorAccountId).execute(client).getBalance();
-  const Hbar recipientBalanceBefore = AccountBalanceQuery().setAccountId(recipientId).execute(client).getBalance();
+  const Hbar senderBalanceBefore = AccountBalanceQuery().setAccountId(operatorAccountId).execute(client).mBalance;
+  const Hbar recipientBalanceBefore = AccountBalanceQuery().setAccountId(recipientId).execute(client).mBalance;
 
-  std::cout << "Sender balance before transfer: " << senderBalanceBefore.toTinybars() << HbarUnit::TINYBAR().getSymbol()
-            << std::endl;
-  std::cout << "Recipient balance before transfer: " << recipientBalanceBefore.toTinybars()
-            << HbarUnit::TINYBAR().getSymbol() << std::endl;
+  std::cout << "Sender balance before transfer: " << senderBalanceBefore.toString() << std::endl;
+  std::cout << "Recipient balance before transfer: " << recipientBalanceBefore.toString() << std::endl;
 
   TransactionResponse txResponse = TransferTransaction()
                                      .addHbarTransfer(operatorAccountId, amount.negated())
@@ -62,15 +60,13 @@ int main(int argc, char** argv)
 
   TransactionRecord txRecord = txResponse.getRecord(client);
 
-  std::cout << "Transferred " << amount.toTinybars() << HbarUnit::TINYBAR().getSymbol() << std::endl;
+  std::cout << "Transferred " << amount.toString() << std::endl;
 
-  const Hbar senderBalanceAfter = AccountBalanceQuery().setAccountId(operatorAccountId).execute(client).getBalance();
-  const Hbar recipientBalanceAfter = AccountBalanceQuery().setAccountId(recipientId).execute(client).getBalance();
+  const Hbar senderBalanceAfter = AccountBalanceQuery().setAccountId(operatorAccountId).execute(client).mBalance;
+  const Hbar recipientBalanceAfter = AccountBalanceQuery().setAccountId(recipientId).execute(client).mBalance;
 
-  std::cout << "Sender balance after transfer: " << senderBalanceAfter.toTinybars() << HbarUnit::TINYBAR().getSymbol()
-            << std::endl;
-  std::cout << "Recipient balance after transfer: " << recipientBalanceAfter.toTinybars()
-            << HbarUnit::TINYBAR().getSymbol() << std::endl;
+  std::cout << "Sender balance after transfer: " << senderBalanceAfter.toString() << std::endl;
+  std::cout << "Recipient balance after transfer: " << recipientBalanceAfter.toString() << std::endl;
   std::cout << "HbarTransfer memo: " << txRecord.mMemo << std::endl;
 
   return 0;

--- a/sdk/examples/ValidateChecksumExample.cc
+++ b/sdk/examples/ValidateChecksumExample.cc
@@ -162,7 +162,7 @@ int main(int argc, char** argv)
 
       // Get the account's balance.
       std::cout << "Balance of account: "
-                << AccountBalanceQuery().setAccountId(accountId).execute(client).getBalance().toTinybars() << std::endl;
+                << AccountBalanceQuery().setAccountId(accountId).execute(client).mBalance.toString() << std::endl;
 
       break;
     }

--- a/sdk/main/include/AccountBalance.h
+++ b/sdk/main/include/AccountBalance.h
@@ -22,6 +22,12 @@
 
 #include "Hbar.h"
 
+#include <cstddef>
+#include <memory>
+#include <ostream>
+#include <string>
+#include <vector>
+
 namespace proto
 {
 class CryptoGetAccountBalanceResponse;
@@ -44,13 +50,43 @@ public:
   [[nodiscard]] static AccountBalance fromProtobuf(const proto::CryptoGetAccountBalanceResponse& proto);
 
   /**
-   * Get the balance of the queried account or contract.
+   * Construct an AccountBalance object from a byte array.
    *
-   * @return The account or contract balance.
+   * @param bytes The byte array from which to construct an AccountBalance object.
+   * @return The constructed AccountBalance object.
    */
-  [[nodiscard]] inline Hbar getBalance() const { return mBalance; }
+  [[nodiscard]] static AccountBalance fromBytes(const std::vector<std::byte>& bytes);
 
-private:
+  /**
+   * Construct a CryptoGetAccountBalanceResponse protobuf object from this FeeSchedules object.
+   *
+   * @return A pointer to the created CryptoGetAccountBalanceResponse protobuf object.
+   */
+  [[nodiscard]] std::unique_ptr<proto::CryptoGetAccountBalanceResponse> toProtobuf() const;
+
+  /**
+   * Construct a representative byte array from this AccountBalance object.
+   *
+   * @return The byte array representing this AccountBalance object.
+   */
+  [[nodiscard]] std::vector<std::byte> toBytes() const;
+
+  /**
+   * Construct a string representation of this AccountBalance object.
+   *
+   * @return The string representation of this AccountBalance object.
+   */
+  [[nodiscard]] std::string toString() const;
+
+  /**
+   * Write this AccountBalance to an output stream.
+   *
+   * @param os      The output stream.
+   * @param balance The AccountBalance to print.
+   * @return The output stream with this AccountBalance written to it.
+   */
+  friend std::ostream& operator<<(std::ostream& os, const AccountBalance& balance);
+
   /**
    * The account or contract balance.
    */

--- a/sdk/main/include/AccountInfo.h
+++ b/sdk/main/include/AccountInfo.h
@@ -28,9 +28,11 @@
 #include "StakingInfo.h"
 
 #include <chrono>
+#include <cstddef>
 #include <memory>
 #include <optional>
 #include <string>
+#include <vector>
 
 namespace proto
 {
@@ -52,6 +54,44 @@ public:
    * @return The constructed AccountInfo object.
    */
   [[nodiscard]] static AccountInfo fromProtobuf(const proto::CryptoGetInfoResponse_AccountInfo& proto);
+
+  /**
+   * Construct an AccountInfo object from a byte array.
+   *
+   * @param bytes The byte array from which to construct an AccountInfo object.
+   * @return The constructed AccountInfo object.
+   */
+  [[nodiscard]] static AccountInfo fromBytes(const std::vector<std::byte>& bytes);
+
+  /**
+   * Construct a CryptoGetInfoResponse_AccountInfo protobuf object from this AccountInfo object.
+   *
+   * @return A pointer to the created CryptoGetInfoResponse_AccountInfo protobuf object.
+   */
+  [[nodiscard]] std::unique_ptr<proto::CryptoGetInfoResponse_AccountInfo> toProtobuf() const;
+
+  /**
+   * Construct a representative byte array from this AccountInfo object.
+   *
+   * @return The byte array representing this AccountInfo object.
+   */
+  [[nodiscard]] std::vector<std::byte> toBytes() const;
+
+  /**
+   * Construct a string representation of this AccountInfo object.
+   *
+   * @return The string representation of this AccountInfo object.
+   */
+  [[nodiscard]] std::string toString() const;
+
+  /**
+   * Write this AccountInfo to an output stream.
+   *
+   * @param os   The output stream.
+   * @param info The AccountInfo to print.
+   * @return The output stream with this AccountInfo written to it.
+   */
+  friend std::ostream& operator<<(std::ostream& os, const AccountInfo& info);
 
   /**
    * The ID of the queried account.

--- a/sdk/main/include/AccountRecords.h
+++ b/sdk/main/include/AccountRecords.h
@@ -23,6 +23,10 @@
 #include "AccountId.h"
 #include "TransactionRecord.h"
 
+#include <cstddef>
+#include <memory>
+#include <ostream>
+#include <string>
 #include <vector>
 
 namespace proto
@@ -47,20 +51,43 @@ public:
   [[nodiscard]] static AccountRecords fromProtobuf(const proto::CryptoGetAccountRecordsResponse& proto);
 
   /**
-   * Get the ID of the queried account.
+   * Construct an AccountRecords object from a byte array.
    *
-   * @return The ID of the queried account.
+   * @param bytes The byte array from which to construct an AccountRecords object.
+   * @return The constructed AccountRecords object.
    */
-  [[nodiscard]] inline AccountId getAccountId() const { return mAccountId; }
+  [[nodiscard]] static AccountRecords fromBytes(const std::vector<std::byte>& bytes);
 
   /**
-   * Get the TransactionRecords of the queried account.
+   * Construct a CryptoGetAccountRecordsResponse protobuf object from this AccountRecords object.
    *
-   * @return The TransactionRecords of the queried account.
+   * @return A pointer to the created CryptoGetAccountRecordsResponse protobuf object.
    */
-  [[nodiscard]] inline std::vector<TransactionRecord> getRecords() const { return mRecords; }
+  [[nodiscard]] std::unique_ptr<proto::CryptoGetAccountRecordsResponse> toProtobuf() const;
 
-private:
+  /**
+   * Construct a representative byte array from this AccountRecords object.
+   *
+   * @return The byte array representing this AccountRecords object.
+   */
+  [[nodiscard]] std::vector<std::byte> toBytes() const;
+
+  /**
+   * Construct a string representation of this AccountRecords object.
+   *
+   * @return The string representation of this AccountRecords object.
+   */
+  [[nodiscard]] std::string toString() const;
+
+  /**
+   * Write this AccountRecords to an output stream.
+   *
+   * @param os      The output stream.
+   * @param records The AccountRecords to print.
+   * @return The output stream with this AccountRecords written to it.
+   */
+  friend std::ostream& operator<<(std::ostream& os, const AccountRecords& records);
+
   /**
    * The ID of the queried account.
    */

--- a/sdk/main/include/AssessedCustomFee.h
+++ b/sdk/main/include/AssessedCustomFee.h
@@ -27,6 +27,8 @@
 #include <cstdint>
 #include <memory>
 #include <optional>
+#include <ostream>
+#include <string>
 #include <vector>
 
 namespace proto
@@ -43,40 +45,55 @@ class AssessedCustomFee
 {
 public:
   /**
-   * Create an AssessedCustomFee object from a AssessedCustomFee protobuf object.
+   * Construct an AssessedCustomFee object from an AssessedCustomFee protobuf object.
    *
-   * @param proto The AssessedCustomFee protobuf object from which to create an AssessedCustomFee object.
+   * @param proto The AssessedCustomFee protobuf object from which to construct an AssessedCustomFee object.
    * @return The constructed AssessedCustomFee object.
    */
   [[nodiscard]] static AssessedCustomFee fromProtobuf(const proto::AssessedCustomFee& proto);
 
   /**
-   * Create an AssessedCustomFee object from an array of bytes.
+   * Construct an AssessedCustomFee object from a byte array.
    *
-   * @param bytes The bytes from which to create an AssessedCustomFee object.
+   * @param bytes The byte array from which to construct an AssessedCustomFee object.
    * @return The constructed AssessedCustomFee object.
    */
   [[nodiscard]] static AssessedCustomFee fromBytes(const std::vector<std::byte>& bytes);
 
   /**
-   * Construct a AssessedCustomFee protobuf object from this AssessedCustomFee object.
+   * Construct an AssessedCustomFee protobuf object from this AssessedCustomFee object.
    *
-   * @return A pointer to the created AssessedCustomFee protobuf object filled with this AssessedCustomFee object's
-   *         data.
+   * @return A pointer to the created AssessedCustomFee protobuf object.
    */
   [[nodiscard]] std::unique_ptr<proto::AssessedCustomFee> toProtobuf() const;
 
   /**
-   * Create a byte array representation of this AssessedCustomFee object.
+   * Construct a representative byte array from this AssessedCustomFee object.
    *
-   * @return A byte array representation of this AssessedCustomFee object.
+   * @return The byte array representing this AssessedCustomFee object.
    */
   [[nodiscard]] std::vector<std::byte> toBytes() const;
 
   /**
+   * Construct a string representation of this AssessedCustomFee object.
+   *
+   * @return The string representation of this AssessedCustomFee object.
+   */
+  [[nodiscard]] std::string toString() const;
+
+  /**
+   * Write this AssessedCustomFee to an output stream.
+   *
+   * @param os  The output stream.
+   * @param fee The AssessedCustomFee to print.
+   * @return The output stream with this AssessedCustomFee written to it.
+   */
+  friend std::ostream& operator<<(std::ostream& os, const AssessedCustomFee& fee);
+
+  /**
    * The number of units assessed for the fee.
    */
-  int64_t mAmount;
+  int64_t mAmount = 0LL;
 
   /**
    * The denomination of the fee. The denomination is Hbar if left unset.

--- a/sdk/main/include/ContractFunctionResult.h
+++ b/sdk/main/include/ContractFunctionResult.h
@@ -28,7 +28,9 @@
 #include "Hbar.h"
 
 #include <cstddef>
+#include <memory>
 #include <optional>
+#include <ostream>
 #include <string>
 #include <vector>
 
@@ -61,6 +63,44 @@ public:
    * @return The constructed ContractFunctionResult object.
    */
   [[nodiscard]] static ContractFunctionResult fromProtobuf(const proto::ContractFunctionResult& proto);
+
+  /**
+   * Construct a ContractFunctionResult object from a byte array.
+   *
+   * @param bytes The byte array from which to construct a ContractFunctionResult object.
+   * @return The constructed ContractFunctionResult object.
+   */
+  [[nodiscard]] static ContractFunctionResult fromBytes(const std::vector<std::byte>& bytes);
+
+  /**
+   * Construct a ContractFunctionResult protobuf object from this ContractFunctionResult object.
+   *
+   * @return A pointer to the created ContractFunctionResult protobuf object.
+   */
+  [[nodiscard]] std::unique_ptr<proto::ContractFunctionResult> toProtobuf() const;
+
+  /**
+   * Construct a representative byte array from this ContractFunctionResult object.
+   *
+   * @return The byte array representing this ContractFunctionResult object.
+   */
+  [[nodiscard]] std::vector<std::byte> toBytes() const;
+
+  /**
+   * Construct a string representation of this ContractFunctionResult object.
+   *
+   * @return The string representation of this ContractFunctionResult object.
+   */
+  [[nodiscard]] std::string toString() const;
+
+  /**
+   * Write this ContractFunctionResult to an output stream.
+   *
+   * @param os     The output stream.
+   * @param result The ContractFunctionResult to print.
+   * @return The output stream with this ContractFunctionResult written to it.
+   */
+  friend std::ostream& operator<<(std::ostream& os, const ContractFunctionResult& result);
 
   /**
    * Get the value at the input index as a string.
@@ -232,9 +272,9 @@ public:
   AccountId mSenderAccountId;
 
   /**
-   * A vector of updated contract account nonces containing the new nonce value for each contract
-   * account. This is always empty in a ContractCallLocalResponse#ContractFunctionResult message,
-   * since no internal creations can happen in a static EVM call.
+   * A vector of updated contract account nonces containing the new nonce value for each contract account. This is
+   * always empty in a ContractCallLocalResponse#ContractFunctionResult message, since no internal creations can happen
+   * in a static EVM call.
    */
   std::vector<ContractNonceInfo> mContractNonces;
 

--- a/sdk/main/include/ContractInfo.h
+++ b/sdk/main/include/ContractInfo.h
@@ -57,6 +57,44 @@ public:
   [[nodiscard]] static ContractInfo fromProtobuf(const proto::ContractGetInfoResponse_ContractInfo& proto);
 
   /**
+   * Construct a ContractInfo object from a byte array.
+   *
+   * @param bytes The byte array from which to construct a ContractInfo object.
+   * @return The constructed ContractInfo object.
+   */
+  [[nodiscard]] static ContractInfo fromBytes(const std::vector<std::byte>& bytes);
+
+  /**
+   * Construct a ContractGetInfoResponse_ContractInfo protobuf object from this ContractInfo object.
+   *
+   * @return A pointer to the created ContractGetInfoResponse_ContractInfo protobuf object.
+   */
+  [[nodiscard]] std::unique_ptr<proto::ContractGetInfoResponse_ContractInfo> toProtobuf() const;
+
+  /**
+   * Construct a representative byte array from this ContractInfo object.
+   *
+   * @return The byte array representing this ContractInfo object.
+   */
+  [[nodiscard]] std::vector<std::byte> toBytes() const;
+
+  /**
+   * Construct a string representation of this ContractInfo object.
+   *
+   * @return The string representation of this ContractInfo object.
+   */
+  [[nodiscard]] std::string toString() const;
+
+  /**
+   * Write this ContractInfo to an output stream.
+   *
+   * @param os   The output stream.
+   * @param info The ContractInfo to print.
+   * @return The output stream with this ContractInfo written to it.
+   */
+  friend std::ostream& operator<<(std::ostream& os, const ContractInfo& info);
+
+  /**
    * The ID of the contract.
    */
   ContractId mContractId;

--- a/sdk/main/include/ContractLogInfo.h
+++ b/sdk/main/include/ContractLogInfo.h
@@ -24,6 +24,8 @@
 
 #include <cstddef>
 #include <memory>
+#include <ostream>
+#include <string>
 #include <vector>
 
 namespace proto
@@ -41,19 +43,50 @@ class ContractLogInfo
 {
 public:
   /**
-   * Construct a ContractLogInfo object from a ContractLogInfo protobuf object.
+   * Construct a ContractLogInfo object from a ContractLoginfo protobuf object.
    *
-   * @param proto The ContractLogInfo protobuf object from which to construct a ContractLogInfo object.
+   * @param proto The ContractLoginfo protobuf object from which to construct a ContractLogInfo object.
    * @return The constructed ContractLogInfo object.
    */
   [[nodiscard]] static ContractLogInfo fromProtobuf(const proto::ContractLoginfo& proto);
 
   /**
-   * Construct a ContractLogInfo protobuf object from this ContractLogInfo object.
+   * Construct a ContractLogInfo object from a byte array.
    *
-   * @return A pointer to the created ContractLogInfo protobuf object filled with this ContractLogInfo object's data.
+   * @param bytes The byte array from which to construct a TransactionRecord object.
+   * @return The constructed ContractLogInfo object.
+   */
+  [[nodiscard]] static ContractLogInfo fromBytes(const std::vector<std::byte>& bytes);
+
+  /**
+   * Construct a ContractLoginfo protobuf object from this ContractLogInfo object.
+   *
+   * @return A pointer to the created ContractLoginfo protobuf object.
    */
   [[nodiscard]] std::unique_ptr<proto::ContractLoginfo> toProtobuf() const;
+
+  /**
+   * Construct a representative byte array from this ContractLogInfo object.
+   *
+   * @return The byte array representing this ContractLogInfo object.
+   */
+  [[nodiscard]] std::vector<std::byte> toBytes() const;
+
+  /**
+   * Construct a string representation of this ContractLogInfo object.
+   *
+   * @return The string representation of this ContractLogInfo object.
+   */
+  [[nodiscard]] std::string toString() const;
+
+  /**
+   * Write this ContractLogInfo to an output stream.
+   *
+   * @param os      The output stream.
+   * @param logInfo The ContractLogInfo to print.
+   * @return The output stream with this ContractLogInfo written to it.
+   */
+  friend std::ostream& operator<<(std::ostream& os, const ContractLogInfo& logInfo);
 
   /**
    * The ID of the contract that emitted this log event.

--- a/sdk/main/include/ContractNonceInfo.h
+++ b/sdk/main/include/ContractNonceInfo.h
@@ -50,7 +50,7 @@ public:
    * @param contractId The ID of the contract.
    * @param nonce      The nonce.
    */
-  explicit ContractNonceInfo(ContractId contractId, const int64_t& nonce);
+  ContractNonceInfo(ContractId contractId, int64_t nonce);
 
   /**
    * Compare this ContractNonceInfo to another ContractNonceInfo and determine if they represent the same nonce for a

--- a/sdk/main/include/ContractNonceInfo.h
+++ b/sdk/main/include/ContractNonceInfo.h
@@ -22,6 +22,9 @@
 
 #include "ContractId.h"
 
+#include <cstddef>
+#include <memory>
+#include <ostream>
 #include <string>
 #include <vector>
 
@@ -39,29 +42,19 @@ namespace Hedera
 class ContractNonceInfo
 {
 public:
-  /**
-   * Id of the contract
-   */
-  ContractId mContractId;
-
-  /**
-   * The current value of the contract account's nonce property
-   */
-  int64_t mNonce;
-
-  /**
-   * Default construct for empty ContractNonceInfo object.
-   */
   ContractNonceInfo() = default;
 
   /**
-   * Construct with a contract Id and nonce.
+   * Construct with a contract ID and nonce.
+   *
+   * @param contractId The ID of the contract.
+   * @param nonce      The nonce.
    */
-  explicit ContractNonceInfo(const ContractId& contractId, const int64_t& nonce);
+  explicit ContractNonceInfo(ContractId contractId, const int64_t& nonce);
 
   /**
-   * Compare this ContractNonceInfo to another ContractNonceInfo and determine if they represent
-   * the same nonce for a specific ContractId.
+   * Compare this ContractNonceInfo to another ContractNonceInfo and determine if they represent the same nonce for a
+   * specific ContractId.
    *
    * @param other The other ContractNonceInfo with which to compare this ContractNonceInfo.
    * @return \c TRUE if this ContractNonceInfo is the same as the input ContractNonceInfo, otherwise \c FALSE.
@@ -69,17 +62,17 @@ public:
   bool operator==(const ContractNonceInfo& other) const;
 
   /**
-   * Create an ContractNonceInfo object from a protobuf object.
+   * Construct a ContractNonceInfo object from a ContractNonceInfo protobuf object.
    *
-   * @param proto the protobuf object
+   * @param proto The ContractNonceInfo protobuf object from which to construct a ContractNonceInfo object.
    * @return The constructed ContractNonceInfo object.
    */
   [[nodiscard]] static ContractNonceInfo fromProtobuf(const proto::ContractNonceInfo& proto);
 
   /**
-   * Create an ContractNonceInfo object from an array of bytes.
+   * Construct a ContractNonceInfo object from a byte array.
    *
-   * @param bytes The bytes from which to create an ContractNonceInfo object.
+   * @param bytes The byte array from which to construct a TransactionRecord object.
    * @return The constructed ContractNonceInfo object.
    */
   [[nodiscard]] static ContractNonceInfo fromBytes(const std::vector<std::byte>& bytes);
@@ -87,24 +80,42 @@ public:
   /**
    * Construct a ContractNonceInfo protobuf object from this ContractNonceInfo object.
    *
-   * @return A pointer to the created ContractNonceInfo protobuf object filled with this ContractNonceInfo object's
-   *         data.
+   * @return A pointer to the created ContractNonceInfo protobuf object.
    */
   [[nodiscard]] std::unique_ptr<proto::ContractNonceInfo> toProtobuf() const;
 
   /**
-   * Create a byte array representation of this ContractNonceInfo object.
+   * Construct a representative byte array from this ContractNonceInfo object.
    *
-   * @return A byte array representation of this ContractNonceInfo object.
+   * @return The byte array representing this ContractNonceInfo object.
    */
   [[nodiscard]] std::vector<std::byte> toBytes() const;
 
   /**
-   * Get a string representation of this ContractNonceInfo object.
+   * Construct a string representation of this ContractNonceInfo object.
    *
-   * @return A string representation of this ContractNonceInfo.
+   * @return The string representation of this ContractNonceInfo object.
    */
   [[nodiscard]] std::string toString() const;
+
+  /**
+   * Write this ContractNonceInfo to an output stream.
+   *
+   * @param os        The output stream.
+   * @param nonceInfo The ContractNonceInfo to print.
+   * @return The output stream with this ContractNonceInfo written to it.
+   */
+  friend std::ostream& operator<<(std::ostream& os, const ContractNonceInfo& nonceInfo);
+
+  /**
+   * The ID of the contract.
+   */
+  ContractId mContractId;
+
+  /**
+   * The current value of the contract account's nonce property.
+   */
+  int64_t mNonce = 0LL;
 };
 
 } // namespace Hedera

--- a/sdk/main/include/CustomFee.h
+++ b/sdk/main/include/CustomFee.h
@@ -24,6 +24,8 @@
 
 #include <cstddef>
 #include <memory>
+#include <ostream>
+#include <string>
 #include <vector>
 
 namespace proto
@@ -49,17 +51,17 @@ public:
   virtual ~CustomFee() = default;
 
   /**
-   * Create a CustomFee object from a CustomFee protobuf object.
+   * Construct a CustomFee object from a CustomFee protobuf object.
    *
-   * @param proto The CustomFee protobuf object from which to create an CustomFee object.
+   * @param proto The CustomFee protobuf object from which to construct a CustomFee object.
    * @return A pointer to the constructed CustomFee object.
    */
   [[nodiscard]] static std::unique_ptr<CustomFee> fromProtobuf(const proto::CustomFee& proto);
 
   /**
-   * Create a CustomFee object from a byte array.
+   * Construct a CustomFee object from a byte array.
    *
-   * @param bytes The byte array from which to create an CustomFee object.
+   * @param bytes The byte array from which to construct a CustomFee object.
    * @return A pointer to the constructed CustomFee object.
    */
   [[nodiscard]] static std::unique_ptr<CustomFee> fromBytes(const std::vector<std::byte>& bytes);
@@ -79,6 +81,22 @@ public:
   [[nodiscard]] virtual std::unique_ptr<proto::CustomFee> toProtobuf() const = 0;
 
   /**
+   * Construct a string representation of this CustomFee object.
+   *
+   * @return The string representation of this CustomFee object.
+   */
+  [[nodiscard]] virtual std::string toString() const = 0;
+
+  /**
+   * Write this CustomFee to an output stream.
+   *
+   * @param os  The output stream.
+   * @param fee The CustomFee to print.
+   * @return The output stream with this CustomFee written to it.
+   */
+  friend std::ostream& operator<<(std::ostream& os, const CustomFee& fee);
+
+  /**
    * Verify the checksums of all the entities involved in this CustomFee.
    *
    * @param client The Client that should be used to validate the checksums.
@@ -87,9 +105,9 @@ public:
   virtual void validateChecksums(const Client& client) const;
 
   /**
-   * Construct a byte array from this CustomFee object.
+   * Construct a representative byte array from this CustomFee object.
    *
-   * @return A byte array filled with this CustomFee object's data.
+   * @return The byte array representing this CustomFee object.
    */
   [[nodiscard]] std::vector<std::byte> toBytes() const;
 

--- a/sdk/main/include/CustomFixedFee.h
+++ b/sdk/main/include/CustomFixedFee.h
@@ -64,6 +64,13 @@ public:
   [[nodiscard]] std::unique_ptr<proto::CustomFee> toProtobuf() const override;
 
   /**
+   * Derived from CustomFee. Construct a string representation of this CustomFee object.
+   *
+   * @return The string representation of this CustomFee object.
+   */
+  [[nodiscard]] std::string toString() const override;
+
+  /**
    * Derived from CustomFee. Verify the checksums of all the entities involved in this CustomFixedFee.
    *
    * @param client The Client that should be used to validate the checksums.

--- a/sdk/main/include/CustomFractionalFee.h
+++ b/sdk/main/include/CustomFractionalFee.h
@@ -64,6 +64,13 @@ public:
   [[nodiscard]] std::unique_ptr<proto::CustomFee> toProtobuf() const override;
 
   /**
+   * Derived from CustomFee. Construct a string representation of this CustomFractionalFee object.
+   *
+   * @return The string representation of this CustomFractionalFee object.
+   */
+  [[nodiscard]] std::string toString() const override;
+
+  /**
    * Set the desired numerator of the fractional amount of the transferred units to assess as a part of this
    * CustomFractionalFee.
    *

--- a/sdk/main/include/CustomRoyaltyFee.h
+++ b/sdk/main/include/CustomRoyaltyFee.h
@@ -64,6 +64,13 @@ public:
   [[nodiscard]] std::unique_ptr<proto::CustomFee> toProtobuf() const override;
 
   /**
+   * Derived from CustomFee. Construct a string representation of this CustomRoyaltyFee object.
+   *
+   * @return The string representation of this CustomRoyaltyFee object.
+   */
+  [[nodiscard]] std::string toString() const override;
+
+  /**
    * Set the desired numerator of the fractional amount of the transferred units to assess as a part of this
    * CustomRoyaltyFee.
    *

--- a/sdk/main/include/ExchangeRate.h
+++ b/sdk/main/include/ExchangeRate.h
@@ -21,6 +21,11 @@
 #define HEDERA_SDK_CPP_EXCHANGE_RATE_H_
 
 #include <chrono>
+#include <cstddef>
+#include <memory>
+#include <ostream>
+#include <string>
+#include <vector>
 
 namespace proto
 {
@@ -48,12 +53,50 @@ public:
   ExchangeRate(int hbar, int cents, const std::chrono::system_clock::time_point& expirationTime);
 
   /**
-   * Construct an ExchangeRate object from a ExchangeRate protobuf object.
+   * Construct an ExchangeRate object from an ExchangeRate protobuf object.
    *
    * @param proto The ExchangeRate protobuf object from which to construct an ExchangeRate object.
    * @return The constructed ExchangeRate object.
    */
   [[nodiscard]] static ExchangeRate fromProtobuf(const proto::ExchangeRate& proto);
+
+  /**
+   * Construct an ExchangeRate object from a byte array.
+   *
+   * @param bytes The byte array from which to construct an ExchangeRate object.
+   * @return The constructed ExchangeRate object.
+   */
+  [[nodiscard]] static ExchangeRate fromBytes(const std::vector<std::byte>& bytes);
+
+  /**
+   * Construct an ExchangeRate protobuf object from this ExchangeRate object.
+   *
+   * @return A pointer to the created ExchangeRate protobuf object.
+   */
+  [[nodiscard]] std::unique_ptr<proto::ExchangeRate> toProtobuf() const;
+
+  /**
+   * Construct a representative byte array from this ExchangeRate object.
+   *
+   * @return The byte array representing this ExchangeRate object.
+   */
+  [[nodiscard]] std::vector<std::byte> toBytes() const;
+
+  /**
+   * Construct a string representation of this ExchangeRate object.
+   *
+   * @return The string representation of this ExchangeRate object.
+   */
+  [[nodiscard]] std::string toString() const;
+
+  /**
+   * Write this ExchangeRate to an output stream.
+   *
+   * @param os   The output stream.
+   * @param rate The ExchangeRate to print.
+   * @return The output stream with this ExchangeRate written to it.
+   */
+  friend std::ostream& operator<<(std::ostream& os, const ExchangeRate& rate);
 
   /**
    * Denotes Hbar equivalent to cents.

--- a/sdk/main/include/ExchangeRates.h
+++ b/sdk/main/include/ExchangeRates.h
@@ -23,6 +23,9 @@
 #include "ExchangeRate.h"
 
 #include <cstddef>
+#include <memory>
+#include <ostream>
+#include <string>
 #include <vector>
 
 namespace proto
@@ -48,9 +51,9 @@ public:
    * @param next    The next ExchangeRate.
    */
   ExchangeRates(const ExchangeRate& current, const ExchangeRate& next);
-
+  
   /**
-   * Construct an ExchangeRates object from a ExchangeRateSet protobuf object.
+   * Construct an ExchangeRates object from an ExchangeRateSet protobuf object.
    *
    * @param proto The ExchangeRateSet protobuf object from which to construct an ExchangeRates object.
    * @return The constructed ExchangeRates object.
@@ -58,12 +61,42 @@ public:
   [[nodiscard]] static ExchangeRates fromProtobuf(const proto::ExchangeRateSet& proto);
 
   /**
-   * Construct an ExchangeRates from a representative byte array.
+   * Construct an ExchangeRates object from a byte array.
    *
    * @param bytes The byte array from which to construct an ExchangeRates object.
    * @return The constructed ExchangeRates object.
    */
   [[nodiscard]] static ExchangeRates fromBytes(const std::vector<std::byte>& bytes);
+
+  /**
+   * Construct an ExchangeRateSet protobuf object from this ExchangeRates object.
+   *
+   * @return A pointer to the created ExchangeRateSet protobuf object.
+   */
+  [[nodiscard]] std::unique_ptr<proto::ExchangeRateSet> toProtobuf() const;
+
+  /**
+   * Construct a representative byte array from this ExchangeRates object.
+   *
+   * @return The byte array representing this ExchangeRates object.
+   */
+  [[nodiscard]] std::vector<std::byte> toBytes() const;
+
+  /**
+   * Construct a string representation of this ExchangeRates object.
+   *
+   * @return The string representation of this ExchangeRates object.
+   */
+  [[nodiscard]] std::string toString() const;
+
+  /**
+   * Write this ExchangeRates to an output stream.
+   *
+   * @param os    The output stream.
+   * @param rates The ExchangeRates to print.
+   * @return The output stream with this ExchangeRates written to it.
+   */
+  friend std::ostream& operator<<(std::ostream& os, const ExchangeRates& rates);
 
   /**
    * The current exchange rate.

--- a/sdk/main/include/ExchangeRates.h
+++ b/sdk/main/include/ExchangeRates.h
@@ -51,7 +51,7 @@ public:
    * @param next    The next ExchangeRate.
    */
   ExchangeRates(const ExchangeRate& current, const ExchangeRate& next);
-  
+
   /**
    * Construct an ExchangeRates object from an ExchangeRateSet protobuf object.
    *

--- a/sdk/main/include/FileInfo.h
+++ b/sdk/main/include/FileInfo.h
@@ -25,9 +25,12 @@
 #include "LedgerId.h"
 
 #include <chrono>
+#include <cstddef>
 #include <cstdint>
 #include <memory>
+#include <ostream>
 #include <string>
+#include <vector>
 
 namespace proto
 {
@@ -49,6 +52,44 @@ public:
    * @return The constructed FileInfo object.
    */
   [[nodiscard]] static FileInfo fromProtobuf(const proto::FileGetInfoResponse_FileInfo& proto);
+
+  /**
+   * Construct a FileInfo object from a byte array.
+   *
+   * @param bytes The byte array from which to construct a FileInfo object.
+   * @return The constructed FileInfo object.
+   */
+  [[nodiscard]] static FileInfo fromBytes(const std::vector<std::byte>& bytes);
+
+  /**
+   * Construct a FileGetInfoResponse_FileInfo protobuf object from this FileInfo object.
+   *
+   * @return A pointer to the created FileGetInfoResponse_FileInfo protobuf object.
+   */
+  [[nodiscard]] std::unique_ptr<proto::FileGetInfoResponse_FileInfo> toProtobuf() const;
+
+  /**
+   * Construct a representative byte array from this FileInfo object.
+   *
+   * @return The byte array representing this FileInfo object.
+   */
+  [[nodiscard]] std::vector<std::byte> toBytes() const;
+
+  /**
+   * Construct a string representation of this FileInfo object.
+   *
+   * @return The string representation of this FileInfo object.
+   */
+  [[nodiscard]] std::string toString() const;
+
+  /**
+   * Write this FileInfo to an output stream.
+   *
+   * @param os   The output stream.
+   * @param info The FileInfo to print.
+   * @return The output stream with this FileInfo written to it.
+   */
+  friend std::ostream& operator<<(std::ostream& os, const FileInfo& info);
 
   /**
    * The ID of the file.

--- a/sdk/main/include/HbarTransfer.h
+++ b/sdk/main/include/HbarTransfer.h
@@ -23,6 +23,12 @@
 #include "AccountId.h"
 #include "Hbar.h"
 
+#include <cstddef>
+#include <memory>
+#include <ostream>
+#include <string>
+#include <vector>
+
 namespace proto
 {
 class AccountAmount;
@@ -53,11 +59,42 @@ public:
   [[nodiscard]] static HbarTransfer fromProtobuf(const proto::AccountAmount& proto);
 
   /**
+   * Construct an HbarTransfer object from a byte array.
+   *
+   * @param bytes The byte array from which to construct an HbarTransfer object.
+   * @return The constructed HbarTransfer object.
+   */
+  [[nodiscard]] static HbarTransfer fromBytes(const std::vector<std::byte>& bytes);
+
+  /**
    * Construct an AccountAmount protobuf object from this HbarTransfer object.
    *
-   * @return A pointer to a constructed AccountAmount protobuf object filled with this HbarTransfer object's data.
+   * @return A pointer to the created HbarTransfer protobuf object.
    */
   [[nodiscard]] std::unique_ptr<proto::AccountAmount> toProtobuf() const;
+
+  /**
+   * Construct a representative byte array from this HbarTransfer object.
+   *
+   * @return The byte array representing this HbarTransfer object.
+   */
+  [[nodiscard]] std::vector<std::byte> toBytes() const;
+
+  /**
+   * Construct a string representation of this HbarTransfer object.
+   *
+   * @return The string representation of this HbarTransfer object.
+   */
+  [[nodiscard]] std::string toString() const;
+
+  /**
+   * Write this HbarTransfer to an output stream.
+   *
+   * @param os       The output stream.
+   * @param transfer The HbarTransfer to print.
+   * @return The output stream with this HbarTransfer written to it.
+   */
+  friend std::ostream& operator<<(std::ostream& os, const HbarTransfer& transfer);
 
   /**
    * The ID of the account associated with this HbarTransfer.

--- a/sdk/main/include/KeyList.h
+++ b/sdk/main/include/KeyList.h
@@ -23,6 +23,7 @@
 #include "Key.h"
 
 #include <memory>
+#include <string>
 #include <vector>
 
 namespace proto
@@ -93,6 +94,22 @@ public:
    * @throws OpenSSLException If OpenSSL is unable to serialize any key in this KeyList.
    */
   [[nodiscard]] std::unique_ptr<proto::KeyList> toProtobuf() const;
+
+  /**
+   * Construct a string representation of this KeyList object.
+   *
+   * @return The string representation of this KeyList object.
+   */
+  [[nodiscard]] std::string toString() const;
+
+  /**
+   * Write this KeyList to an output stream.
+   *
+   * @param os   The output stream.
+   * @param list The KeyList to print.
+   * @return The output stream with this KeyList written to it.
+   */
+  friend std::ostream& operator<<(std::ostream& os, const KeyList& list);
 
   /**
    * Set the threshold for this KeyList.

--- a/sdk/main/include/NetworkVersionInfo.h
+++ b/sdk/main/include/NetworkVersionInfo.h
@@ -62,7 +62,7 @@ public:
   /**
    * Construct a NetworkVersionInfo object from a byte array.
    *
-   * @param bytes The byte array from which to construct a TransactionRecord object.
+   * @param bytes The byte array from which to construct a NetworkVersionInfo object.
    * @return The constructed NetworkVersionInfo object.
    */
   [[nodiscard]] static NetworkVersionInfo fromBytes(const std::vector<std::byte>& bytes);

--- a/sdk/main/include/NetworkVersionInfo.h
+++ b/sdk/main/include/NetworkVersionInfo.h
@@ -24,6 +24,8 @@
 
 #include <cstddef>
 #include <memory>
+#include <ostream>
+#include <string>
 #include <vector>
 
 namespace proto
@@ -60,7 +62,7 @@ public:
   /**
    * Construct a NetworkVersionInfo object from a byte array.
    *
-   * @param bytes The byte array from which to construct a NetworkVersionInfo object.
+   * @param bytes The byte array from which to construct a TransactionRecord object.
    * @return The constructed NetworkVersionInfo object.
    */
   [[nodiscard]] static NetworkVersionInfo fromBytes(const std::vector<std::byte>& bytes);
@@ -68,7 +70,7 @@ public:
   /**
    * Construct a NetworkGetVersionInfoResponse protobuf object from this NetworkVersionInfo object.
    *
-   * @return A pointer to the created NetworkVersionInfo protobuf object.
+   * @return A pointer to the created NetworkGetVersionInfoResponse protobuf object.
    */
   [[nodiscard]] std::unique_ptr<proto::NetworkGetVersionInfoResponse> toProtobuf() const;
 
@@ -78,6 +80,22 @@ public:
    * @return The byte array representing this NetworkVersionInfo object.
    */
   [[nodiscard]] std::vector<std::byte> toBytes() const;
+
+  /**
+   * Construct a string representation of this NetworkVersionInfo object.
+   *
+   * @return The string representation of this NetworkVersionInfo object.
+   */
+  [[nodiscard]] std::string toString() const;
+
+  /**
+   * Write this NetworkVersionInfo to an output stream.
+   *
+   * @param os   The output stream.
+   * @param info The NetworkVersionInfo to print.
+   * @return The output stream with this NetworkVersionInfo written to it.
+   */
+  friend std::ostream& operator<<(std::ostream& os, const NetworkVersionInfo& info);
 
   /**
    * The version of the protobuf schema in use by the network.

--- a/sdk/main/include/ProxyStaker.h
+++ b/sdk/main/include/ProxyStaker.h
@@ -23,7 +23,12 @@
 #include "AccountId.h"
 #include "Hbar.h"
 
+#include <cstddef>
 #include <cstdint>
+#include <memory>
+#include <ostream>
+#include <string>
+#include <vector>
 
 namespace proto
 {
@@ -55,6 +60,44 @@ public:
    * @return The constructed ProxyStaker object.
    */
   [[nodiscard]] static ProxyStaker fromProtobuf(const proto::ProxyStaker& proto);
+
+  /**
+   * Construct a ProxyStaker object from a byte array.
+   *
+   * @param bytes The byte array from which to construct a ProxyStaker object.
+   * @return The constructed ProxyStaker object.
+   */
+  [[nodiscard]] static ProxyStaker fromBytes(const std::vector<std::byte>& bytes);
+
+  /**
+   * Construct a ProxyStaker protobuf object from this ProxyStaker object.
+   *
+   * @return A pointer to the created ProxyStaker protobuf object.
+   */
+  [[nodiscard]] std::unique_ptr<proto::ProxyStaker> toProtobuf() const;
+
+  /**
+   * Construct a representative byte array from this ProxyStaker object.
+   *
+   * @return The byte array representing this ProxyStaker object.
+   */
+  [[nodiscard]] std::vector<std::byte> toBytes() const;
+
+  /**
+   * Construct a string representation of this ProxyStaker object.
+   *
+   * @return The string representation of this ProxyStaker object.
+   */
+  [[nodiscard]] std::string toString() const;
+
+  /**
+   * Write this ProxyStaker to an output stream.
+   *
+   * @param os     The output stream.
+   * @param staker The ProxyStaker to print.
+   * @return The output stream with this ProxyStaker written to it.
+   */
+  friend std::ostream& operator<<(std::ostream& os, const ProxyStaker& staker);
 
   /**
    * The ID of the account that is proxy staking.

--- a/sdk/main/include/ScheduleInfo.h
+++ b/sdk/main/include/ScheduleInfo.h
@@ -32,6 +32,8 @@
 #include <cstddef>
 #include <memory>
 #include <optional>
+#include <ostream>
+#include <string>
 #include <vector>
 
 namespace proto
@@ -58,7 +60,7 @@ public:
   /**
    * Construct a ScheduleInfo object from a byte array.
    *
-   * @param bytes The byte array representing a ScheduleInfo object.
+   * @param bytes The byte array from which to construct a ScheduleInfo object.
    * @return The constructed ScheduleInfo object.
    */
   [[nodiscard]] static ScheduleInfo fromBytes(const std::vector<std::byte>& bytes);
@@ -76,6 +78,22 @@ public:
    * @return The byte array representing this ScheduleInfo object.
    */
   [[nodiscard]] std::vector<std::byte> toBytes() const;
+
+  /**
+   * Construct a string representation of this ScheduleInfo object.
+   *
+   * @return The string representation of this ScheduleInfo object.
+   */
+  [[nodiscard]] std::string toString() const;
+
+  /**
+   * Write this ScheduleInfo to an output stream.
+   *
+   * @param os   The output stream.
+   * @param info The ScheduleInfo to print.
+   * @return The output stream with this ScheduleInfo written to it.
+   */
+  friend std::ostream& operator<<(std::ostream& os, const ScheduleInfo& info);
 
   /**
    * The ID of the schedule.

--- a/sdk/main/include/StakingInfo.h
+++ b/sdk/main/include/StakingInfo.h
@@ -24,7 +24,11 @@
 #include "Hbar.h"
 
 #include <chrono>
+#include <cstddef>
+#include <memory>
 #include <optional>
+#include <string>
+#include <vector>
 
 namespace proto
 {
@@ -40,59 +44,51 @@ class StakingInfo
 {
 public:
   /**
-   * Construct an StakingInfo object from a StakingInfo protobuf object.
+   * Construct a StakingInfo object from a StakingInfo protobuf object.
    *
-   * @param proto The StakingInfo protobuf object from which to construct an StakingInfo object.
+   * @param proto The StakingInfo protobuf object from which to construct a StakingInfo object.
    * @return The constructed StakingInfo object.
    */
   [[nodiscard]] static StakingInfo fromProtobuf(const proto::StakingInfo& proto);
 
   /**
-   * Get the decline reward policy of the account/contract.
+   * Construct a StakingInfo object from a byte array.
    *
-   * @return \c TRUE if the account/contract is declining to receive staking rewards, otherwise \c FALSE.
+   * @param bytes The byte array from which to construct a StakingInfo object.
+   * @return The constructed StakingInfo object.
    */
-  [[nodiscard]] inline bool getDeclineReward() const { return mDeclineRewards; }
+  [[nodiscard]] static StakingInfo fromBytes(const std::vector<std::byte>& bytes);
 
   /**
-   * Get the current staking period start time.
+   * Construct a StakingInfo protobuf object from this StakingInfo object.
    *
-   * @return The current staking period start time. Uninitialized if not staked to a node.
+   * @return A pointer to the created StakingInfo protobuf object.
    */
-  [[nodiscard]] inline std::optional<std::chrono::system_clock::time_point> getStakePeriodStart() const
-  {
-    return mStakePeriodStart;
-  }
+  [[nodiscard]] std::unique_ptr<proto::StakingInfo> toProtobuf() const;
 
   /**
-   * Get the amount of Hbar that the account/contract will receive in the next reward situation.
+   * Construct a representative byte array from this StakingInfo object.
    *
-   * @return The amount of Hbar that the account/contract will receive in the next reward situation.
+   * @return The byte array representing this StakingInfo object.
    */
-  [[nodiscard]] inline Hbar getPendingReward() const { return mPendingReward; }
+  [[nodiscard]] std::vector<std::byte> toBytes() const;
 
   /**
-   * Get the total balance of all accounts staked to the account/contract.
+   * Construct a string representation of this StakingInfo object.
    *
-   * @return The total balance of all accounts staked to the account/contract.
+   * @return The string representation of this StakingInfo object.
    */
-  [[nodiscard]] inline Hbar getStakedToMe() const { return mStakedToMe; }
+  [[nodiscard]] std::string toString() const;
 
   /**
-   * Get the ID of the account to which the account/contract is staking.
+   * Write this StakingInfo to an output stream.
    *
-   * @return The ID of the account to which the account/contract is staking. Uninitialized if not staking to an account.
+   * @param os   The output stream.
+   * @param info The StakingInfo to print.
+   * @return The output stream with this StakingInfo written to it.
    */
-  [[nodiscard]] inline std::optional<AccountId> getStakedAccountId() const { return mStakedAccountId; }
+  friend std::ostream& operator<<(std::ostream& os, const StakingInfo& info);
 
-  /**
-   * Get the ID of the node to which the account/contract is staking.
-   *
-   * @return The ID of the node to which the account/contract is staking. Uninitialized if not staking to a node.
-   */
-  [[nodiscard]] inline std::optional<uint64_t> getStakedNodeId() const { return mStakedNodeId; }
-
-private:
   /**
    * Is this account/contract declining to receive staking rewards?
    */

--- a/sdk/main/include/TokenAssociation.h
+++ b/sdk/main/include/TokenAssociation.h
@@ -23,6 +23,12 @@
 #include "AccountId.h"
 #include "TokenId.h"
 
+#include <cstddef>
+#include <memory>
+#include <ostream>
+#include <string>
+#include <vector>
+
 namespace proto
 {
 class TokenAssociation;
@@ -37,17 +43,17 @@ class TokenAssociation
 {
 public:
   /**
-   * Create a TokenAssociation object from a TokenAssociation protobuf object.
+   * Construct a TokenAssociation object from a TokenAssociation protobuf object.
    *
-   * @param proto The TokenAssociation protobuf object from which to create a TokenAssociation object.
+   * @param proto The TokenAssociation protobuf object from which to construct a TokenAssociation object.
    * @return The constructed TokenAssociation object.
    */
   [[nodiscard]] static TokenAssociation fromProtobuf(const proto::TokenAssociation& proto);
 
   /**
-   * Create a TokenAssociation object from an array of bytes.
+   * Construct a TokenAssociation object from a byte array.
    *
-   * @param bytes The bytes from which to create a TokenAssociation object.
+   * @param bytes The byte array from which to construct a TokenAssociation object.
    * @return The constructed TokenAssociation object.
    */
   [[nodiscard]] static TokenAssociation fromBytes(const std::vector<std::byte>& bytes);
@@ -55,17 +61,32 @@ public:
   /**
    * Construct a TokenAssociation protobuf object from this TokenAssociation object.
    *
-   * @return A pointer to the created TokenAssociation protobuf object filled with this TokenAssociation object's
-   *         data.
+   * @return A pointer to the created TokenAssociation protobuf object.
    */
   [[nodiscard]] std::unique_ptr<proto::TokenAssociation> toProtobuf() const;
 
   /**
-   * Create a byte array representation of this TokenAssociation object.
+   * Construct a representative byte array from this TokenAssociation object.
    *
-   * @return A byte array representation of this TokenAssociation object.
+   * @return The byte array representing this TokenAssociation object.
    */
   [[nodiscard]] std::vector<std::byte> toBytes() const;
+
+  /**
+   * Construct a string representation of this TokenAssociation object.
+   *
+   * @return The string representation of this TokenAssociation object.
+   */
+  [[nodiscard]] std::string toString() const;
+
+  /**
+   * Write this TokenAssociation to an output stream.
+   *
+   * @param os     The output stream.
+   * @param record The TokenAssociation to print.
+   * @return The output stream with this TokenAssociation written to it.
+   */
+  friend std::ostream& operator<<(std::ostream& os, const TokenAssociation& record);
 
   /**
    * The ID of the account associated with the token.

--- a/sdk/main/include/TokenInfo.h
+++ b/sdk/main/include/TokenInfo.h
@@ -33,6 +33,7 @@
 #include <cstdint>
 #include <memory>
 #include <optional>
+#include <ostream>
 #include <string>
 #include <vector>
 
@@ -60,7 +61,7 @@ public:
   /**
    * Construct a TokenInfo object from a byte array.
    *
-   * @param bytes The byte array representing a TokenInfo object.
+   * @param bytes The byte array from which to construct a TokenInfo object.
    * @return The constructed TokenInfo object.
    */
   [[nodiscard]] static TokenInfo fromBytes(const std::vector<std::byte>& bytes);
@@ -78,6 +79,22 @@ public:
    * @return The byte array representing this TokenInfo object.
    */
   [[nodiscard]] std::vector<std::byte> toBytes() const;
+
+  /**
+   * Construct a string representation of this TokenInfo object.
+   *
+   * @return The string representation of this TokenInfo object.
+   */
+  [[nodiscard]] std::string toString() const;
+
+  /**
+   * Write this TokenInfo to an output stream.
+   *
+   * @param os   The output stream.
+   * @param info The TokenInfo to print.
+   * @return The output stream with this TokenInfo written to it.
+   */
+  friend std::ostream& operator<<(std::ostream& os, const TokenInfo& info);
 
   /**
    * The ID of the token.

--- a/sdk/main/include/TokenNftInfo.h
+++ b/sdk/main/include/TokenNftInfo.h
@@ -26,7 +26,10 @@
 
 #include <chrono>
 #include <cstddef>
+#include <memory>
 #include <optional>
+#include <ostream>
+#include <string>
 #include <vector>
 
 namespace proto
@@ -53,7 +56,7 @@ public:
   /**
    * Construct a TokenNftInfo object from a byte array.
    *
-   * @param bytes The byte array representing a TokenNftInfo object.
+   * @param bytes The byte array from which to construct a TokenNftInfo object.
    * @return The constructed TokenNftInfo object.
    */
   [[nodiscard]] static TokenNftInfo fromBytes(const std::vector<std::byte>& bytes);
@@ -71,6 +74,22 @@ public:
    * @return The byte array representing this TokenNftInfo object.
    */
   [[nodiscard]] std::vector<std::byte> toBytes() const;
+
+  /**
+   * Construct a string representation of this TokenNftInfo object.
+   *
+   * @return The string representation of this TokenNftInfo object.
+   */
+  [[nodiscard]] std::string toString() const;
+
+  /**
+   * Write this TokenNftInfo to an output stream.
+   *
+   * @param os   The output stream.
+   * @param info The TokenNftInfo to print.
+   * @return The output stream with this TokenNftInfo written to it.
+   */
+  friend std::ostream& operator<<(std::ostream& os, const TokenNftInfo& info);
 
   /**
    * The ID of the NFT.

--- a/sdk/main/include/TokenNftTransfer.h
+++ b/sdk/main/include/TokenNftTransfer.h
@@ -23,7 +23,11 @@
 #include "AccountId.h"
 #include "NftId.h"
 
+#include <cstddef>
 #include <memory>
+#include <ostream>
+#include <string>
+#include <vector>
 
 namespace proto
 {
@@ -62,6 +66,14 @@ public:
   [[nodiscard]] static TokenNftTransfer fromProtobuf(const proto::NftTransfer& proto, const TokenId& tokenId);
 
   /**
+   * Construct a TokenNftTransfer object from a byte array.
+   *
+   * @param bytes The byte array from which to construct a TokenNftTransfer object.
+   * @return The constructed TokenNftTransfer object.
+   */
+  [[nodiscard]] static TokenNftTransfer fromBytes(const std::vector<std::byte>& bytes);
+
+  /**
    * Validate the checksums of the entities associated with this TokenNftTransfer.
    *
    * @param client The Client to use to validate the checksums.
@@ -70,11 +82,34 @@ public:
   void validateChecksums(const Client& client) const;
 
   /**
-   * Construct an NftTransfer protobuf object from this TokenNftTransfer object.
+   * Construct a NftTransfer protobuf object from this TokenNftTransfer object.
    *
-   * @return A pointer to a created NftTransfer protobuf object filled with this TokenNftTransfer object's data.
+   * @return A pointer to the created NftTransfer protobuf object.
    */
   [[nodiscard]] std::unique_ptr<proto::NftTransfer> toProtobuf() const;
+
+  /**
+   * Construct a representative byte array from this TokenNftTransfer object.
+   *
+   * @return The byte array representing this TokenNftTransfer object.
+   */
+  [[nodiscard]] std::vector<std::byte> toBytes() const;
+
+  /**
+   * Construct a string representation of this TokenNftTransfer object.
+   *
+   * @return The string representation of this TokenNftTransfer object.
+   */
+  [[nodiscard]] std::string toString() const;
+
+  /**
+   * Write this TokenNftTransfer to an output stream.
+   *
+   * @param os       The output stream.
+   * @param transfer The TokenNftTransfer to print.
+   * @return The output stream with this TokenNftTransfer written to it.
+   */
+  friend std::ostream& operator<<(std::ostream& os, const TokenNftTransfer& transfer);
 
   /**
    * The ID of the NFT.

--- a/sdk/main/include/TokenTransfer.h
+++ b/sdk/main/include/TokenTransfer.h
@@ -23,7 +23,10 @@
 #include "AccountId.h"
 #include "TokenId.h"
 
+#include <cstddef>
 #include <memory>
+#include <ostream>
+#include <string>
 #include <vector>
 
 namespace proto
@@ -55,7 +58,7 @@ public:
    * @param amount     The amount of the token being transferred.
    * @param isApproved \c TRUE if this transfer is approved, otherwise \c FALSE.
    */
-  TokenTransfer(const TokenId& tokenId, AccountId accountId, int64_t amount, bool isApproved);
+  TokenTransfer(TokenId tokenId, AccountId accountId, int64_t amount, bool isApproved);
 
   /**
    * Construct with a token ID, account ID, amount, expected decimals of the token, and approval.
@@ -65,7 +68,7 @@ public:
    * @param amount     The amount of the token being transferred.
    * @param isApproved \c TRUE if this transfer is approved, otherwise \c FALSE.
    */
-  TokenTransfer(const TokenId& tokenId, AccountId accountId, int64_t amount, uint32_t decimals, bool isApproved);
+  TokenTransfer(TokenId tokenId, AccountId accountId, int64_t amount, uint32_t decimals, bool isApproved);
 
   /**
    * Construct a TokenTransfer object from an AccountAmount protobuf object, a TokenId object, and the number of
@@ -81,6 +84,14 @@ public:
                                                   uint32_t expectedDecimals);
 
   /**
+   * Construct a TokenTransfer object from a byte array.
+   *
+   * @param bytes The byte array from which to construct a TokenTransfer object.
+   * @return The constructed TokenTransfer object.
+   */
+  [[nodiscard]] static TokenTransfer fromBytes(const std::vector<std::byte>& bytes);
+
+  /**
    * Validate the checksums of the entities in this TokenTransfer.
    *
    * @param client The Client to use to validate the checksums.
@@ -94,6 +105,29 @@ public:
    * @return A pointer to the constructed AccountAmount protobuf object.
    */
   [[nodiscard]] std::unique_ptr<proto::AccountAmount> toProtobuf() const;
+
+  /**
+   * Construct a representative byte array from this TokenTransfer object.
+   *
+   * @return The byte array representing this TokenTransfer object.
+   */
+  [[nodiscard]] std::vector<std::byte> toBytes() const;
+
+  /**
+   * Construct a string representation of this TokenTransfer object.
+   *
+   * @return The string representation of this TokenTransfer object.
+   */
+  [[nodiscard]] std::string toString() const;
+
+  /**
+   * Write this TokenTransfer to an output stream.
+   *
+   * @param os       The output stream.
+   * @param transfer The TokenTransfer to print.
+   * @return The output stream with this TokenTransfer written to it.
+   */
+  friend std::ostream& operator<<(std::ostream& os, const TokenTransfer& transfer);
 
   /**
    * The ID of the token being transferred.

--- a/sdk/main/include/TopicInfo.h
+++ b/sdk/main/include/TopicInfo.h
@@ -30,6 +30,7 @@
 #include <cstdint>
 #include <memory>
 #include <optional>
+#include <ostream>
 #include <string>
 #include <vector>
 
@@ -57,7 +58,7 @@ public:
   /**
    * Construct a TopicInfo object from a byte array.
    *
-   * @param bytes The byte array representing a TopicInfo object.
+   * @param bytes The byte array from which to construct a TopicInfo object.
    * @return The constructed TopicInfo object.
    */
   [[nodiscard]] static TopicInfo fromBytes(const std::vector<std::byte>& bytes);
@@ -75,6 +76,22 @@ public:
    * @return The byte array representing this TopicInfo object.
    */
   [[nodiscard]] std::vector<std::byte> toBytes() const;
+
+  /**
+   * Construct a string representation of this TopicInfo object.
+   *
+   * @return The string representation of this TopicInfo object.
+   */
+  [[nodiscard]] std::string toString() const;
+
+  /**
+   * Write this TopicInfo to an output stream.
+   *
+   * @param os   The output stream.
+   * @param info The TopicInfo to print.
+   * @return The output stream with this TopicInfo written to it.
+   */
+  friend std::ostream& operator<<(std::ostream& os, const TopicInfo& info);
 
   /**
    * The ID of the topic.

--- a/sdk/main/include/TransactionReceipt.h
+++ b/sdk/main/include/TransactionReceipt.h
@@ -33,6 +33,8 @@
 #include <cstddef>
 #include <memory>
 #include <optional>
+#include <ostream>
+#include <string>
 #include <vector>
 
 namespace proto
@@ -92,6 +94,22 @@ public:
    * @return The byte array representing this TransactionReceipt object.
    */
   [[nodiscard]] std::vector<std::byte> toBytes() const;
+
+  /**
+   * Construct a string representation of this TransactionReceipt object.
+   *
+   * @return The string representation of this TransactionReceipt object.
+   */
+  [[nodiscard]] std::string toString() const;
+
+  /**
+   * Write this TransactionReceipt to an output stream.
+   *
+   * @param os      The output stream.
+   * @param receipt The TransactionReceipt to print.
+   * @return The output stream with this TransactionReceipt written to it.
+   */
+  friend std::ostream& operator<<(std::ostream& os, const TransactionReceipt& receipt);
 
   /**
    * Validate the status and throw if it is not a Status::SUCCESS.

--- a/sdk/main/include/TransactionRecord.h
+++ b/sdk/main/include/TransactionRecord.h
@@ -36,6 +36,7 @@
 #include <cstddef>
 #include <memory>
 #include <optional>
+#include <ostream>
 #include <string>
 #include <utility>
 #include <vector>
@@ -73,6 +74,44 @@ public:
   [[nodiscard]] static TransactionRecord fromProtobuf(const proto::TransactionRecord& proto);
 
   /**
+   * Construct a TransactionRecord object from a byte array.
+   *
+   * @param bytes The byte array from which to construct a TransactionRecord object.
+   * @return The constructed TransactionRecord object.
+   */
+  [[nodiscard]] static TransactionRecord fromBytes(const std::vector<std::byte>& bytes);
+
+  /**
+   * Construct a TransactionRecord protobuf object from this TransactionRecord object.
+   *
+   * @return A pointer to the created TransactionRecord protobuf object.
+   */
+  [[nodiscard]] std::unique_ptr<proto::TransactionRecord> toProtobuf() const;
+
+  /**
+   * Construct a representative byte array from this TransactionRecord object.
+   *
+   * @return The byte array representing this TransactionRecord object.
+   */
+  [[nodiscard]] std::vector<std::byte> toBytes() const;
+
+  /**
+   * Construct a string representation of this TransactionRecord object.
+   *
+   * @return The string representation of this TransactionRecord object.
+   */
+  [[nodiscard]] std::string toString() const;
+
+  /**
+   * Write this TransactionRecord to an output stream.
+   *
+   * @param os     The output stream.
+   * @param record The TransactionRecord to print.
+   * @return The output stream with this TransactionRecord written to it.
+   */
+  friend std::ostream& operator<<(std::ostream& os, const TransactionRecord& record);
+
+  /**
    * The status (reach consensus, or failed, or is unknown) and the ID of any new account/file/instance created.
    */
   std::optional<TransactionReceipt> mReceipt;
@@ -81,7 +120,7 @@ public:
    * The hash of the transaction that executed (not the hash of any transaction that failed for having a duplicate
    * transaction ID).
    */
-  std::string mTransactionHash;
+  std::vector<std::byte> mTransactionHash;
 
   /**
    * The consensus timestamp (or uninitialized if the transaction hasn't reached consensus yet).
@@ -91,7 +130,7 @@ public:
   /**
    * The ID of the transaction this record represents.
    */
-  std::optional<TransactionId> mTransactionID;
+  std::optional<TransactionId> mTransactionId;
 
   /**
    * The memo that was submitted as part of the transaction (max 100 bytes).

--- a/sdk/main/include/TransactionResponse.h
+++ b/sdk/main/include/TransactionResponse.h
@@ -28,6 +28,7 @@
 #include <cstdint>
 #include <functional>
 #include <future>
+#include <string>
 #include <vector>
 
 namespace Hedera
@@ -342,6 +343,22 @@ public:
                       const std::chrono::system_clock::duration& timeout,
                       const std::function<void(const TransactionRecord&)>& responseCallback,
                       const std::function<void(const std::exception&)>& exceptionCallback) const;
+
+  /**
+   * Construct a string representation of this TransactionResponse object.
+   *
+   * @return The string representation of this TransactionResponse object.
+   */
+  [[nodiscard]] std::string toString() const;
+
+  /**
+   * Write this TransactionResponse to an output stream.
+   *
+   * @param os       The output stream.
+   * @param response The TransactionResponse to print.
+   * @return The output stream with this TransactionResponse written to it.
+   */
+  friend std::ostream& operator<<(std::ostream& os, const TransactionResponse& response);
 
   /**
    * Set this TransactionResponse's TransactionReceipt validation policy.

--- a/sdk/main/src/AccountBalance.cc
+++ b/sdk/main/src/AccountBalance.cc
@@ -18,7 +18,9 @@
  *
  */
 #include "AccountBalance.h"
+#include "impl/Utilities.h"
 
+#include <nlohmann/json.hpp>
 #include <proto/crypto_get_account_balance.pb.h>
 
 namespace Hedera
@@ -29,6 +31,44 @@ AccountBalance AccountBalance::fromProtobuf(const proto::CryptoGetAccountBalance
   AccountBalance balance;
   balance.mBalance = Hbar(static_cast<int64_t>(proto.balance()), HbarUnit::TINYBAR());
   return balance;
+}
+
+//-----
+AccountBalance AccountBalance::fromBytes(const std::vector<std::byte>& bytes)
+{
+  proto::CryptoGetAccountBalanceResponse proto;
+  proto.ParseFromArray(bytes.data(), static_cast<int>(bytes.size()));
+  return fromProtobuf(proto);
+}
+
+//-----
+std::unique_ptr<proto::CryptoGetAccountBalanceResponse> AccountBalance::toProtobuf() const
+{
+  auto proto = std::make_unique<proto::CryptoGetAccountBalanceResponse>();
+  proto->set_balance(static_cast<uint64_t>(mBalance.toTinybars()));
+  return proto;
+}
+
+//-----
+std::vector<std::byte> AccountBalance::toBytes() const
+{
+  return internal::Utilities::stringToByteVector(toProtobuf()->SerializeAsString());
+}
+
+//-----
+std::string AccountBalance::toString() const
+{
+  nlohmann::json json;
+  json["mBalance"] = mBalance.toString();
+
+  return json.dump();
+}
+
+//-----
+std::ostream& operator<<(std::ostream& os, const AccountBalance& balance)
+{
+  os << balance.toString();
+  return os;
 }
 
 } // namespace Hedera

--- a/sdk/main/src/AccountInfo.cc
+++ b/sdk/main/src/AccountInfo.cc
@@ -146,7 +146,7 @@ std::string AccountInfo::toString() const
   nlohmann::json json;
   json["mAccountId"] = mAccountId.toString();
   json["mContractAccountId"] = mContractAccountId;
-  json["mIsDeleted"] = (mIsDeleted ? "true" : "false");
+  json["mIsDeleted"] = mIsDeleted;
   json["mProxyReceived"] = mProxyReceived.toString();
 
   if (mKey != nullptr)
@@ -155,7 +155,7 @@ std::string AccountInfo::toString() const
   }
 
   json["mBalance"] = mBalance.toString();
-  json["mReceiverSignatureRequired"] = (mReceiverSignatureRequired ? "true" : "false");
+  json["mReceiverSignatureRequired"] = mReceiverSignatureRequired;
   json["mExpirationTime"] = internal::TimestampConverter::toString(mExpirationTime);
   json["mAutoRenewPeriod"] = std::to_string(mAutoRenewPeriod.count());
   json["mMemo"] = mMemo;

--- a/sdk/main/src/AccountRecords.cc
+++ b/sdk/main/src/AccountRecords.cc
@@ -19,7 +19,9 @@
  */
 #include "AccountRecords.h"
 #include "TransactionRecord.h"
+#include "impl/Utilities.h"
 
+#include <nlohmann/json.hpp>
 #include <proto/crypto_get_account_records.pb.h>
 
 namespace Hedera
@@ -36,6 +38,52 @@ AccountRecords AccountRecords::fromProtobuf(const proto::CryptoGetAccountRecords
   }
 
   return records;
+}
+
+//-----
+AccountRecords AccountRecords::fromBytes(const std::vector<std::byte>& bytes)
+{
+  proto::CryptoGetAccountRecordsResponse proto;
+  proto.ParseFromArray(bytes.data(), static_cast<int>(bytes.size()));
+  return fromProtobuf(proto);
+}
+
+//-----
+std::unique_ptr<proto::CryptoGetAccountRecordsResponse> AccountRecords::toProtobuf() const
+{
+  auto proto = std::make_unique<proto::CryptoGetAccountRecordsResponse>();
+  proto->set_allocated_accountid(mAccountId.toProtobuf().release());
+
+  for (const TransactionRecord& record : mRecords)
+  {
+    *proto->add_records() = *record.toProtobuf();
+  }
+
+  return proto;
+}
+
+//-----
+std::vector<std::byte> AccountRecords::toBytes() const
+{
+  return internal::Utilities::stringToByteVector(toProtobuf()->SerializeAsString());
+}
+
+//-----
+std::string AccountRecords::toString() const
+{
+  nlohmann::json json;
+  json["mAccountId"] = mAccountId.toString();
+  std::for_each(mRecords.cbegin(),
+                mRecords.cend(),
+                [&json](const TransactionRecord& record) { json["mRecords"].push_back(record.toString()); });
+  return json.dump();
+}
+
+//-----
+std::ostream& operator<<(std::ostream& os, const AccountRecords& records)
+{
+  os << records.toString();
+  return os;
 }
 
 } // namespace Hedera

--- a/sdk/main/src/AssessedCustomFee.cc
+++ b/sdk/main/src/AssessedCustomFee.cc
@@ -20,6 +20,7 @@
 #include "AssessedCustomFee.h"
 #include "impl/Utilities.h"
 
+#include <nlohmann/json.hpp>
 #include <proto/custom_fees.pb.h>
 
 namespace Hedera
@@ -81,6 +82,31 @@ std::unique_ptr<proto::AssessedCustomFee> AssessedCustomFee::toProtobuf() const
 std::vector<std::byte> AssessedCustomFee::toBytes() const
 {
   return internal::Utilities::stringToByteVector(toProtobuf()->SerializeAsString());
+}
+
+//-----
+std::string AssessedCustomFee::toString() const
+{
+  nlohmann::json json;
+  json["mAmount"] = mAmount;
+
+  if (mTokenId.has_value())
+  {
+    json["mTokenId"] = mTokenId->toString();
+  }
+
+  json["mFeeCollectorAccountId"] = mFeeCollectorAccountId.toString();
+  std::for_each(mPayerAccountIdList.cbegin(),
+                mPayerAccountIdList.cend(),
+                [&json](const AccountId& accountId) { json["mPayerAccountIdList"].push_back(accountId.toString()); });
+  return json.dump();
+}
+
+//-----
+std::ostream& operator<<(std::ostream& os, const AssessedCustomFee& fee)
+{
+  os << fee.toString();
+  return os;
 }
 
 } // namespace Hedera

--- a/sdk/main/src/ContractInfo.cc
+++ b/sdk/main/src/ContractInfo.cc
@@ -19,9 +19,11 @@
  */
 #include "ContractInfo.h"
 #include "impl/DurationConverter.h"
+#include "impl/HexConverter.h"
 #include "impl/TimestampConverter.h"
 #include "impl/Utilities.h"
 
+#include <nlohmann/json.hpp>
 #include <proto/contract_get_info.pb.h>
 
 namespace Hedera
@@ -77,6 +79,89 @@ ContractInfo ContractInfo::fromProtobuf(const proto::ContractGetInfoResponse_Con
   }
 
   return contractInfo;
+}
+
+//-----
+ContractInfo ContractInfo::fromBytes(const std::vector<std::byte>& bytes)
+{
+  proto::ContractGetInfoResponse_ContractInfo proto;
+  proto.ParseFromArray(bytes.data(), static_cast<int>(bytes.size()));
+  return fromProtobuf(proto);
+}
+
+//-----
+std::unique_ptr<proto::ContractGetInfoResponse_ContractInfo> ContractInfo::toProtobuf() const
+{
+  auto proto = std::make_unique<proto::ContractGetInfoResponse_ContractInfo>();
+  proto->set_allocated_contractid(mContractId.toProtobuf().release());
+  proto->set_allocated_accountid(mAccountId.toProtobuf().release());
+  proto->set_contractaccountid(mContractAccountId);
+
+  if (mAdminKey)
+  {
+    proto->set_allocated_adminkey(mAdminKey->toProtobufKey().release());
+  }
+
+  proto->set_allocated_expirationtime(internal::TimestampConverter::toProtobuf(mExpirationTime));
+  proto->set_allocated_autorenewperiod(internal::DurationConverter::toProtobuf(mAutoRenewPeriod));
+  proto->set_storage(static_cast<int64_t>(mStorage));
+  proto->set_memo(mMemo);
+  proto->set_balance(mBalance.toTinybars());
+  proto->set_deleted(mIsDeleted);
+  proto->set_ledger_id(internal::Utilities::byteVectorToString(mLedgerId.toBytes()));
+
+  if (mAutoRenewAccountId.has_value())
+  {
+    proto->set_allocated_auto_renew_account_id(mAutoRenewAccountId->toProtobuf().release());
+  }
+
+  proto->set_max_automatic_token_associations(mMaxAutomaticTokenAssociations);
+  proto->set_allocated_staking_info(mStakingInfo.toProtobuf().release());
+  return proto;
+}
+
+//-----
+std::vector<std::byte> ContractInfo::toBytes() const
+{
+  return internal::Utilities::stringToByteVector(toProtobuf()->SerializeAsString());
+}
+
+//-----
+std::string ContractInfo::toString() const
+{
+  nlohmann::json json;
+  json["mContractId"] = mContractId.toString();
+  json["mAccountId"] = mAccountId.toString();
+  json["mContractAccountId"] = mContractAccountId;
+
+  if (mAdminKey)
+  {
+    json["mAdminKey"] = internal::HexConverter::bytesToHex(mAdminKey->toBytes());
+  }
+
+  json["mExpirationTime"] = internal::TimestampConverter::toString(mExpirationTime);
+  json["mAutoRenewPeriod"] = std::to_string(mAutoRenewPeriod.count());
+  json["mStorage"] = mStorage;
+  json["mMemo"] = mMemo;
+  json["mBalance"] = mBalance.toString();
+  json["mIsDeleted"] = (mIsDeleted ? "true" : "false");
+  json["mLedgerId"] = mLedgerId.toString();
+
+  if (mAutoRenewAccountId.has_value())
+  {
+    json["mAutoRenewAccountId"] = mAutoRenewAccountId->toString();
+  }
+
+  json["mMaxAutomaticTokenAssociations"] = mMaxAutomaticTokenAssociations;
+  json["mStakingInfo"] = mStakingInfo.toString();
+  return json;
+}
+
+//-----
+std::ostream& operator<<(std::ostream& os, const ContractInfo& info)
+{
+  os << info.toString();
+  return os;
 }
 
 } // namespace Hedera

--- a/sdk/main/src/ContractInfo.cc
+++ b/sdk/main/src/ContractInfo.cc
@@ -144,7 +144,7 @@ std::string ContractInfo::toString() const
   json["mStorage"] = mStorage;
   json["mMemo"] = mMemo;
   json["mBalance"] = mBalance.toString();
-  json["mIsDeleted"] = (mIsDeleted ? "true" : "false");
+  json["mIsDeleted"] = mIsDeleted;
   json["mLedgerId"] = mLedgerId.toString();
 
   if (mAutoRenewAccountId.has_value())

--- a/sdk/main/src/ContractLogInfo.cc
+++ b/sdk/main/src/ContractLogInfo.cc
@@ -18,8 +18,10 @@
  *
  */
 #include "ContractLogInfo.h"
+#include "impl/HexConverter.h"
 #include "impl/Utilities.h"
 
+#include <nlohmann/json.hpp>
 #include <proto/contract_call_local.pb.h>
 
 namespace Hedera
@@ -41,19 +43,53 @@ ContractLogInfo ContractLogInfo::fromProtobuf(const proto::ContractLoginfo& prot
 }
 
 //-----
+ContractLogInfo ContractLogInfo::fromBytes(const std::vector<std::byte>& bytes)
+{
+  proto::ContractLoginfo proto;
+  proto.ParseFromArray(bytes.data(), static_cast<int>(bytes.size()));
+  return fromProtobuf(proto);
+}
+
+//-----
 std::unique_ptr<proto::ContractLoginfo> ContractLogInfo::toProtobuf() const
 {
   auto proto = std::make_unique<proto::ContractLoginfo>();
   proto->set_allocated_contractid(mContractId.toProtobuf().release());
   proto->set_bloom(internal::Utilities::byteVectorToString(mBloom));
-
-  for (const auto& topic : mTopics)
-  {
-    proto->add_topic(internal::Utilities::byteVectorToString(topic));
-  }
-
+  std::for_each(mTopics.cbegin(),
+                mTopics.cend(),
+                [&proto](const std::vector<std::byte>& topic)
+                { proto->add_topic(internal::Utilities::byteVectorToString(topic)); });
   proto->set_data(internal::Utilities::byteVectorToString(mData));
   return proto;
+}
+
+//-----
+std::vector<std::byte> ContractLogInfo::toBytes() const
+{
+  return internal::Utilities::stringToByteVector(toProtobuf()->SerializeAsString());
+}
+
+//-----
+std::string ContractLogInfo::toString() const
+{
+  nlohmann::json json;
+  json["mContractId"] = mContractId.toString();
+  json["mBloom"] = internal::HexConverter::bytesToHex(mBloom);
+  std::for_each(mTopics.cbegin(),
+                mTopics.cend(),
+                [&json](const std::vector<std::byte>& topic)
+                { json["mTopics"].push_back(internal::HexConverter::bytesToHex(topic)); });
+  json["mData"] = internal::HexConverter::bytesToHex(mData);
+
+  return json.dump();
+}
+
+//-----
+std::ostream& operator<<(std::ostream& os, const ContractLogInfo& logInfo)
+{
+  os << logInfo.toString();
+  return os;
 }
 
 } // namespace Hedera

--- a/sdk/main/src/ContractNonceInfo.cc
+++ b/sdk/main/src/ContractNonceInfo.cc
@@ -25,8 +25,8 @@
 namespace Hedera
 {
 //-----
-ContractNonceInfo::ContractNonceInfo(const ContractId& contractId, const int64_t& nonce)
-  : mContractId(contractId)
+ContractNonceInfo::ContractNonceInfo(ContractId contractId, const int64_t& nonce)
+  : mContractId(std::move(contractId))
   , mNonce(nonce)
 {
 }
@@ -40,9 +40,7 @@ bool ContractNonceInfo::operator==(const ContractNonceInfo& other) const
 //-----
 ContractNonceInfo ContractNonceInfo::fromProtobuf(const proto::ContractNonceInfo& proto)
 {
-  ContractId contractId = ContractId::fromProtobuf(proto.contract_id());
-  ContractNonceInfo contractNonceInfo = ContractNonceInfo(contractId, proto.nonce());
-  return contractNonceInfo;
+  return ContractNonceInfo(ContractId::fromProtobuf(proto.contract_id()), proto.nonce());
 }
 
 //-----
@@ -57,10 +55,8 @@ ContractNonceInfo ContractNonceInfo::fromBytes(const std::vector<std::byte>& byt
 std::unique_ptr<proto::ContractNonceInfo> ContractNonceInfo::toProtobuf() const
 {
   auto protoContractNonceInfo = std::make_unique<proto::ContractNonceInfo>();
-
   protoContractNonceInfo->set_allocated_contract_id(mContractId.toProtobuf().release());
   protoContractNonceInfo->set_nonce(mNonce);
-
   return protoContractNonceInfo;
 }
 
@@ -77,13 +73,17 @@ std::string ContractNonceInfo::toString() const
 
   if (mNonce)
   {
-    return str + '.' + std::to_string(mNonce);
+    str = '.' + std::to_string(mNonce);
   }
-  else
-  {
-    // Uninitialized case
-    return str + '0';
-  }
+
+  return str;
+}
+
+//-----
+std::ostream& operator<<(std::ostream& os, const ContractNonceInfo& nonceInfo)
+{
+  os << nonceInfo.toString();
+  return os;
 }
 
 } // namespace Hedera

--- a/sdk/main/src/ContractNonceInfo.cc
+++ b/sdk/main/src/ContractNonceInfo.cc
@@ -25,7 +25,7 @@
 namespace Hedera
 {
 //-----
-ContractNonceInfo::ContractNonceInfo(ContractId contractId, const int64_t& nonce)
+ContractNonceInfo::ContractNonceInfo(ContractId contractId, int64_t nonce)
   : mContractId(std::move(contractId))
   , mNonce(nonce)
 {
@@ -40,7 +40,7 @@ bool ContractNonceInfo::operator==(const ContractNonceInfo& other) const
 //-----
 ContractNonceInfo ContractNonceInfo::fromProtobuf(const proto::ContractNonceInfo& proto)
 {
-  return ContractNonceInfo(ContractId::fromProtobuf(proto.contract_id()), proto.nonce());
+  return { ContractId::fromProtobuf(proto.contract_id()), proto.nonce() };
 }
 
 //-----
@@ -73,7 +73,7 @@ std::string ContractNonceInfo::toString() const
 
   if (mNonce)
   {
-    str = '.' + std::to_string(mNonce);
+    str += '.' + std::to_string(mNonce);
   }
 
   return str;

--- a/sdk/main/src/CustomFee.cc
+++ b/sdk/main/src/CustomFee.cc
@@ -67,6 +67,13 @@ std::unique_ptr<CustomFee> CustomFee::fromBytes(const std::vector<std::byte>& by
 }
 
 //-----
+std::ostream& operator<<(std::ostream& os, const CustomFee& fee)
+{
+  os << fee.toString();
+  return os;
+}
+
+//-----
 void CustomFee::validateChecksums(const Client& client) const
 {
   mFeeCollectorAccountId.validateChecksum(client);

--- a/sdk/main/src/CustomFixedFee.cc
+++ b/sdk/main/src/CustomFixedFee.cc
@@ -19,6 +19,7 @@
  */
 #include "CustomFixedFee.h"
 
+#include <nlohmann/json.hpp>
 #include <proto/custom_fees.pb.h>
 
 namespace Hedera
@@ -55,6 +56,22 @@ std::unique_ptr<proto::CustomFee> CustomFixedFee::toProtobuf() const
   }
 
   return fee;
+}
+
+//-----
+std::string CustomFixedFee::toString() const
+{
+  nlohmann::json json;
+  json["mFeeCollectorAccountId"] = mFeeCollectorAccountId.toString();
+  json["mAllCollectorsAreExempt"] = (mAllCollectorsAreExempt ? "true" : "false");
+  json["mAmount"] = mAmount;
+
+  if (mDenominatingTokenId.has_value())
+  {
+    json["mDenominatingTokenId"] = mDenominatingTokenId->toString();
+  }
+
+  return json.dump();
 }
 
 //-----

--- a/sdk/main/src/CustomFixedFee.cc
+++ b/sdk/main/src/CustomFixedFee.cc
@@ -63,7 +63,7 @@ std::string CustomFixedFee::toString() const
 {
   nlohmann::json json;
   json["mFeeCollectorAccountId"] = mFeeCollectorAccountId.toString();
-  json["mAllCollectorsAreExempt"] = (mAllCollectorsAreExempt ? "true" : "false");
+  json["mAllCollectorsAreExempt"] = mAllCollectorsAreExempt;
   json["mAmount"] = mAmount;
 
   if (mDenominatingTokenId.has_value())

--- a/sdk/main/src/CustomFractionalFee.cc
+++ b/sdk/main/src/CustomFractionalFee.cc
@@ -67,7 +67,7 @@ std::string CustomFractionalFee::toString() const
 {
   nlohmann::json json;
   json["mFeeCollectorAccountId"] = mFeeCollectorAccountId.toString();
-  json["mAllCollectorsAreExempt"] = (mAllCollectorsAreExempt ? "true" : "false");
+  json["mAllCollectorsAreExempt"] = mAllCollectorsAreExempt;
   json["mNumerator"] = mNumerator;
   json["mDenominator"] = mDenominator;
   json["mMinAmount"] = mMinAmount;

--- a/sdk/main/src/CustomFractionalFee.cc
+++ b/sdk/main/src/CustomFractionalFee.cc
@@ -19,6 +19,7 @@
  */
 #include "CustomFractionalFee.h"
 
+#include <nlohmann/json.hpp>
 #include <proto/custom_fees.pb.h>
 #include <stdexcept>
 
@@ -59,6 +60,21 @@ std::unique_ptr<proto::CustomFee> CustomFractionalFee::toProtobuf() const
   fee->mutable_fractional_fee()->set_maximum_amount(static_cast<int64_t>(mMaxAmount));
   fee->mutable_fractional_fee()->set_net_of_transfers(mAssessmentMethod == FeeAssessmentMethod::EXCLUSIVE);
   return fee;
+}
+
+//-----
+std::string CustomFractionalFee::toString() const
+{
+  nlohmann::json json;
+  json["mFeeCollectorAccountId"] = mFeeCollectorAccountId.toString();
+  json["mAllCollectorsAreExempt"] = (mAllCollectorsAreExempt ? "true" : "false");
+  json["mNumerator"] = mNumerator;
+  json["mDenominator"] = mDenominator;
+  json["mMinAmount"] = mMinAmount;
+  json["mMaxAmount"] = mMaxAmount;
+  json["mMaxAmount"] = mMaxAmount;
+  json["mAssessmentMethod"] = gFeeAssessmentMethodToString.at(mAssessmentMethod);
+  return json.dump();
 }
 
 //-----

--- a/sdk/main/src/CustomRoyaltyFee.cc
+++ b/sdk/main/src/CustomRoyaltyFee.cc
@@ -19,6 +19,7 @@
  */
 #include "CustomRoyaltyFee.h"
 
+#include <nlohmann/json.hpp>
 #include <proto/custom_fees.pb.h>
 
 namespace Hedera
@@ -61,6 +62,23 @@ std::unique_ptr<proto::CustomFee> CustomRoyaltyFee::toProtobuf() const
   }
 
   return fee;
+}
+
+//-----
+std::string CustomRoyaltyFee::toString() const
+{
+  nlohmann::json json;
+  json["mFeeCollectorAccountId"] = mFeeCollectorAccountId.toString();
+  json["mAllCollectorsAreExempt"] = (mAllCollectorsAreExempt ? "true" : "false");
+  json["mNumerator"] = mNumerator;
+  json["mDenominator"] = mDenominator;
+
+  if (mFallbackFee.has_value())
+  {
+    json["mFallbackFee"] = mFallbackFee->toString();
+  }
+
+  return json.dump();
 }
 
 //-----

--- a/sdk/main/src/CustomRoyaltyFee.cc
+++ b/sdk/main/src/CustomRoyaltyFee.cc
@@ -69,7 +69,7 @@ std::string CustomRoyaltyFee::toString() const
 {
   nlohmann::json json;
   json["mFeeCollectorAccountId"] = mFeeCollectorAccountId.toString();
-  json["mAllCollectorsAreExempt"] = (mAllCollectorsAreExempt ? "true" : "false");
+  json["mAllCollectorsAreExempt"] = mAllCollectorsAreExempt;
   json["mNumerator"] = mNumerator;
   json["mDenominator"] = mDenominator;
 

--- a/sdk/main/src/ExchangeRate.cc
+++ b/sdk/main/src/ExchangeRate.cc
@@ -19,7 +19,9 @@
  */
 #include "ExchangeRate.h"
 #include "impl/TimestampConverter.h"
+#include "impl/Utilities.h"
 
+#include <nlohmann/json.hpp>
 #include <proto/exchange_rate.pb.h>
 
 namespace Hedera
@@ -37,6 +39,48 @@ ExchangeRate::ExchangeRate(int hbar, int cents, const std::chrono::system_clock:
 ExchangeRate ExchangeRate::fromProtobuf(const proto::ExchangeRate& proto)
 {
   return { proto.hbarequiv(), proto.centequiv(), internal::TimestampConverter::fromProtobuf(proto.expirationtime()) };
+}
+
+//-----
+ExchangeRate ExchangeRate::fromBytes(const std::vector<std::byte>& bytes)
+{
+  proto::ExchangeRate proto;
+  proto.ParseFromArray(bytes.data(), static_cast<int>(bytes.size()));
+  return fromProtobuf(proto);
+}
+
+//-----
+std::unique_ptr<proto::ExchangeRate> ExchangeRate::toProtobuf() const
+{
+  auto proto = std::make_unique<proto::ExchangeRate>();
+  proto->set_hbarequiv(mHbars);
+  proto->set_centequiv(mCents);
+  proto->set_allocated_expirationtime(internal::TimestampConverter::toSecondsProtobuf(mExpirationTime));
+  return proto;
+}
+
+//-----
+std::vector<std::byte> ExchangeRate::toBytes() const
+{
+  return internal::Utilities::stringToByteVector(toProtobuf()->SerializeAsString());
+}
+
+//-----
+std::string ExchangeRate::toString() const
+{
+  nlohmann::json json;
+  json["mHbars"] = mHbars;
+  json["mCents"] = mCents;
+  json["mExpirationTime"] = internal::TimestampConverter::toString(mExpirationTime);
+  json["mExchangeRateInCents"] = mExchangeRateInCents;
+  return json.dump();
+}
+
+//-----
+std::ostream& operator<<(std::ostream& os, const ExchangeRate& rate)
+{
+  os << rate.toString();
+  return os;
 }
 
 } // namespace Hedera

--- a/sdk/main/src/ExchangeRates.cc
+++ b/sdk/main/src/ExchangeRates.cc
@@ -18,7 +18,9 @@
  *
  */
 #include "ExchangeRates.h"
+#include "impl/Utilities.h"
 
+#include <nlohmann/json.hpp>
 #include <proto/exchange_rate.pb.h>
 
 namespace Hedera
@@ -42,6 +44,37 @@ ExchangeRates ExchangeRates::fromBytes(const std::vector<std::byte>& bytes)
   proto::ExchangeRateSet proto;
   proto.ParseFromArray(bytes.data(), static_cast<int>(bytes.size()));
   return fromProtobuf(proto);
+}
+
+//-----
+std::unique_ptr<proto::ExchangeRateSet> ExchangeRates::toProtobuf() const
+{
+  auto proto = std::make_unique<proto::ExchangeRateSet>();
+  proto->set_allocated_currentrate(mCurrentRate.toProtobuf().release());
+  proto->set_allocated_nextrate(mNextRate.toProtobuf().release());
+  return proto;
+}
+
+//-----
+std::vector<std::byte> ExchangeRates::toBytes() const
+{
+  return internal::Utilities::stringToByteVector(toProtobuf()->SerializeAsString());
+}
+
+//-----
+std::string ExchangeRates::toString() const
+{
+  nlohmann::json json;
+  json["mCurrentRate"] = mCurrentRate.toString();
+  json["mNextRate"] = mNextRate.toString();
+  return json.dump();
+}
+
+//-----
+std::ostream& operator<<(std::ostream& os, const ExchangeRates& rates)
+{
+  os << rates.toString();
+  return os;
 }
 
 } // namespace Hedera

--- a/sdk/main/src/FileInfo.cc
+++ b/sdk/main/src/FileInfo.cc
@@ -18,11 +18,10 @@
  *
  */
 #include "FileInfo.h"
-#include "KeyList.h"
-#include "exceptions/BadKeyException.h"
 #include "impl/TimestampConverter.h"
 #include "impl/Utilities.h"
 
+#include <nlohmann/json.hpp>
 #include <proto/file_get_info.pb.h>
 
 namespace Hedera
@@ -55,6 +54,55 @@ FileInfo FileInfo::fromProtobuf(const proto::FileGetInfoResponse_FileInfo& proto
   fileInfo.mLedgerId = LedgerId(internal::Utilities::stringToByteVector(proto.ledger_id()));
 
   return fileInfo;
+}
+
+//-----
+FileInfo FileInfo::fromBytes(const std::vector<std::byte>& bytes)
+{
+  proto::FileGetInfoResponse_FileInfo proto;
+  proto.ParseFromArray(bytes.data(), static_cast<int>(bytes.size()));
+  return fromProtobuf(proto);
+}
+
+//-----
+std::unique_ptr<proto::FileGetInfoResponse_FileInfo> FileInfo::toProtobuf() const
+{
+  auto proto = std::make_unique<proto::FileGetInfoResponse_FileInfo>();
+  proto->set_allocated_fileid(mFileId.toProtobuf().release());
+  proto->set_size(static_cast<int64_t>(mSize));
+  proto->set_allocated_expirationtime(internal::TimestampConverter::toProtobuf(mExpirationTime));
+  proto->set_deleted(mIsDeleted);
+  proto->set_allocated_keys(mAdminKeys.toProtobuf().release());
+  proto->set_memo(mMemo);
+  proto->set_ledger_id(internal::Utilities::byteVectorToString(mLedgerId.toBytes()));
+  return proto;
+}
+
+//-----
+std::vector<std::byte> FileInfo::toBytes() const
+{
+  return internal::Utilities::stringToByteVector(toProtobuf()->SerializeAsString());
+}
+
+//-----
+std::string FileInfo::toString() const
+{
+  nlohmann::json json;
+  json["mFileId"] = mFileId.toString();
+  json["mSize"] = mSize;
+  json["mExpirationTime"] = internal::TimestampConverter::toString(mExpirationTime);
+  json["mIsDeleted"] = (mIsDeleted ? "true" : "false");
+  json["mAdminKeys"] = mAdminKeys.toString();
+  json["mMemo"] = mMemo;
+  json["mLedgerId"] = mLedgerId.toString();
+  return json.dump();
+}
+
+//-----
+std::ostream& operator<<(std::ostream& os, const FileInfo& info)
+{
+  os << info.toString();
+  return os;
 }
 
 } // namespace Hedera

--- a/sdk/main/src/FileInfo.cc
+++ b/sdk/main/src/FileInfo.cc
@@ -91,7 +91,7 @@ std::string FileInfo::toString() const
   json["mFileId"] = mFileId.toString();
   json["mSize"] = mSize;
   json["mExpirationTime"] = internal::TimestampConverter::toString(mExpirationTime);
-  json["mIsDeleted"] = (mIsDeleted ? "true" : "false");
+  json["mIsDeleted"] = mIsDeleted;
   json["mAdminKeys"] = mAdminKeys.toString();
   json["mMemo"] = mMemo;
   json["mLedgerId"] = mLedgerId.toString();

--- a/sdk/main/src/HbarTransfer.cc
+++ b/sdk/main/src/HbarTransfer.cc
@@ -18,7 +18,9 @@
  *
  */
 #include "HbarTransfer.h"
+#include "impl/Utilities.h"
 
+#include <nlohmann/json.hpp>
 #include <proto/basic_types.pb.h>
 
 namespace Hedera
@@ -48,14 +50,44 @@ HbarTransfer HbarTransfer::fromProtobuf(const proto::AccountAmount& proto)
 }
 
 //-----
+HbarTransfer HbarTransfer::fromBytes(const std::vector<std::byte>& bytes)
+{
+  proto::AccountAmount proto;
+  proto.ParseFromArray(bytes.data(), static_cast<int>(bytes.size()));
+  return fromProtobuf(proto);
+}
+
+//-----
 std::unique_ptr<proto::AccountAmount> HbarTransfer::toProtobuf() const
 {
   auto proto = std::make_unique<proto::AccountAmount>();
   proto->set_allocated_accountid(mAccountId.toProtobuf().release());
   proto->set_amount(mAmount.toTinybars());
   proto->set_is_approval(mIsApproved);
-
   return proto;
+}
+
+//-----
+std::vector<std::byte> HbarTransfer::toBytes() const
+{
+  return internal::Utilities::stringToByteVector(toProtobuf()->SerializeAsString());
+}
+
+//-----
+std::string HbarTransfer::toString() const
+{
+  nlohmann::json json;
+  json["mAccountId"] = mAccountId.toString();
+  json["mAmount"] = mAmount.toString();
+  json["mIsApproved"] = (mIsApproved ? "true" : "false");
+  return json.dump();
+}
+
+//-----
+std::ostream& operator<<(std::ostream& os, const HbarTransfer& transfer)
+{
+  os << transfer.toString();
+  return os;
 }
 
 } // namespace Hedera

--- a/sdk/main/src/HbarTransfer.cc
+++ b/sdk/main/src/HbarTransfer.cc
@@ -79,7 +79,7 @@ std::string HbarTransfer::toString() const
   nlohmann::json json;
   json["mAccountId"] = mAccountId.toString();
   json["mAmount"] = mAmount.toString();
-  json["mIsApproved"] = (mIsApproved ? "true" : "false");
+  json["mIsApproved"] = mIsApproved;
   return json.dump();
 }
 

--- a/sdk/main/src/KeyList.cc
+++ b/sdk/main/src/KeyList.cc
@@ -18,9 +18,11 @@
  *
  */
 #include "KeyList.h"
+#include "impl/HexConverter.h"
 
 #include <algorithm>
 #include <cstddef>
+#include <nlohmann/json.hpp>
 #include <proto/basic_types.pb.h>
 
 namespace Hedera
@@ -89,6 +91,30 @@ std::unique_ptr<proto::KeyList> KeyList::toProtobuf() const
   }
 
   return keyList;
+}
+
+//-----
+std::string KeyList::toString() const
+{
+  nlohmann::json json;
+
+  if (mThreshold > 0)
+  {
+    json["mThreshold"] = mThreshold;
+  }
+
+  std::for_each(mKeys.cbegin(),
+                mKeys.cend(),
+                [&json](const std::shared_ptr<Key>& key)
+                { json["mKeys"].push_back(internal::HexConverter::bytesToHex(key->toBytes())); });
+  return json.dump();
+}
+
+//-----
+std::ostream& operator<<(std::ostream& os, const KeyList& list)
+{
+  os << list.toString();
+  return os;
 }
 
 //-----

--- a/sdk/main/src/NetworkVersionInfo.cc
+++ b/sdk/main/src/NetworkVersionInfo.cc
@@ -20,6 +20,7 @@
 #include "NetworkVersionInfo.h"
 #include "impl/Utilities.h"
 
+#include <nlohmann/json.hpp>
 #include <proto/network_get_version_info.pb.h>
 
 namespace Hedera
@@ -34,8 +35,8 @@ NetworkVersionInfo::NetworkVersionInfo(const SemanticVersion& hapi, const Semant
 //-----
 NetworkVersionInfo NetworkVersionInfo::fromProtobuf(const proto::NetworkGetVersionInfoResponse& proto)
 {
-  return NetworkVersionInfo(SemanticVersion::fromProtobuf(proto.hapiprotoversion()),
-                            SemanticVersion::fromProtobuf(proto.hederaservicesversion()));
+  return { SemanticVersion::fromProtobuf(proto.hapiprotoversion()),
+           SemanticVersion::fromProtobuf(proto.hederaservicesversion()) };
 }
 
 //-----
@@ -59,6 +60,22 @@ std::unique_ptr<proto::NetworkGetVersionInfoResponse> NetworkVersionInfo::toProt
 std::vector<std::byte> NetworkVersionInfo::toBytes() const
 {
   return internal::Utilities::stringToByteVector(toProtobuf()->SerializeAsString());
+}
+
+//-----
+std::string NetworkVersionInfo::toString() const
+{
+  nlohmann::json json;
+  json["mProtobufVersion"] = mProtobufVersion.toString();
+  json["mServicesVersion"] = mServicesVersion.toString();
+  return json.dump();
+}
+
+//-----
+std::ostream& operator<<(std::ostream& os, const NetworkVersionInfo& info)
+{
+  os << info.toString();
+  return os;
 }
 
 } // namespace Hedera

--- a/sdk/main/src/ProxyStaker.cc
+++ b/sdk/main/src/ProxyStaker.cc
@@ -18,10 +18,10 @@
  *
  */
 #include "ProxyStaker.h"
+#include "impl/Utilities.h"
 
+#include <nlohmann/json.hpp>
 #include <proto/crypto_get_stakers.pb.h>
-
-#include <utility>
 
 namespace Hedera
 {
@@ -36,6 +36,45 @@ ProxyStaker::ProxyStaker(AccountId accountId, int64_t amount)
 ProxyStaker ProxyStaker::fromProtobuf(const proto::ProxyStaker& proto)
 {
   return { AccountId::fromProtobuf(proto.accountid()), proto.amount() };
+}
+
+//-----
+ProxyStaker ProxyStaker::fromBytes(const std::vector<std::byte>& bytes)
+{
+  proto::ProxyStaker proto;
+  proto.ParseFromArray(bytes.data(), static_cast<int>(bytes.size()));
+  return fromProtobuf(proto);
+}
+
+//-----
+std::unique_ptr<proto::ProxyStaker> ProxyStaker::toProtobuf() const
+{
+  auto proto = std::make_unique<proto::ProxyStaker>();
+  proto->set_allocated_accountid(mAccountId.toProtobuf().release());
+  proto->set_amount(mAmount.toTinybars());
+  return proto;
+}
+
+//-----
+std::vector<std::byte> ProxyStaker::toBytes() const
+{
+  return internal::Utilities::stringToByteVector(toProtobuf()->SerializeAsString());
+}
+
+//-----
+std::string ProxyStaker::toString() const
+{
+  nlohmann::json json;
+  json["mAccountId"] = mAccountId.toString();
+  json["mAmount"] = mAmount.toString();
+  return json.dump();
+}
+
+//-----
+std::ostream& operator<<(std::ostream& os, const ProxyStaker& staker)
+{
+  os << staker.toString();
+  return os;
 }
 
 } // namespace Hedera

--- a/sdk/main/src/ScheduleInfo.cc
+++ b/sdk/main/src/ScheduleInfo.cc
@@ -18,9 +18,11 @@
  *
  */
 #include "ScheduleInfo.h"
+#include "impl/HexConverter.h"
 #include "impl/TimestampConverter.h"
 #include "impl/Utilities.h"
 
+#include <nlohmann/json.hpp>
 #include <proto/schedule_get_info.pb.h>
 
 namespace Hedera
@@ -137,6 +139,46 @@ std::unique_ptr<proto::ScheduleInfo> ScheduleInfo::toProtobuf() const
 std::vector<std::byte> ScheduleInfo::toBytes() const
 {
   return internal::Utilities::stringToByteVector(toProtobuf()->SerializeAsString());
+}
+
+//-----
+std::string ScheduleInfo::toString() const
+{
+  nlohmann::json json;
+  json["mScheduleId"] = mScheduleId.toString();
+
+  if (mExecutionTime.has_value())
+  {
+    json["mExecutionTime"] = internal::TimestampConverter::toString(mExecutionTime.value());
+  }
+
+  if (mDeletionTime.has_value())
+  {
+    json["mDeletionTime"] = internal::TimestampConverter::toString(mDeletionTime.value());
+  }
+
+  json["mExpirationTime"] = internal::TimestampConverter::toString(mExpirationTime);
+  json["mMemo"] = mMemo;
+
+  if (mAdminKey)
+  {
+    json["mAdminKey"] = internal::HexConverter::bytesToHex(mAdminKey->toBytes());
+  }
+
+  json["mSignatories"] = mSignatories.toString();
+  json["mCreatorAccountId"] = mCreatorAccountId.toString();
+  json["mPayerAccountId"] = mPayerAccountId.toString();
+  json["mScheduledTransactionId"] = mScheduledTransactionId.toString();
+  json["mLedgerId"] = mLedgerId.toString();
+  json["mWaitForExpiry"] = (mWaitForExpiry ? "true" : "false");
+  return json.dump();
+}
+
+//-----
+std::ostream& operator<<(std::ostream& os, const ScheduleInfo& info)
+{
+  os << info.toString();
+  return os;
 }
 
 } // namespace Hedera

--- a/sdk/main/src/ScheduleInfo.cc
+++ b/sdk/main/src/ScheduleInfo.cc
@@ -170,7 +170,7 @@ std::string ScheduleInfo::toString() const
   json["mPayerAccountId"] = mPayerAccountId.toString();
   json["mScheduledTransactionId"] = mScheduledTransactionId.toString();
   json["mLedgerId"] = mLedgerId.toString();
-  json["mWaitForExpiry"] = (mWaitForExpiry ? "true" : "false");
+  json["mWaitForExpiry"] = mWaitForExpiry;
   return json.dump();
 }
 

--- a/sdk/main/src/StakingInfo.cc
+++ b/sdk/main/src/StakingInfo.cc
@@ -19,7 +19,9 @@
  */
 #include "StakingInfo.h"
 #include "impl/TimestampConverter.h"
+#include "impl/Utilities.h"
 
+#include <nlohmann/json.hpp>
 #include <proto/basic_types.pb.h>
 
 namespace Hedera
@@ -49,6 +51,79 @@ StakingInfo StakingInfo::fromProtobuf(const proto::StakingInfo& proto)
   }
 
   return stakingInfo;
+}
+
+//-----
+StakingInfo StakingInfo::fromBytes(const std::vector<std::byte>& bytes)
+{
+  proto::StakingInfo proto;
+  proto.ParseFromArray(bytes.data(), static_cast<int>(bytes.size()));
+  return fromProtobuf(proto);
+}
+
+//-----
+std::unique_ptr<proto::StakingInfo> StakingInfo::toProtobuf() const
+{
+  auto proto = std::make_unique<proto::StakingInfo>();
+  proto->set_decline_reward(mDeclineRewards);
+
+  if (mStakePeriodStart.has_value())
+  {
+    proto->set_allocated_stake_period_start(internal::TimestampConverter::toProtobuf(mStakePeriodStart.value()));
+  }
+
+  proto->set_pending_reward(mPendingReward.toTinybars());
+  proto->set_staked_to_me(mStakedToMe.toTinybars());
+
+  if (mStakedAccountId.has_value())
+  {
+    proto->set_allocated_staked_account_id(mStakedAccountId->toProtobuf().release());
+  }
+  else if (mStakedNodeId.has_value())
+  {
+    proto->set_staked_node_id(static_cast<int64_t>(mStakedNodeId.value()));
+  }
+
+  return proto;
+}
+
+//-----
+std::vector<std::byte> StakingInfo::toBytes() const
+{
+  return internal::Utilities::stringToByteVector(toProtobuf()->SerializeAsString());
+}
+
+//-----
+std::string StakingInfo::toString() const
+{
+  nlohmann::json json;
+  json["mDeclineRewards"] = (mDeclineRewards ? "true" : "false");
+
+  if (mStakePeriodStart.has_value())
+  {
+    json["mStakePeriodStart"] = internal::TimestampConverter::toString(mStakePeriodStart.value());
+  }
+
+  json["mPendingReward"] = mPendingReward.toString();
+  json["mStakedToMe"] = mStakedToMe.toString();
+
+  if (mStakedAccountId.has_value())
+  {
+    json["mStakedAccountId"] = mStakedAccountId->toString();
+  }
+  else if (mStakedNodeId.has_value())
+  {
+    json["mStakedNodeId"] = mStakedNodeId.value();
+  }
+
+  return json.dump();
+}
+
+//-----
+std::ostream& operator<<(std::ostream& os, const StakingInfo& info)
+{
+  os << info.toString();
+  return os;
 }
 
 } // namespace Hedera

--- a/sdk/main/src/StakingInfo.cc
+++ b/sdk/main/src/StakingInfo.cc
@@ -97,7 +97,7 @@ std::vector<std::byte> StakingInfo::toBytes() const
 std::string StakingInfo::toString() const
 {
   nlohmann::json json;
-  json["mDeclineRewards"] = (mDeclineRewards ? "true" : "false");
+  json["mDeclineRewards"] = mDeclineRewards;
 
   if (mStakePeriodStart.has_value())
   {

--- a/sdk/main/src/TokenAssociation.cc
+++ b/sdk/main/src/TokenAssociation.cc
@@ -20,6 +20,7 @@
 #include "TokenAssociation.h"
 #include "impl/Utilities.h"
 
+#include <nlohmann/json.hpp>
 #include <proto/custom_fees.pb.h>
 
 namespace Hedera
@@ -63,6 +64,15 @@ std::unique_ptr<proto::TokenAssociation> TokenAssociation::toProtobuf() const
 std::vector<std::byte> TokenAssociation::toBytes() const
 {
   return internal::Utilities::stringToByteVector(toProtobuf()->SerializeAsString());
+}
+
+//-----
+std::string TokenAssociation::toString() const
+{
+  nlohmann::json json;
+  json["mAccountId"] = mAccountId.toString();
+  json["mTokenId"] = mTokenId.toString();
+  return json.dump();
 }
 
 } // namespace Hedera

--- a/sdk/main/src/TokenInfo.cc
+++ b/sdk/main/src/TokenInfo.cc
@@ -251,15 +251,15 @@ std::string TokenInfo::toString() const
 
   if (mDefaultFreezeStatus.has_value())
   {
-    json["mDefaultFreezeStatus"] = (mDefaultFreezeStatus.value() ? "true" : "false");
+    json["mDefaultFreezeStatus"] = mDefaultFreezeStatus.value();
   }
 
   if (mDefaultKycStatus.has_value())
   {
-    json["mDefaultKycStatus"] = (mDefaultKycStatus.value() ? "true" : "false");
+    json["mDefaultKycStatus"] = mDefaultKycStatus.value();
   }
 
-  json["mIsDeleted"] = (mIsDeleted ? "true" : "false");
+  json["mIsDeleted"] = mIsDeleted;
   json["mAutoRenewAccountId"] = mAutoRenewAccountId.toString();
   json["mAutoRenewPeriod"] = std::to_string(mAutoRenewPeriod.count());
   json["mExpirationTime"] = internal::TimestampConverter::toString(mExpirationTime);
@@ -284,7 +284,7 @@ std::string TokenInfo::toString() const
 
   if (mPauseStatus.has_value())
   {
-    json["mPauseStatus"] = (mPauseStatus.value() ? "true" : "false");
+    json["mPauseStatus"] = mPauseStatus.value();
   }
 
   json["mLedgerId"] = mLedgerId.toString();

--- a/sdk/main/src/TokenNftInfo.cc
+++ b/sdk/main/src/TokenNftInfo.cc
@@ -18,9 +18,11 @@
  *
  */
 #include "TokenNftInfo.h"
+#include "impl/HexConverter.h"
 #include "impl/TimestampConverter.h"
 #include "impl/Utilities.h"
 
+#include <nlohmann/json.hpp>
 #include <proto/token_get_nft_info.pb.h>
 
 namespace Hedera
@@ -86,6 +88,31 @@ std::unique_ptr<proto::TokenNftInfo> TokenNftInfo::toProtobuf() const
 std::vector<std::byte> TokenNftInfo::toBytes() const
 {
   return internal::Utilities::stringToByteVector(toProtobuf()->SerializeAsString());
+}
+
+//-----
+std::string TokenNftInfo::toString() const
+{
+  nlohmann::json json;
+  json["mNftId"] = mNftId.toString();
+  json["mAccountId"] = mAccountId.toString();
+  json["mCreationTime"] = internal::TimestampConverter::toString(mCreationTime);
+  json["mMetadata"] = internal::HexConverter::bytesToHex(mMetadata);
+  json["mLedgerId"] = mLedgerId.toString();
+
+  if (mSpenderId.has_value())
+  {
+    json["mSpenderId"] = mSpenderId->toString();
+  }
+
+  return json.dump();
+}
+
+//-----
+std::ostream& operator<<(std::ostream& os, const TokenNftInfo& info)
+{
+  os << info.toString();
+  return os;
 }
 
 } // namespace Hedera

--- a/sdk/main/src/TokenNftTransfer.cc
+++ b/sdk/main/src/TokenNftTransfer.cc
@@ -18,7 +18,9 @@
  *
  */
 #include "TokenNftTransfer.h"
+#include "impl/Utilities.h"
 
+#include <nlohmann/json.hpp>
 #include <proto/basic_types.pb.h>
 
 namespace Hedera
@@ -35,14 +37,22 @@ TokenNftTransfer::TokenNftTransfer(NftId nftId, AccountId sender, AccountId rece
 //-----
 TokenNftTransfer TokenNftTransfer::fromProtobuf(const proto::NftTransfer& proto, const TokenId& tokenId)
 {
-  return TokenNftTransfer(NftId(tokenId, static_cast<uint64_t>(proto.serialnumber())),
-                          AccountId::fromProtobuf(proto.senderaccountid()),
-                          AccountId::fromProtobuf(proto.receiveraccountid()),
-                          proto.is_approval());
+  return { NftId(tokenId, static_cast<uint64_t>(proto.serialnumber())),
+           AccountId::fromProtobuf(proto.senderaccountid()),
+           AccountId::fromProtobuf(proto.receiveraccountid()),
+           proto.is_approval() };
 }
 
 //-----
-void TokenNftTransfer::validateChecksums(const Hedera::Client& client) const
+TokenNftTransfer TokenNftTransfer::fromBytes(const std::vector<std::byte>& bytes)
+{
+  proto::NftTransfer proto;
+  proto.ParseFromArray(bytes.data(), static_cast<int>(bytes.size()));
+  return fromProtobuf(proto, TokenId());
+}
+
+//-----
+void TokenNftTransfer::validateChecksums(const Client& client) const
 {
   mNftId.mTokenId.validateChecksum(client);
   mSenderAccountId.validateChecksum(client);
@@ -58,6 +68,30 @@ std::unique_ptr<proto::NftTransfer> TokenNftTransfer::toProtobuf() const
   proto->set_serialnumber(static_cast<int64_t>(mNftId.mSerialNum));
   proto->set_is_approval(mIsApproval);
   return proto;
+}
+
+//-----
+std::vector<std::byte> TokenNftTransfer::toBytes() const
+{
+  return internal::Utilities::stringToByteVector(toProtobuf()->SerializeAsString());
+}
+
+//-----
+std::string TokenNftTransfer::toString() const
+{
+  nlohmann::json json;
+  json["mNftId"] = mNftId.toString();
+  json["mSenderAccountId"] = mSenderAccountId.toString();
+  json["mReceiverAccountId"] = mReceiverAccountId.toString();
+  json["mIsApproval"] = (mIsApproval ? "true" : "false");
+  return json.dump();
+}
+
+//-----
+std::ostream& operator<<(std::ostream& os, const TokenNftTransfer& transfer)
+{
+  os << transfer.toString();
+  return os;
 }
 
 } // namespace Hedera

--- a/sdk/main/src/TokenNftTransfer.cc
+++ b/sdk/main/src/TokenNftTransfer.cc
@@ -83,7 +83,7 @@ std::string TokenNftTransfer::toString() const
   json["mNftId"] = mNftId.toString();
   json["mSenderAccountId"] = mSenderAccountId.toString();
   json["mReceiverAccountId"] = mReceiverAccountId.toString();
-  json["mIsApproval"] = (mIsApproval ? "true" : "false");
+  json["mIsApproval"] = mIsApproval;
   return json.dump();
 }
 

--- a/sdk/main/src/TokenTransfer.cc
+++ b/sdk/main/src/TokenTransfer.cc
@@ -89,7 +89,7 @@ std::string TokenTransfer::toString() const
   json["mAccountId"] = mAccountId.toString();
   json["mAmount"] = mAmount;
   json["mExpectedDecimals"] = mExpectedDecimals;
-  json["mIsApproval"] = (mIsApproval ? "true" : "false");
+  json["mIsApproval"] = mIsApproval;
   return json.dump();
 }
 

--- a/sdk/main/src/TokenTransfer.cc
+++ b/sdk/main/src/TokenTransfer.cc
@@ -18,14 +18,16 @@
  *
  */
 #include "TokenTransfer.h"
+#include "impl/Utilities.h"
 
+#include <nlohmann/json.hpp>
 #include <proto/basic_types.pb.h>
 
 namespace Hedera
 {
 //-----
-TokenTransfer::TokenTransfer(const TokenId& tokenId, AccountId accountId, int64_t amount, bool isApproved)
-  : mTokenId(tokenId)
+TokenTransfer::TokenTransfer(TokenId tokenId, AccountId accountId, int64_t amount, bool isApproved)
+  : mTokenId(std::move(tokenId))
   , mAccountId(std::move(accountId))
   , mAmount(amount)
   , mIsApproval(isApproved)
@@ -33,12 +35,8 @@ TokenTransfer::TokenTransfer(const TokenId& tokenId, AccountId accountId, int64_
 }
 
 //-----
-TokenTransfer::TokenTransfer(const TokenId& tokenId,
-                             AccountId accountId,
-                             int64_t amount,
-                             uint32_t decimals,
-                             bool isApproved)
-  : mTokenId(tokenId)
+TokenTransfer::TokenTransfer(TokenId tokenId, AccountId accountId, int64_t amount, uint32_t decimals, bool isApproved)
+  : mTokenId(std::move(tokenId))
   , mAccountId(std::move(accountId))
   , mAmount(amount)
   , mExpectedDecimals(decimals)
@@ -49,8 +47,15 @@ TokenTransfer::TokenTransfer(const TokenId& tokenId,
 //-----
 TokenTransfer TokenTransfer::fromProtobuf(const proto::AccountAmount& proto, const TokenId& tokenId, uint32_t decimals)
 {
-  return TokenTransfer(
-    tokenId, AccountId::fromProtobuf(proto.accountid()), proto.amount(), decimals, proto.is_approval());
+  return { tokenId, AccountId::fromProtobuf(proto.accountid()), proto.amount(), decimals, proto.is_approval() };
+}
+
+//-----
+TokenTransfer TokenTransfer::fromBytes(const std::vector<std::byte>& bytes)
+{
+  proto::AccountAmount proto;
+  proto.ParseFromArray(bytes.data(), static_cast<int>(bytes.size()));
+  return fromProtobuf(proto, TokenId(), 0U);
 }
 
 //-----
@@ -68,6 +73,31 @@ std::unique_ptr<proto::AccountAmount> TokenTransfer::toProtobuf() const
   accountAmount->set_amount(mAmount);
   accountAmount->set_is_approval(mIsApproval);
   return accountAmount;
+}
+
+//-----
+std::vector<std::byte> TokenTransfer::toBytes() const
+{
+  return internal::Utilities::stringToByteVector(toProtobuf()->SerializeAsString());
+}
+
+//-----
+std::string TokenTransfer::toString() const
+{
+  nlohmann::json json;
+  json["mTokenId"] = mTokenId.toString();
+  json["mAccountId"] = mAccountId.toString();
+  json["mAmount"] = mAmount;
+  json["mExpectedDecimals"] = mExpectedDecimals;
+  json["mIsApproval"] = (mIsApproval ? "true" : "false");
+  return json.dump();
+}
+
+//-----
+std::ostream& operator<<(std::ostream& os, const TokenTransfer& transfer)
+{
+  os << transfer.toString();
+  return os;
 }
 
 } // namespace Hedera

--- a/sdk/main/src/TopicInfo.cc
+++ b/sdk/main/src/TopicInfo.cc
@@ -19,9 +19,11 @@
  */
 #include "TopicInfo.h"
 #include "impl/DurationConverter.h"
+#include "impl/HexConverter.h"
 #include "impl/TimestampConverter.h"
 #include "impl/Utilities.h"
 
+#include <nlohmann/json.hpp>
 #include <proto/consensus_get_topic_info.pb.h>
 
 namespace Hedera
@@ -121,6 +123,47 @@ std::unique_ptr<proto::ConsensusGetTopicInfoResponse> TopicInfo::toProtobuf() co
 std::vector<std::byte> TopicInfo::toBytes() const
 {
   return internal::Utilities::stringToByteVector(toProtobuf()->SerializeAsString());
+}
+
+//-----
+std::string TopicInfo::toString() const
+{
+  nlohmann::json json;
+  json["mTopicId"] = mTopicId.toString();
+  json["mMemo"] = mMemo;
+  json["mRunningHash"] = internal::HexConverter::bytesToHex(mRunningHash);
+  json["mSequenceNumber"] = mSequenceNumber;
+  json["mExpirationTime"] = internal::TimestampConverter::toString(mExpirationTime);
+
+  if (mAdminKey)
+  {
+    json["mAdminKey"] = internal::HexConverter::bytesToHex(mAdminKey->toBytes());
+  }
+
+  if (mSubmitKey)
+  {
+    json["mSubmitKey"] = internal::HexConverter::bytesToHex(mSubmitKey->toBytes());
+  }
+
+  if (mAutoRenewPeriod.has_value())
+  {
+    json["mAutoRenewPeriod"] = std::to_string(mAutoRenewPeriod->count());
+  }
+
+  if (mAutoRenewAccountId.has_value())
+  {
+    json["mAutoRenewAccountId"] = mAutoRenewAccountId->toString();
+  }
+
+  json["mLedgerId"] = mLedgerId.toString();
+  return json.dump();
+}
+
+//-----
+std::ostream& operator<<(std::ostream& os, const TopicInfo& info)
+{
+  os << info.toString();
+  return os;
 }
 
 } // namespace Hedera

--- a/sdk/main/src/TransactionResponse.cc
+++ b/sdk/main/src/TransactionResponse.cc
@@ -18,12 +18,14 @@
  *
  */
 #include "TransactionResponse.h"
-
 #include "Client.h"
 #include "TransactionReceipt.h"
 #include "TransactionReceiptQuery.h"
 #include "TransactionRecord.h"
 #include "TransactionRecordQuery.h"
+#include "impl/HexConverter.h"
+
+#include <nlohmann/json.hpp>
 
 namespace Hedera
 {
@@ -214,6 +216,23 @@ void TransactionResponse::getRecordAsync(const Client& client,
   {
     exceptionCallback(exception);
   }
+}
+
+//-----
+std::string TransactionResponse::toString() const
+{
+  nlohmann::json json;
+  json["mNodeId"] = mNodeId.toString();
+  json["mTransactionHash"] = internal::HexConverter::bytesToHex(mTransactionHash);
+  json["mTransactionId"] = mTransactionId.toString();
+  return json.dump();
+}
+
+//-----
+std::ostream& operator<<(std::ostream& os, const TransactionResponse& response)
+{
+  os << response.toString();
+  return os;
 }
 
 //-----

--- a/sdk/tests/integration/AccountBalanceQueryIntegrationTests.cc
+++ b/sdk/tests/integration/AccountBalanceQueryIntegrationTests.cc
@@ -48,7 +48,7 @@ TEST_F(AccountBalanceQueryIntegrationTests, AccountId)
   EXPECT_NO_THROW(accountBalance = AccountBalanceQuery().setAccountId(AccountId(1023ULL)).execute(getTestClient()));
 
   // Then
-  EXPECT_EQ(accountBalance.getBalance(), Hbar(10000LL));
+  EXPECT_EQ(accountBalance.mBalance, Hbar(10000LL));
 }
 
 //-----
@@ -98,7 +98,7 @@ TEST_F(AccountBalanceQueryIntegrationTests, ContractId)
   EXPECT_NO_THROW(accountBalance = AccountBalanceQuery().setContractId(contractId).execute(getTestClient()));
 
   // Then
-  EXPECT_EQ(accountBalance.getBalance(), Hbar(0LL));
+  EXPECT_EQ(accountBalance.mBalance, Hbar(0LL));
 
   // Clean up
   ASSERT_NO_THROW(ContractDeleteTransaction()

--- a/sdk/tests/integration/AccountCreateTransactionIntegrationTests.cc
+++ b/sdk/tests/integration/AccountCreateTransactionIntegrationTests.cc
@@ -88,8 +88,8 @@ TEST_F(AccountCreateTransactionIntegrationTests, ExecuteAccountCreateTransaction
   EXPECT_EQ(accountInfo.mAutoRenewPeriod, testAutoRenewPeriod);
   EXPECT_EQ(accountInfo.mMemo, testMemo);
   EXPECT_EQ(accountInfo.mMaxAutomaticTokenAssociations, testMaxAutomaticTokenAssociations);
-  EXPECT_TRUE(accountInfo.mStakingInfo.getDeclineReward());
-  EXPECT_FALSE(accountInfo.mStakingInfo.getStakedAccountId().has_value());
+  EXPECT_TRUE(accountInfo.mStakingInfo.mDeclineRewards);
+  EXPECT_FALSE(accountInfo.mStakingInfo.mStakedAccountId.has_value());
 
   // Clean up
   ASSERT_NO_THROW(AccountDeleteTransaction()
@@ -135,16 +135,16 @@ TEST_F(AccountCreateTransactionIntegrationTests, MutuallyExclusiveStakingIds)
   ASSERT_NO_THROW(accountInfo = AccountInfoQuery().setAccountId(accountIdStakedAccountId).execute(getTestClient()));
   EXPECT_EQ(accountInfo.mAccountId, accountIdStakedAccountId);
   EXPECT_EQ(accountInfo.mKey->toBytes(), testPublicKey->toBytes());
-  ASSERT_TRUE(accountInfo.mStakingInfo.getStakedAccountId().has_value());
-  EXPECT_EQ(accountInfo.mStakingInfo.getStakedAccountId(), operatorAccountId);
-  EXPECT_FALSE(accountInfo.mStakingInfo.getStakedNodeId().has_value());
+  ASSERT_TRUE(accountInfo.mStakingInfo.mStakedAccountId.has_value());
+  EXPECT_EQ(accountInfo.mStakingInfo.mStakedAccountId, operatorAccountId);
+  EXPECT_FALSE(accountInfo.mStakingInfo.mStakedNodeId.has_value());
 
   ASSERT_NO_THROW(accountInfo = AccountInfoQuery().setAccountId(accountIdStakedNodeId).execute(getTestClient()));
   EXPECT_EQ(accountInfo.mAccountId, accountIdStakedNodeId);
   EXPECT_EQ(accountInfo.mKey->toBytes(), testPublicKey->toBytes());
-  EXPECT_FALSE(accountInfo.mStakingInfo.getStakedAccountId().has_value());
-  ASSERT_TRUE(accountInfo.mStakingInfo.getStakedNodeId().has_value());
-  EXPECT_EQ(accountInfo.mStakingInfo.getStakedNodeId(), nodeId);
+  EXPECT_FALSE(accountInfo.mStakingInfo.mStakedAccountId.has_value());
+  ASSERT_TRUE(accountInfo.mStakingInfo.mStakedNodeId.has_value());
+  EXPECT_EQ(accountInfo.mStakingInfo.mStakedNodeId, nodeId);
 
   // Clean up
   ASSERT_NO_THROW(AccountDeleteTransaction()

--- a/sdk/tests/integration/AccountRecordsQueryIntegrationTests.cc
+++ b/sdk/tests/integration/AccountRecordsQueryIntegrationTests.cc
@@ -73,7 +73,7 @@ TEST_F(AccountRecordsQueryIntegrationTests, ExecuteAccountRecordsQuery)
   EXPECT_NO_THROW(accountRecords = AccountRecordsQuery().setAccountId(accountId).execute(getTestClient()));
 
   // Then
-  EXPECT_TRUE(accountRecords.getRecords().empty());
+  EXPECT_TRUE(accountRecords.mRecords.empty());
 
   // Clean up
   ASSERT_NO_THROW(AccountDeleteTransaction()

--- a/sdk/tests/integration/AccountUpdateTransactionIntegrationTests.cc
+++ b/sdk/tests/integration/AccountUpdateTransactionIntegrationTests.cc
@@ -98,9 +98,9 @@ TEST_F(AccountUpdateTransactionIntegrationTests, ExecuteAccountUpdateTransaction
   EXPECT_EQ(accountInfo.mAutoRenewPeriod, newAutoRenewPeriod);
   EXPECT_EQ(accountInfo.mMemo, newAccountMemo);
   EXPECT_EQ(accountInfo.mMaxAutomaticTokenAssociations, newMaxAutomaticTokenAssociations);
-  ASSERT_TRUE(accountInfo.mStakingInfo.getStakedNodeId().has_value());
-  EXPECT_EQ(accountInfo.mStakingInfo.getStakedNodeId(), newStakedNodeId);
-  EXPECT_EQ(accountInfo.mStakingInfo.getDeclineReward(), newDeclineStakingRewards);
+  ASSERT_TRUE(accountInfo.mStakingInfo.mStakedNodeId.has_value());
+  EXPECT_EQ(accountInfo.mStakingInfo.mStakedNodeId, newStakedNodeId);
+  EXPECT_EQ(accountInfo.mStakingInfo.mDeclineRewards, newDeclineStakingRewards);
 
   // Clean up
   ASSERT_NO_THROW(AccountDeleteTransaction()

--- a/sdk/tests/integration/ContractUpdateTransactionIntegrationTests.cc
+++ b/sdk/tests/integration/ContractUpdateTransactionIntegrationTests.cc
@@ -96,7 +96,7 @@ TEST_F(ContractUpdateTransactionIntegrationTests, ExecuteContractUpdateTransacti
   EXPECT_EQ(contractInfo.mAdminKey->toBytes(), newAdminKey->getPublicKey()->toBytes());
   EXPECT_EQ(contractInfo.mAutoRenewPeriod, newAutoRenewPeriod);
   EXPECT_EQ(contractInfo.mMemo, newMemo);
-  EXPECT_TRUE(contractInfo.mStakingInfo.getDeclineReward());
+  EXPECT_TRUE(contractInfo.mStakingInfo.mDeclineRewards);
 
   // Clean up
   ASSERT_NO_THROW(txReceipt = ContractDeleteTransaction()

--- a/sdk/tests/unit/AccountBalanceUnitTests.cc
+++ b/sdk/tests/unit/AccountBalanceUnitTests.cc
@@ -44,5 +44,5 @@ TEST_F(AccountBalanceUnitTests, DeserializeAccountBalanceFromProtobuf)
   const AccountBalance accountBalance = AccountBalance::fromProtobuf(testProtoAccountBalance);
 
   // Then
-  EXPECT_EQ(accountBalance.getBalance().toTinybars(), getTestBalance().toTinybars());
+  EXPECT_EQ(accountBalance.mBalance, getTestBalance());
 }

--- a/sdk/tests/unit/AccountInfoUnitTests.cc
+++ b/sdk/tests/unit/AccountInfoUnitTests.cc
@@ -136,11 +136,11 @@ TEST_F(AccountInfoUnitTests, FromProtobuf)
   EXPECT_EQ(accountInfo.mMaxAutomaticTokenAssociations, getTestMaxAutomaticTokenAssociations());
   EXPECT_EQ(accountInfo.mPublicKeyAlias->toBytesDer(), getTestPublicKeyAlias()->toBytesDer());
   EXPECT_EQ(accountInfo.mLedgerId.toBytes(), getTestLedgerId().toBytes());
-  EXPECT_EQ(accountInfo.mStakingInfo.getDeclineReward(), getTestDeclineReward());
-  EXPECT_EQ(accountInfo.mStakingInfo.getStakePeriodStart(), getTestStakePeriodStart());
-  EXPECT_EQ(accountInfo.mStakingInfo.getPendingReward(), getTestPendingReward());
-  EXPECT_EQ(accountInfo.mStakingInfo.getStakedToMe(), getTestStakedToMe());
-  ASSERT_TRUE(accountInfo.mStakingInfo.getStakedAccountId().has_value());
-  EXPECT_EQ(accountInfo.mStakingInfo.getStakedAccountId(), getTestStakedAccountId());
-  EXPECT_FALSE(accountInfo.mStakingInfo.getStakedNodeId().has_value());
+  EXPECT_EQ(accountInfo.mStakingInfo.mDeclineRewards, getTestDeclineReward());
+  EXPECT_EQ(accountInfo.mStakingInfo.mStakePeriodStart, getTestStakePeriodStart());
+  EXPECT_EQ(accountInfo.mStakingInfo.mPendingReward, getTestPendingReward());
+  EXPECT_EQ(accountInfo.mStakingInfo.mStakedToMe, getTestStakedToMe());
+  ASSERT_TRUE(accountInfo.mStakingInfo.mStakedAccountId.has_value());
+  EXPECT_EQ(accountInfo.mStakingInfo.mStakedAccountId, getTestStakedAccountId());
+  EXPECT_FALSE(accountInfo.mStakingInfo.mStakedNodeId.has_value());
 }

--- a/sdk/tests/unit/AccountRecordsUnitTests.cc
+++ b/sdk/tests/unit/AccountRecordsUnitTests.cc
@@ -46,7 +46,7 @@ TEST_F(AccountRecordsUnitTests, DeserializeAccountRecordsFromProtobuf)
   const AccountRecords accountRecords = AccountRecords::fromProtobuf(accountRecordsResponse);
 
   // Then
-  EXPECT_EQ(accountRecords.getAccountId(), getTestAccountId());
+  EXPECT_EQ(accountRecords.mAccountId, getTestAccountId());
   // Don't bother testing records data as that's already tested in TransactionRecordTest
-  EXPECT_EQ(accountRecords.getRecords().size(), 2);
+  EXPECT_EQ(accountRecords.mRecords.size(), 2);
 }

--- a/sdk/tests/unit/ContractInfoUnitTests.cc
+++ b/sdk/tests/unit/ContractInfoUnitTests.cc
@@ -127,11 +127,11 @@ TEST_F(ContractInfoUnitTests, FromProtobuf)
   EXPECT_EQ(contractInfo.mAutoRenewAccountId, getTestAutoRenewAccountId());
   EXPECT_EQ(contractInfo.mMaxAutomaticTokenAssociations, getTestMaxAutomaticTokenAssociations());
 
-  EXPECT_EQ(contractInfo.mStakingInfo.getDeclineReward(), getTestDeclineReward());
-  EXPECT_EQ(contractInfo.mStakingInfo.getStakePeriodStart(), getTestStakePeriodStart());
-  EXPECT_EQ(contractInfo.mStakingInfo.getPendingReward(), getTestPendingReward());
-  EXPECT_EQ(contractInfo.mStakingInfo.getStakedToMe(), getTestStakedToMe());
-  ASSERT_TRUE(contractInfo.mStakingInfo.getStakedAccountId().has_value());
-  EXPECT_EQ(contractInfo.mStakingInfo.getStakedAccountId(), getTestStakedAccountId());
-  EXPECT_FALSE(contractInfo.mStakingInfo.getStakedNodeId().has_value());
+  EXPECT_EQ(contractInfo.mStakingInfo.mDeclineRewards, getTestDeclineReward());
+  EXPECT_EQ(contractInfo.mStakingInfo.mStakePeriodStart, getTestStakePeriodStart());
+  EXPECT_EQ(contractInfo.mStakingInfo.mPendingReward, getTestPendingReward());
+  EXPECT_EQ(contractInfo.mStakingInfo.mStakedToMe, getTestStakedToMe());
+  ASSERT_TRUE(contractInfo.mStakingInfo.mStakedAccountId.has_value());
+  EXPECT_EQ(contractInfo.mStakingInfo.mStakedAccountId, getTestStakedAccountId());
+  EXPECT_FALSE(contractInfo.mStakingInfo.mStakedNodeId.has_value());
 }

--- a/sdk/tests/unit/StakingInfoUnitTests.cc
+++ b/sdk/tests/unit/StakingInfoUnitTests.cc
@@ -62,12 +62,12 @@ TEST_F(StakingInfoUnitTests, FromProtobuf)
   const StakingInfo stakingInfo = StakingInfo::fromProtobuf(protoStakingInfo);
 
   // Then
-  EXPECT_EQ(stakingInfo.getDeclineReward(), getTestDeclineReward());
-  ASSERT_TRUE(stakingInfo.getStakePeriodStart().has_value());
-  EXPECT_EQ(*stakingInfo.getStakePeriodStart(), getTestStakePeriodStart());
-  EXPECT_EQ(stakingInfo.getPendingReward().toTinybars(), getTestPendingReward());
-  EXPECT_EQ(stakingInfo.getStakedToMe().toTinybars(), getTestStakedToMe());
-  EXPECT_FALSE(stakingInfo.getStakedAccountId().has_value());
-  ASSERT_TRUE(stakingInfo.getStakedNodeId().has_value());
-  EXPECT_EQ(*stakingInfo.getStakedNodeId(), getTestStakedNodeId());
+  EXPECT_EQ(stakingInfo.mDeclineRewards, getTestDeclineReward());
+  ASSERT_TRUE(stakingInfo.mStakePeriodStart.has_value());
+  EXPECT_EQ(*stakingInfo.mStakePeriodStart, getTestStakePeriodStart());
+  EXPECT_EQ(stakingInfo.mPendingReward.toTinybars(), getTestPendingReward());
+  EXPECT_EQ(stakingInfo.mStakedToMe.toTinybars(), getTestStakedToMe());
+  EXPECT_FALSE(stakingInfo.mStakedAccountId.has_value());
+  ASSERT_TRUE(stakingInfo.mStakedNodeId.has_value());
+  EXPECT_EQ(*stakingInfo.mStakedNodeId, getTestStakedNodeId());
 }

--- a/sdk/tests/unit/TransactionRecordUnitTests.cc
+++ b/sdk/tests/unit/TransactionRecordUnitTests.cc
@@ -41,7 +41,7 @@ TEST_F(TransactionRecordUnitTests, FromProtobuf)
   const auto accountIdTo = AccountId(3ULL);
   const auto accountIdFrom = AccountId(4ULL);
   const int64_t amount = 10LL;
-  const std::string txHash = "txHash";
+  const std::vector<std::byte> txHash = { std::byte(0x01), std::byte(0x02), std::byte(0x03) };
   const std::chrono::system_clock::time_point now = std::chrono::system_clock::now();
   const std::string txMemo = "txMemo";
   const uint64_t txFee = 10ULL;
@@ -61,7 +61,7 @@ TEST_F(TransactionRecordUnitTests, FromProtobuf)
 
   proto::TransactionRecord protoTransactionRecord;
   protoTransactionRecord.mutable_receipt()->set_allocated_accountid(accountIdFrom.toProtobuf().release());
-  protoTransactionRecord.set_transactionhash(txHash);
+  protoTransactionRecord.set_transactionhash(internal::Utilities::byteVectorToString(txHash));
   protoTransactionRecord.set_allocated_consensustimestamp(internal::TimestampConverter::toProtobuf(now));
   protoTransactionRecord.set_allocated_transactionid(TransactionId::generate(accountIdFrom).toProtobuf().release());
   protoTransactionRecord.set_memo(txMemo);
@@ -133,9 +133,9 @@ TEST_F(TransactionRecordUnitTests, FromProtobuf)
   ASSERT_TRUE(txRecord.mConsensusTimestamp.has_value());
   EXPECT_EQ(txRecord.mConsensusTimestamp->time_since_epoch().count(), now.time_since_epoch().count());
 
-  ASSERT_TRUE(txRecord.mTransactionID.has_value());
-  EXPECT_EQ(txRecord.mTransactionID->mAccountId, accountIdFrom);
-  EXPECT_GE(txRecord.mTransactionID->mValidTransactionTime, now);
+  ASSERT_TRUE(txRecord.mTransactionId.has_value());
+  EXPECT_EQ(txRecord.mTransactionId->mAccountId, accountIdFrom);
+  EXPECT_GE(txRecord.mTransactionId->mValidTransactionTime, now);
 
   EXPECT_EQ(txRecord.mMemo, txMemo);
 


### PR DESCRIPTION
**Description**:
This PR addresses the concerns made in #625, which states that query responses should be able to be printed to an output stream. This involved overloading the `<<` operator for all objects as well as adding missing `toString()` methods to allow for the stringification of these objects, which just puts the objects into a JSON string.

This also adds some other missing APIs for these objects as well, namely `[to|from][Protobuf|Bytes]()`

**Related issue(s)**:

Fixes #625 

**Checklist**

- [x] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
