### PR TITLE
Added ED25519 keys adaptation to import PEM/DER

### DIFF
--- a/sdk/main/CMakeLists.txt
+++ b/sdk/main/CMakeLists.txt
@@ -170,6 +170,8 @@ add_library(${PROJECT_NAME} STATIC
         src/impl/ASN1ECKey.cc
         src/impl/ASN1ECPrivateKey.cc
         src/impl/ASN1ECPublicKey.cc
+        src/impl/ASN1ED25519PrivateKey.cc
+        src/impl/ASN1ED25519PublicKey.cc
         src/impl/BaseNetwork.cc
         src/impl/BaseNode.cc
         src/impl/BaseNodeAddress.cc

--- a/sdk/main/include/impl/ASN1ECKey.h
+++ b/sdk/main/include/impl/ASN1ECKey.h
@@ -26,7 +26,9 @@
 
 namespace Hedera::internal::asn1
 {
-constexpr size_t ECDSA_KEY_LENGTH = 32; // bytes
+constexpr size_t EC_KEY_LENGTH = 32; // bytes
+// more than this would be a melicious attempt
+constexpr size_t MAX_ENCRYPTED_KEY_LENGHT = 160; // bytes ~ 320 charachters
 
 /**
  * @class ASN1Key

--- a/sdk/main/include/impl/ASN1ECKey.h
+++ b/sdk/main/include/impl/ASN1ECKey.h
@@ -27,8 +27,8 @@
 namespace Hedera::internal::asn1
 {
 constexpr size_t EC_KEY_LENGTH = 32; // bytes
-// more than this would be a melicious attempt
-constexpr size_t MAX_ENCRYPTED_KEY_LENGHT = 160; // bytes ~ 320 charachters
+// more than this would be a malicious attempt
+constexpr size_t MAX_ENCRYPTED_KEY_LENGHT = 160; // bytes ~ 320 characters
 
 /**
  * @class ASN1Key

--- a/sdk/main/include/impl/ASN1ECPrivateKey.h
+++ b/sdk/main/include/impl/ASN1ECPrivateKey.h
@@ -36,20 +36,9 @@ const std::vector<std::byte> ASN1_PRK_SUFFIX_BYTES = { std::byte(0xA0), std::byt
                                                        std::byte(0x05), std::byte(0x2B), std::byte(0x81),
                                                        std::byte(0x04), std::byte(0x00), std::byte(0x0A) };
 
-// The ASN.1 algorithm identifier prefix bytes for an ED25519PrivateKey
-const std::vector<std::byte> ASN1_EDPRK_PREFIX_BYTES = {
-  std::byte(0x30), std::byte(0x2E), std::byte(0x02), std::byte(0x01), std::byte(0x00), std::byte(0x30),
-  std::byte(0x05), std::byte(0x06), std::byte(0x03), std::byte(0x2B), std::byte(0x65), std::byte(0x70),
-  std::byte(0x04), std::byte(0x22), std::byte(0x04), std::byte(0x20)
-};
-
 // PEM Format prefix/suffix string ECDSA
 constexpr std::string_view PEM_ECPRK_PREFIX_STRING = "-----BEGIN EC PRIVATE KEY-----";
 constexpr std::string_view PEM_ECPRK_SUFFIX_STRING = "-----END EC PRIVATE KEY-----";
-
-// PEM Format prefix/suffix string ED25519
-constexpr std::string_view PEM_ECPRK_PREFIX_STRING = "-----BEGIN PRIVATE KEY-----";
-constexpr std::string_view PEM_ECPRK_SUFFIX_STRING = "-----END PRIVATE KEY-----";
 
 /**
  * @class ASN1Key

--- a/sdk/main/include/impl/ASN1ECPrivateKey.h
+++ b/sdk/main/include/impl/ASN1ECPrivateKey.h
@@ -31,14 +31,25 @@ const std::vector<std::byte> ASN1_PRK_PREFIX_BYTES = { std::byte(0x30), std::byt
                                                        std::byte(0x01), std::byte(0x01), std::byte(0x04),
                                                        std::byte(0x20) };
 
-// The ASN.1 algorithm identifier suffix bytes for an ECDSAsecp256k1Key.
+// The ASN.1 algorithm identifier suffix bytes for an ECDSAsecp256k1KeyPrivateKey.
 const std::vector<std::byte> ASN1_PRK_SUFFIX_BYTES = { std::byte(0xA0), std::byte(0x07), std::byte(0x06),
                                                        std::byte(0x05), std::byte(0x2B), std::byte(0x81),
                                                        std::byte(0x04), std::byte(0x00), std::byte(0x0A) };
 
-// PEM Format prefix/suffix string
+// The ASN.1 algorithm identifier prefix bytes for an ED25519PrivateKey
+const std::vector<std::byte> ASN1_EDPRK_PREFIX_BYTES = {
+  std::byte(0x30), std::byte(0x2E), std::byte(0x02), std::byte(0x01), std::byte(0x00), std::byte(0x30),
+  std::byte(0x05), std::byte(0x06), std::byte(0x03), std::byte(0x2B), std::byte(0x65), std::byte(0x70),
+  std::byte(0x04), std::byte(0x22), std::byte(0x04), std::byte(0x20)
+};
+
+// PEM Format prefix/suffix string ECDSA
 constexpr std::string_view PEM_ECPRK_PREFIX_STRING = "-----BEGIN EC PRIVATE KEY-----";
 constexpr std::string_view PEM_ECPRK_SUFFIX_STRING = "-----END EC PRIVATE KEY-----";
+
+// PEM Format prefix/suffix string ED25519
+constexpr std::string_view PEM_ECPRK_PREFIX_STRING = "-----BEGIN PRIVATE KEY-----";
+constexpr std::string_view PEM_ECPRK_SUFFIX_STRING = "-----END PRIVATE KEY-----";
 
 /**
  * @class ASN1Key

--- a/sdk/main/include/impl/ASN1ED25519PrivateKey.h
+++ b/sdk/main/include/impl/ASN1ED25519PrivateKey.h
@@ -16,7 +16,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  *
- * @brief This file defines the Hedera C++ SDK's ED25519PrivateKey class, derived from ASN1ECKey.
+ * @brief This file defines the Hedera C++ SDK's ASN1ED25519PrivateKey class, derived from ASN1ECKey.
  */
 
 #ifndef HEDERA_SDK_CPP_IMPL_ASN1_ED25519_PRIVATE_KEY_H_

--- a/sdk/main/include/impl/ASN1ED25519PrivateKey.h
+++ b/sdk/main/include/impl/ASN1ED25519PrivateKey.h
@@ -1,0 +1,70 @@
+/*-
+ *
+ * Hedera C++ SDK
+ *
+ * Copyright (C) 2020 - 2023 Hedera Hashgraph, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * @brief This file defines the Hedera C++ SDK's ED25519PrivateKey class, derived from ASN1ECKey.
+ */
+
+#ifndef HEDERA_SDK_CPP_IMPL_ASN1_ED25519_PRIVATE_KEY_H_
+#define HEDERA_SDK_CPP_IMPL_ASN1_ED25519_PRIVATE_KEY_H_
+
+#include "ASN1ECKey.h"
+
+namespace Hedera::internal::asn1
+{
+// The ASN.1 algorithm identifier prefix bytes for an EC ED25519PrivateKey
+const std::vector<std::byte> ASN1_EDPRK_PREFIX_BYTES = {
+  std::byte(0x30), std::byte(0x2E), std::byte(0x02), std::byte(0x01), std::byte(0x00), std::byte(0x30),
+  std::byte(0x05), std::byte(0x06), std::byte(0x03), std::byte(0x2B), std::byte(0x65), std::byte(0x70),
+  std::byte(0x04), std::byte(0x22), std::byte(0x04), std::byte(0x20)
+};
+
+// PEM Format prefix/suffix string EC ED25519 Key
+constexpr std::string_view PEM_EDPRK_PREFIX_STRING = "-----BEGIN PRIVATE KEY-----";
+constexpr std::string_view PEM_EDPRK_SUFFIX_STRING = "-----END PRIVATE KEY-----";
+
+/**
+ * @class ASN1Key
+ * @brief ASN.1 key object.
+ */
+class ASN1ED25519PrivateKey : public ASN1ECKey
+{
+public:
+  /**
+   * @brief Constructor for ASN.1 key from a vector of bytes.
+   *
+   * @param bytes The vector of bytes containing the ASN.1 key data.
+   */
+  ASN1ED25519PrivateKey(const std::vector<std::byte>& bytes);
+
+  /**
+   * @brief Get the key value associated with the ASN.1 key.
+   *
+   * @return The key as a vector of bytes.
+   */
+  std::vector<std::byte> getKey() const override;
+
+private:
+  /**
+   * @brief Constructor for ASN.1 key.
+   */
+  ASN1ED25519PrivateKey() = default;
+};
+
+} // namespace Hedera::internal:asn1
+
+#endif // HEDERA_SDK_CPP_IMPL_ASN1_ED25519_PRIVATE_KEY_H_

--- a/sdk/main/include/impl/ASN1ED25519PublicKey.h
+++ b/sdk/main/include/impl/ASN1ED25519PublicKey.h
@@ -1,0 +1,70 @@
+/*-
+ *
+ * Hedera C++ SDK
+ *
+ * Copyright (C) 2020 - 2023 Hedera Hashgraph, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * @file
+ * @brief Defines the Hedera C++ SDK's ASN1ED25519PublicKey class, derived from ASN1ECKey.
+ */
+
+#ifndef HEDERA_SDK_CPP_IMPL_ASN1_ED25519_PUBLIC_KEY_H_
+#define HEDERA_SDK_CPP_IMPL_ASN1_ED25519_PUBLIC_KEY_H_
+
+#include "ASN1ECKey.h"
+
+namespace Hedera::internal::asn1
+{
+/**
+ * The prefix bytes of a DER-encoded ED25519PublicKey.
+ */
+static inline const std::vector<std::byte> ASN1_EDPBK_PREFIX_BYTES = {
+  std::byte(0x30), std::byte(0x2A), std::byte(0x30), std::byte(0x05), std::byte(0x06), std::byte(0x03),
+  std::byte(0x2B), std::byte(0x65), std::byte(0x70), std::byte(0x03), std::byte(0x21), std::byte(0x00)
+};
+
+// PEM Format prefix/suffix string
+constexpr std::string_view PEM_ECPBK_PREFIX_STRING = "-----BEGIN PUBLIC KEY-----";
+constexpr std::string_view PEM_ECPBK_SUFFIX_STRING = "-----END PUBLIC KEY-----";
+
+/**
+ * @class ASN1ED25519PublicKey
+ * @brief ASN.1 elliptic curve public key object.
+ */
+class ASN1ED25519PublicKey : public ASN1ECKey
+{
+public:
+  /**
+   * @brief Constructor for ASN.1 elliptic curve public key from a vector of bytes.
+   * @param bytes The vector of bytes containing the ASN.1 key data.
+   */
+  ASN1ED25519PublicKey(const std::vector<std::byte>& bytes);
+
+  /**
+   * @brief Get the key value associated with the ASN.1 elliptic curve public key.
+   * @return The key as a vector of bytes.
+   */
+  std::vector<std::byte> getKey() const override;
+
+private:
+  /**
+   * @brief Constructor for ASN.1 elliptic curve public key.
+   */
+  ASN1ED25519PublicKey() = default;
+};
+
+} // namespace Hedera::internal:asn1
+
+#endif // HEDERA_SDK_CPP_IMPL_ASN1_ED25519_PUBLIC_KEY_H_

--- a/sdk/main/src/ECDSAsecp256k1PrivateKey.cc
+++ b/sdk/main/src/ECDSAsecp256k1PrivateKey.cc
@@ -63,7 +63,7 @@ const internal::OpenSSLUtils::BIGNUM CURVE_ORDER =
 
   // This means potentially only the key bytes will be in the input not standard for ASN1 encodings but the SDK needs to
   // be able to process them
-  if (bytes.size() == internal::asn1::ECDSA_KEY_LENGTH)
+  if (bytes.size() == internal::asn1::EC_KEY_LENGTH)
   {
     buildPrivateKeyBytes = internal::Utilities::concatenateVectors(
       { internal::asn1::ASN1_PRK_PREFIX_BYTES, bytes, internal::asn1::ASN1_PRK_SUFFIX_BYTES });

--- a/sdk/main/src/ECDSAsecp256k1PrivateKey.cc
+++ b/sdk/main/src/ECDSAsecp256k1PrivateKey.cc
@@ -115,8 +115,9 @@ std::unique_ptr<ECDSAsecp256k1PrivateKey> ECDSAsecp256k1PrivateKey::fromString(s
     if (formattedKey.compare(formattedKey.size() - internal::asn1::PEM_ECPRK_SUFFIX_STRING.size(),
                              formattedKey.size(),
                              internal::asn1::PEM_ECPRK_SUFFIX_STRING) == 0)
+    {
       formattedKey = formattedKey.substr(0, formattedKey.size() - internal::asn1::PEM_ECPRK_SUFFIX_STRING.size());
-
+    }
     formattedKey = internal::HexConverter::base64ToHex(formattedKey);
   }
 

--- a/sdk/main/src/ECDSAsecp256k1PublicKey.cc
+++ b/sdk/main/src/ECDSAsecp256k1PublicKey.cc
@@ -60,14 +60,14 @@ namespace
   // OpenSSL requires that the bytes are uncompressed and that they contain the appropriate ASN.1 prefix.
   std::vector<std::byte> buildPublicKeyBytes = bytes;
 
-  if (buildPublicKeyBytes.size() == internal::asn1::ECDSA_KEY_LENGTH + 1)
+  if (buildPublicKeyBytes.size() == internal::asn1::EC_KEY_LENGTH + 1)
   {
     buildPublicKeyBytes = internal::Utilities::concatenateVectors(
       { internal::asn1::ASN1_CPUBK_PREFIX_BYTES, { std::byte(0x00) }, buildPublicKeyBytes });
   }
   else
   {
-    if (buildPublicKeyBytes.size() == internal::asn1::ECDSA_KEY_LENGTH * 2 + 1)
+    if (buildPublicKeyBytes.size() == internal::asn1::EC_KEY_LENGTH * 2 + 1)
     {
       buildPublicKeyBytes = internal::Utilities::concatenateVectors(
         { internal::asn1::ASN1_UPUBK_PREFIX_BYTES, { std::byte(0x00) }, buildPublicKeyBytes });

--- a/sdk/main/src/ECDSAsecp256k1PublicKey.cc
+++ b/sdk/main/src/ECDSAsecp256k1PublicKey.cc
@@ -57,7 +57,6 @@ namespace
  */
 [[nodiscard]] internal::OpenSSLUtils::EVP_PKEY bytesToPKEY(const std::vector<std::byte>& bytes)
 {
-  // OpenSSL requires that the bytes are uncompressed and that they contain the appropriate ASN.1 prefix.
   std::vector<std::byte> buildPublicKeyBytes = bytes;
 
   if (buildPublicKeyBytes.size() == internal::asn1::EC_KEY_LENGTH + 1)
@@ -111,7 +110,9 @@ std::unique_ptr<ECDSAsecp256k1PublicKey> ECDSAsecp256k1PublicKey::fromString(std
     if (formattedKey.compare(formattedKey.size() - internal::asn1::PEM_ECPUBK_SUFFIX_STRING.size(),
                              formattedKey.size(),
                              internal::asn1::PEM_ECPUBK_SUFFIX_STRING) == 0)
+    {
       formattedKey = formattedKey.substr(0, formattedKey.size() - internal::asn1::PEM_ECPUBK_SUFFIX_STRING.size());
+    }
 
     formattedKey = internal::HexConverter::base64ToHex(formattedKey);
   }

--- a/sdk/main/src/ED25519PrivateKey.cc
+++ b/sdk/main/src/ED25519PrivateKey.cc
@@ -53,21 +53,19 @@ const std::vector<std::byte> SLIP10_SEED = { std::byte('e'), std::byte('d'), std
  */
 [[nodiscard]] internal::OpenSSLUtils::EVP_PKEY bytesToPKEY(std::vector<std::byte> bytes)
 {
-  std::vector<std::byte> buildBytes = bytes;
-
   if (bytes.size() == ED25519PrivateKey::KEY_SIZE)
   {
-    buildBytes = internal::Utilities::concatenateVectors({ internal::asn1::ASN1_EDPRK_PREFIX_BYTES, bytes });
+    bytes = internal::Utilities::concatenateVectors({ internal::asn1::ASN1_EDPRK_PREFIX_BYTES, bytes });
   }
   else
   {
-    internal::asn1::ASN1ED25519PrivateKey asn1key(buildBytes);
-    buildBytes = internal::Utilities::concatenateVectors({ internal::asn1::ASN1_EDPRK_PREFIX_BYTES, asn1key.getKey() });
+    internal::asn1::ASN1ED25519PrivateKey asn1key(bytes);
+    bytes = internal::Utilities::concatenateVectors({ internal::asn1::ASN1_EDPRK_PREFIX_BYTES, asn1key.getKey() });
   }
 
-  const unsigned char* rawKeyBytes = internal::Utilities::toTypePtr<unsigned char>(buildBytes.data());
+  const unsigned char* rawKeyBytes = internal::Utilities::toTypePtr<unsigned char>(bytes.data());
   internal::OpenSSLUtils::EVP_PKEY key(
-    d2i_PrivateKey(EVP_PKEY_ED25519, nullptr, &rawKeyBytes, static_cast<long>(buildBytes.size())));
+    d2i_PrivateKey(EVP_PKEY_ED25519, nullptr, &rawKeyBytes, static_cast<long>(bytes.size())));
   if (!key)
   {
     throw OpenSSLException(internal::OpenSSLUtils::getErrorMessage("d2i_PrivateKey"));

--- a/sdk/main/src/ED25519PublicKey.cc
+++ b/sdk/main/src/ED25519PublicKey.cc
@@ -20,6 +20,7 @@
 #include "ED25519PublicKey.h"
 #include "exceptions/BadKeyException.h"
 #include "exceptions/OpenSSLException.h"
+#include "impl/ASN1ED25519PublicKey.h"
 #include "impl/HexConverter.h"
 #include "impl/PublicKeyImpl.h"
 #include "impl/Utilities.h"
@@ -42,13 +43,20 @@ namespace
  */
 [[nodiscard]] internal::OpenSSLUtils::EVP_PKEY bytesToPKEY(std::vector<std::byte> bytes)
 {
+  std::vector<std::byte> buildBytes = bytes;
+
   if (bytes.size() == ED25519PublicKey::KEY_SIZE)
   {
-    bytes = internal::Utilities::concatenateVectors({ ED25519PublicKey::DER_ENCODED_PREFIX_BYTES, bytes });
+    buildBytes = internal::Utilities::concatenateVectors({ internal::asn1::ASN1_EDPBK_PREFIX_BYTES, bytes });
+  }
+  else
+  {
+    internal::asn1::ASN1ED25519PublicKey asn1key(buildBytes);
+    buildBytes = internal::Utilities::concatenateVectors({ internal::asn1::ASN1_EDPBK_PREFIX_BYTES, asn1key.getKey() });
   }
 
-  const auto* bytesPtr = internal::Utilities::toTypePtr<unsigned char>(bytes.data());
-  internal::OpenSSLUtils::EVP_PKEY key(d2i_PUBKEY(nullptr, &bytesPtr, static_cast<long>(bytes.size())));
+  const auto* bytesPtr = internal::Utilities::toTypePtr<unsigned char>(buildBytes.data());
+  internal::OpenSSLUtils::EVP_PKEY key(d2i_PUBKEY(nullptr, &bytesPtr, static_cast<long>(buildBytes.size())));
   if (!key)
   {
     throw OpenSSLException(internal::OpenSSLUtils::getErrorMessage("d2i_PUBKEY"));
@@ -62,16 +70,25 @@ namespace
 //-----
 std::unique_ptr<ED25519PublicKey> ED25519PublicKey::fromString(std::string_view key)
 {
-  if (key.size() != KEY_SIZE * 2 + DER_ENCODED_PREFIX_HEX.size() && key.size() != KEY_SIZE * 2)
+  std::string formattedKey = key.data();
+  // Remove PEM prefix/suffix if is present and hex the base64 val
+  if (formattedKey.compare(
+        0, internal::asn1::PEM_ECPBK_PREFIX_STRING.size(), internal::asn1::PEM_ECPBK_PREFIX_STRING) == 0)
   {
-    throw BadKeyException("ED25519PublicKey cannot be realized from input string: input string size should be " +
-                          std::to_string(KEY_SIZE * 2 + DER_ENCODED_PREFIX_HEX.size()) + " or " +
-                          std::to_string(KEY_SIZE * 2));
+    formattedKey = formattedKey.substr(internal::asn1::PEM_ECPBK_PREFIX_STRING.size(), formattedKey.size());
+
+    if (formattedKey.compare(formattedKey.size() - internal::asn1::PEM_ECPBK_SUFFIX_STRING.size(),
+                             formattedKey.size(),
+                             internal::asn1::PEM_ECPBK_SUFFIX_STRING) == 0)
+      formattedKey = formattedKey.substr(0, formattedKey.size() - internal::asn1::PEM_ECPBK_SUFFIX_STRING.size());
+
+    formattedKey = internal::HexConverter::base64ToHex(formattedKey);
   }
 
   try
   {
-    return std::make_unique<ED25519PublicKey>(ED25519PublicKey(bytesToPKEY(internal::HexConverter::hexToBytes(key))));
+    return std::make_unique<ED25519PublicKey>(
+      ED25519PublicKey(bytesToPKEY(internal::HexConverter::hexToBytes(formattedKey))));
   }
   catch (const OpenSSLException& openSSLException)
   {
@@ -83,13 +100,6 @@ std::unique_ptr<ED25519PublicKey> ED25519PublicKey::fromString(std::string_view 
 //-----
 std::unique_ptr<ED25519PublicKey> ED25519PublicKey::fromBytes(const std::vector<std::byte>& bytes)
 {
-  if (bytes.size() != KEY_SIZE + DER_ENCODED_PREFIX_BYTES.size() && bytes.size() != KEY_SIZE)
-  {
-    throw BadKeyException("ED25519PublicKey cannot be realized from input bytes: input byte array size should be " +
-                          std::to_string(KEY_SIZE + DER_ENCODED_PREFIX_BYTES.size()) + " or " +
-                          std::to_string(KEY_SIZE));
-  }
-
   try
   {
     return std::make_unique<ED25519PublicKey>(ED25519PublicKey(bytesToPKEY(bytes)));

--- a/sdk/main/src/impl/ASN1ECKey.cc
+++ b/sdk/main/src/impl/ASN1ECKey.cc
@@ -30,24 +30,22 @@ void ASN1ECKey::decode(const std::vector<std::byte>& bytes)
   int currentByteIndex = 0;
   while (currentByteIndex < bytes.size() - 1)
   {
-    std::byte asn1Tag = bytes[currentByteIndex++];
-    int asn1TagSize = static_cast<int>(bytes[currentByteIndex++]);
+    const std::byte asn1Tag = bytes[currentByteIndex++];
+    const int asn1TagSize = static_cast<int>(bytes[currentByteIndex++]);
 
     if (currentByteIndex + asn1TagSize > bytes.size())
     {
       throw BadKeyException("Bad PEM/DER EC KEY bytes data!");
     }
     // Ignore sequence as ASN1 for EC Key is in basic format
-    if (asn1Tag == SEQUENCE)
+    if (asn1Tag != SEQUENCE)
     {
-      continue;
+      std::vector<std::byte> asn1DataAtTag(bytes.begin() + currentByteIndex,
+                                           bytes.begin() + currentByteIndex + asn1TagSize);
+      currentByteIndex += asn1TagSize;
+
+      asn1KeyData.insert({ asn1Tag, asn1DataAtTag });
     }
-
-    std::vector<std::byte> asn1DataAtTag(bytes.begin() + currentByteIndex,
-                                         bytes.begin() + currentByteIndex + asn1TagSize);
-    currentByteIndex += asn1TagSize;
-
-    asn1KeyData.insert({ asn1Tag, asn1DataAtTag });
   }
 }
 

--- a/sdk/main/src/impl/ASN1ECKey.cc
+++ b/sdk/main/src/impl/ASN1ECKey.cc
@@ -33,9 +33,15 @@ void ASN1ECKey::decode(const std::vector<std::byte>& bytes)
     std::byte asn1Tag = bytes[currentByteIndex++];
     int asn1TagSize = static_cast<int>(bytes[currentByteIndex++]);
 
+    if (currentByteIndex + asn1TagSize > bytes.size())
+    {
+      throw BadKeyException("Bad PEM/DER EC KEY bytes data!");
+    }
     // Ignore sequence as ASN1 for EC Key is in basic format
     if (asn1Tag == SEQUENCE)
+    {
       continue;
+    }
 
     std::vector<std::byte> asn1DataAtTag(bytes.begin() + currentByteIndex,
                                          bytes.begin() + currentByteIndex + asn1TagSize);

--- a/sdk/main/src/impl/ASN1ECPrivateKey.cc
+++ b/sdk/main/src/impl/ASN1ECPrivateKey.cc
@@ -27,14 +27,25 @@ namespace Hedera::internal::asn1
 {
 ASN1ECPrivateKey::ASN1ECPrivateKey(const std::vector<std::byte>& bytes)
 {
-  decode(bytes);
+  if (bytes.size() >= MAX_ENCRYPTED_KEY_LENGHT)
+  {
+    throw BadKeyException("Over maximum possible input bytes for EC Key!");
+  }
+  else
+  {
+    decode(bytes);
+  }
 }
 
 std::vector<std::byte> ASN1ECPrivateKey::getKey() const
 {
   std::vector<std::byte> privateKey = get(OCTET_STRING);
-  if (privateKey.size() > ECDSA_KEY_LENGTH) // remove redundant padded bytes if any
-    privateKey = std::vector<std::byte>(privateKey.end() - ECDSA_KEY_LENGTH, privateKey.end());
+  if (privateKey.empty())
+  {
+    throw BadKeyException("Data not decoded properly for input PEM/DER EC KEY bytes!");
+  }
+  if (privateKey.size() > EC_KEY_LENGTH) // remove redundant padded bytes if any
+    privateKey = std::vector<std::byte>(privateKey.end() - EC_KEY_LENGTH, privateKey.end());
 
   return privateKey;
 }

--- a/sdk/main/src/impl/ASN1ECPrivateKey.cc
+++ b/sdk/main/src/impl/ASN1ECPrivateKey.cc
@@ -45,7 +45,9 @@ std::vector<std::byte> ASN1ECPrivateKey::getKey() const
     throw BadKeyException("Data not decoded properly for input PEM/DER EC KEY bytes!");
   }
   if (privateKey.size() > EC_KEY_LENGTH) // remove redundant padded bytes if any
+  {
     privateKey = std::vector<std::byte>(privateKey.end() - EC_KEY_LENGTH, privateKey.end());
+  }
 
   return privateKey;
 }

--- a/sdk/main/src/impl/ASN1ED25519PrivateKey.cc
+++ b/sdk/main/src/impl/ASN1ED25519PrivateKey.cc
@@ -20,12 +20,12 @@
 
 #include "exceptions/BadKeyException.h"
 
-#include "impl/ASN1ECPrivateKey.h"
+#include "impl/ASN1ED25519PrivateKey.h"
 #include "impl/HexConverter.h"
 
 namespace Hedera::internal::asn1
 {
-ASN1ECPrivateKey::ASN1ECPrivateKey(const std::vector<std::byte>& bytes)
+ASN1ED25519PrivateKey::ASN1ED25519PrivateKey(const std::vector<std::byte>& bytes)
 {
   if (bytes.size() >= MAX_ENCRYPTED_KEY_LENGHT)
   {
@@ -37,10 +37,10 @@ ASN1ECPrivateKey::ASN1ECPrivateKey(const std::vector<std::byte>& bytes)
   }
 }
 
-std::vector<std::byte> ASN1ECPrivateKey::getKey() const
+std::vector<std::byte> ASN1ED25519PrivateKey::getKey() const
 {
   std::vector<std::byte> privateKey = get(OCTET_STRING);
-  if (privateKey.size() < EC_KEY_LENGTH)
+  if (privateKey.empty())
   {
     throw BadKeyException("Data not decoded properly for input PEM/DER EC KEY bytes!");
   }

--- a/sdk/main/src/impl/ASN1ED25519PrivateKey.cc
+++ b/sdk/main/src/impl/ASN1ED25519PrivateKey.cc
@@ -45,7 +45,9 @@ std::vector<std::byte> ASN1ED25519PrivateKey::getKey() const
     throw BadKeyException("Data not decoded properly for input PEM/DER EC KEY bytes!");
   }
   if (privateKey.size() > EC_KEY_LENGTH) // remove redundant padded bytes if any
+  {
     privateKey = std::vector<std::byte>(privateKey.end() - EC_KEY_LENGTH, privateKey.end());
+  }
 
   return privateKey;
 }

--- a/sdk/main/src/impl/ASN1ED25519PublicKey.cc
+++ b/sdk/main/src/impl/ASN1ED25519PublicKey.cc
@@ -45,7 +45,9 @@ std::vector<std::byte> ASN1ED25519PublicKey::getKey() const
     throw BadKeyException("Data not decoded properly for input PEM/DER EC KEY bytes!");
   }
   if (publicKey.size() > EC_KEY_LENGTH) // remove redundant padded bytes if any
+  {
     publicKey = std::vector<std::byte>(publicKey.end() - EC_KEY_LENGTH, publicKey.end());
+  }
 
   return publicKey;
 }

--- a/sdk/main/src/impl/ASN1ED25519PublicKey.cc
+++ b/sdk/main/src/impl/ASN1ED25519PublicKey.cc
@@ -20,12 +20,12 @@
 
 #include "exceptions/BadKeyException.h"
 
-#include "impl/ASN1ECPrivateKey.h"
+#include "impl/ASN1ED25519PublicKey.h"
 #include "impl/HexConverter.h"
 
 namespace Hedera::internal::asn1
 {
-ASN1ECPrivateKey::ASN1ECPrivateKey(const std::vector<std::byte>& bytes)
+ASN1ED25519PublicKey::ASN1ED25519PublicKey(const std::vector<std::byte>& bytes)
 {
   if (bytes.size() >= MAX_ENCRYPTED_KEY_LENGHT)
   {
@@ -37,17 +37,17 @@ ASN1ECPrivateKey::ASN1ECPrivateKey(const std::vector<std::byte>& bytes)
   }
 }
 
-std::vector<std::byte> ASN1ECPrivateKey::getKey() const
+std::vector<std::byte> ASN1ED25519PublicKey::getKey() const
 {
-  std::vector<std::byte> privateKey = get(OCTET_STRING);
-  if (privateKey.size() < EC_KEY_LENGTH)
+  std::vector<std::byte> publicKey = get(BIT_STRING);
+  if (publicKey.size() < EC_KEY_LENGTH)
   {
     throw BadKeyException("Data not decoded properly for input PEM/DER EC KEY bytes!");
   }
-  if (privateKey.size() > EC_KEY_LENGTH) // remove redundant padded bytes if any
-    privateKey = std::vector<std::byte>(privateKey.end() - EC_KEY_LENGTH, privateKey.end());
+  if (publicKey.size() > EC_KEY_LENGTH) // remove redundant padded bytes if any
+    publicKey = std::vector<std::byte>(publicKey.end() - EC_KEY_LENGTH, publicKey.end());
 
-  return privateKey;
+  return publicKey;
 }
 
 } // namespace Hedera::internal:asn1

--- a/sdk/tests/unit/ED25519PrivateKeyUnitTests.cc
+++ b/sdk/tests/unit/ED25519PrivateKeyUnitTests.cc
@@ -45,6 +45,11 @@ protected:
 
   [[nodiscard]] inline const std::string& getTestPrivateKeyHexString() const { return mPrivateKeyHexString; }
   [[nodiscard]] inline const std::vector<std::byte>& getTestPrivateKeyBytes() const { return mPrivateKeyBytes; }
+  [[nodiscard]] inline const std::unordered_map<std::string_view, std::pair<std::string_view, std::string_view>>
+  getExpectedPrivateKeyPairs() const
+  {
+    return expectedPrivateKeyPairs;
+  };
 
 private:
   const std::string mPrivateKeyHexString = "68FBA516472B387C9F33C3E667616D806E5B9CEFF23A766E5D9A3818C77871F1";
@@ -55,6 +60,20 @@ private:
     std::byte(0x9C), std::byte(0xEF), std::byte(0xF2), std::byte(0x3A), std::byte(0x76), std::byte(0x6E),
     std::byte(0x5D), std::byte(0x9A), std::byte(0x38), std::byte(0x18), std::byte(0xC7), std::byte(0x78),
     std::byte(0x71), std::byte(0xF1)
+  };
+  const std::string_view openSSLCompatiblePrivateKey =
+    "302e020100300506032b657004220420feb858a4a69600a5eef2d9c76f7fb84fc0b6627f29e0ab17e160f640c267d404";
+  const std::string_view unencryptedPemPrivateKey =
+    "-----BEGIN PRIVATE KEY-----MC4CAQAwBQYDK2VwBCIEIOgbjaHgEqF7PY0t2dUf2VU0u1MRoKii/fywDlze4lvl-----END PRIVATE "
+    "KEY-----";
+
+  const std::unordered_map<std::string_view, std::pair<std::string_view, std::string_view>> expectedPrivateKeyPairs{
+    {openSSLCompatiblePrivateKey,
+     { "FEB858A4A69600A5EEF2D9C76F7FB84FC0B6627F29E0AB17E160F640C267D404",
+        "8CCD31B53D1835B467AAC795DAB19B274DD3B37E3DAF12FCEC6BC02BAC87B53D" }},
+    { unencryptedPemPrivateKey,
+     { "E81B8DA1E012A17B3D8D2DD9D51FD95534BB5311A0A8A2FDFCB00E5CDEE25BE5",
+        "F7B9AA4A8E4EEE94E4277DFE757D8D7CDE027E7CD5349B7D8E6EE21C9B9395BE" }},
   };
 };
 
@@ -239,4 +258,24 @@ TEST_F(ED25519PrivateKeyUnitTests, GetChainCode)
   EXPECT_TRUE(chainCode.empty());
 
   // Chain code functionality is further tested in SLIP10 test vectors
+}
+
+//-----
+TEST_F(ED25519PrivateKeyUnitTests, ED25519Compatibility)
+{
+  // Given
+  auto expectedKeys = getExpectedPrivateKeyPairs();
+
+  // When // Then
+  for (auto pair : expectedKeys)
+  {
+    auto actualKey = pair.first;
+
+    auto expectedPrivateKey = pair.second.first;
+    auto expectedPublicKey = pair.second.second;
+
+    auto actualResultKeyPair = ED25519PrivateKey::fromString(actualKey);
+    ASSERT_EQ(actualResultKeyPair->toStringRaw(), expectedPrivateKey);
+    ASSERT_EQ(actualResultKeyPair->getPublicKey()->toStringRaw(), expectedPublicKey);
+  }
 }

--- a/sdk/tests/unit/ED25519PrivateKeyUnitTests.cc
+++ b/sdk/tests/unit/ED25519PrivateKeyUnitTests.cc
@@ -129,9 +129,6 @@ TEST_F(ED25519PrivateKeyUnitTests, FromString)
                                                "F83DEF42411E046461D5AEEAE9S11C56F661 557F349F3412DBD95C9FE8B026X"),
                BadKeyException);
   EXPECT_THROW(const std::unique_ptr<ED25519PrivateKey> key = ED25519PrivateKey::fromString(
-                 ECDSAsecp256k1PrivateKey::DER_ENCODED_PREFIX_HEX + getTestPrivateKeyHexString()),
-               BadKeyException);
-  EXPECT_THROW(const std::unique_ptr<ED25519PrivateKey> key = ED25519PrivateKey::fromString(
                  std::string(ED25519PrivateKey::DER_ENCODED_PREFIX_HEX.size(), 'A') + getTestPrivateKeyHexString()),
                BadKeyException);
   EXPECT_NO_THROW(const std::unique_ptr<ED25519PrivateKey> key =

--- a/sdk/tests/unit/ED25519PublicKeyUnitTests.cc
+++ b/sdk/tests/unit/ED25519PublicKeyUnitTests.cc
@@ -45,6 +45,10 @@ protected:
 
   [[nodiscard]] inline const std::string& getTestPublicKeyHex() const { return mPublicKeyHexString; }
   [[nodiscard]] inline const std::vector<std::byte>& getTestPublicKeyBytes() const { return mPublicKeyBytes; }
+  [[nodiscard]] inline const std::unordered_map<std::string_view, std::string_view> getExpectedPublicKeyPairs() const
+  {
+    return expectedPublicKeyPairs;
+  };
 
 private:
   const std::string mPublicKeyHexString = "F83DEF42411E046461D5AEEAE9311C56F6612557F349F3412DBD95C9FE8B0265";
@@ -56,6 +60,11 @@ private:
                                                    std::byte(0xF3), std::byte(0x49), std::byte(0xF3), std::byte(0x41),
                                                    std::byte(0x2D), std::byte(0xBD), std::byte(0x95), std::byte(0xC9),
                                                    std::byte(0xFE), std::byte(0x8B), std::byte(0x02), std::byte(0x65) };
+  const std::string_view openSSLCompatibleDERPublicKey =
+    "302A300506032B65700321008CCD31B53D1835B467AAC795DAB19B274DD3B37E3DAF12FCEC6BC02BAC87B53D";
+  const std::unordered_map<std::string_view, std::string_view> expectedPublicKeyPairs{
+    {openSSLCompatibleDERPublicKey, "8CCD31B53D1835B467AAC795DAB19B274DD3B37E3DAF12FCEC6BC02BAC87B53D"},
+  };
 };
 
 //-----
@@ -256,4 +265,21 @@ TEST_F(ED25519PublicKeyUnitTests, PublicKeyFromProtobuf)
   // Then
   ASSERT_NE(publicKey, nullptr);
   EXPECT_EQ(publicKey->toBytes(), getTestPublicKeyBytes());
+}
+
+//-----
+TEST_F(ED25519PublicKeyUnitTests, ED25519Compatibility)
+{
+  // Given
+  auto expectedKeys = getExpectedPublicKeyPairs();
+
+  // When // Then
+  for (auto pair : expectedKeys)
+  {
+    auto actualKey = pair.first;
+    auto expectedKey = pair.second;
+
+    auto actualResultKeyPair = ED25519PublicKey::fromString(actualKey);
+    ASSERT_EQ(actualResultKeyPair->toStringRaw(), expectedKey);
+  }
 }


### PR DESCRIPTION
**Description**:
This PR adapts the ED25519 Keys to use the ASN.1 decomposition used for solving
ECDSA compatibility issues so we can import PEM/DER formatted ED25519 keys.

**Related issue(s)**: https://github.com/hashgraph/hedera-sdk-cpp/issues/423

Fixes https://github.com/hashgraph/hedera-sdk-cpp/issues/638

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [X] Documented (Code comments, README, etc.)
- [X] Tested (unit, integration, etc.)
