### PR TITLE
perf: Removed redundant sleep in Query.cc

### DIFF
--- a/src/sdk/main/src/Query.cc
+++ b/src/sdk/main/src/Query.cc
@@ -59,7 +59,6 @@
 #include <proto/query.pb.h>
 #include <proto/query_header.pb.h>
 #include <proto/transaction.pb.h>
-#include <thread>
 
 namespace Hedera
 {
@@ -362,9 +361,6 @@ void Query<SdkRequestType, SdkResponseType>::onExecute(const Client& client)
   mImpl->mClient = &client;
 
   // Get the cost and make sure it's willing to be paid.
-  std::this_thread::sleep_for(
-    std::chrono::seconds(2)); // It's not really clear why this needs to be here, but if it isn't the incorrect
-                              // transaction fee is fetched. This should be investigated at a later point.
   mImpl->mCost = getCost(client);
   if (mImpl->mCost.toTinybars() > ((mImpl->mMaxPayment.has_value()) ? mImpl->mMaxPayment->toTinybars()
                                                                     : ((client.getMaxQueryPayment().has_value())


### PR DESCRIPTION
**Description**:
Removed the thread_sleep in Query.cc. Looks like the reason for this being added is not broken functionality but was a result of local errors.

**Related issue(s)**:

Fixes https://github.com/hashgraph/hedera-sdk-cpp/issues/655

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
