### PR TITLE
refactor: Reorder `#include`s to fix Windows build

### DIFF
--- a/src/sdk/main/include/ContractInfo.h
+++ b/src/sdk/main/include/ContractInfo.h
@@ -34,6 +34,7 @@
 #include <memory>
 #include <optional>
 #include <string>
+#include <unordered_map>
 
 namespace proto
 {

--- a/src/sdk/main/src/AccountBalanceQuery.cc
+++ b/src/sdk/main/src/AccountBalanceQuery.cc
@@ -17,14 +17,15 @@
  * limitations under the License.
  *
  */
-#include "AccountBalanceQuery.h"
+#include <proto/crypto_get_account_balance.pb.h>
+
 #include "AccountBalance.h"
+#include "AccountBalanceQuery.h"
 #include "TokenId.h"
 #include "exceptions/UninitializedException.h"
 #include "impl/MirrorNodeGateway.h"
 #include "impl/Node.h"
 
-#include <proto/crypto_get_account_balance.pb.h>
 #include <proto/query.pb.h>
 #include <proto/query_header.pb.h>
 #include <proto/response.pb.h>

--- a/src/sdk/main/src/AccountInfoQuery.cc
+++ b/src/sdk/main/src/AccountInfoQuery.cc
@@ -17,6 +17,8 @@
  * limitations under the License.
  *
  */
+#include <proto/crypto_get_info.pb.h>
+
 #include "AccountInfoQuery.h"
 #include "AccountInfo.h"
 #include "TokenId.h"
@@ -24,7 +26,6 @@
 #include "impl/MirrorNodeGateway.h"
 #include "impl/Node.h"
 
-#include <proto/crypto_get_info.pb.h>
 #include <proto/query.pb.h>
 #include <proto/query_header.pb.h>
 #include <proto/response.pb.h>

--- a/src/sdk/main/src/AccountInfoQuery.cc
+++ b/src/sdk/main/src/AccountInfoQuery.cc
@@ -19,8 +19,8 @@
  */
 #include <proto/crypto_get_info.pb.h>
 
-#include "AccountInfoQuery.h"
 #include "AccountInfo.h"
+#include "AccountInfoQuery.h"
 #include "TokenId.h"
 #include "TokenRelationship.h"
 #include "impl/MirrorNodeGateway.h"

--- a/src/sdk/main/src/ContractInfoQuery.cc
+++ b/src/sdk/main/src/ContractInfoQuery.cc
@@ -17,12 +17,13 @@
  * limitations under the License.
  *
  */
+#include <proto/contract_get_info.pb.h>
+
 #include "ContractInfoQuery.h"
 #include "ContractInfo.h"
 #include "impl/MirrorNodeGateway.h"
 #include "impl/Node.h"
 
-#include <proto/contract_get_info.pb.h>
 #include <proto/query.pb.h>
 #include <proto/query_header.pb.h>
 #include <proto/response.pb.h>

--- a/src/sdk/main/src/ContractInfoQuery.cc
+++ b/src/sdk/main/src/ContractInfoQuery.cc
@@ -19,8 +19,8 @@
  */
 #include <proto/contract_get_info.pb.h>
 
-#include "ContractInfoQuery.h"
 #include "ContractInfo.h"
+#include "ContractInfoQuery.h"
 #include "impl/MirrorNodeGateway.h"
 #include "impl/Node.h"
 


### PR DESCRIPTION
This PR fixes an issue with the Windows build where it wasn't building due to `#include` ordering. It's still not clear why `#include`s need to be added in a particular order for Windows builds so this should be investigated at a later point.

**Related issue(s)**:

Fixes #676 

**Checklist**

- [x] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
