### PR TITLE
ci: Remove limechain-hedera as a codeowner

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -2,7 +2,7 @@
 ##### Global Protection Rule ######
 ###################################
 # NOTE: This rule is overriden by the more specific rules below. This is the catch-all rule for all files not covered by the more specific rules below.
-*                                               @hashgraph/hedera-sdk @hashgraph/hedera-sdk-cpp-contributors
+*                                               @hashgraph/hedera-sdk @hashgraph/hedera-sdk-cpp-maintainers
 
 #########################
 #####  Core Files  ######

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -2,7 +2,7 @@
 ##### Global Protection Rule ######
 ###################################
 # NOTE: This rule is overriden by the more specific rules below. This is the catch-all rule for all files not covered by the more specific rules below.
-*                                               @hashgraph/hedera-sdk @hashgraph/hedera-sdk-cpp-contributors @hashgraph/limechain-hedera
+*                                               @hashgraph/hedera-sdk @hashgraph/hedera-sdk-cpp-contributors
 
 #########################
 #####  Core Files  ######
@@ -25,7 +25,7 @@
 .remarkrc                                       @hashgraph/release-engineering @hashgraph/release-engineering-managers
 
 # Self-protection for root CODEOWNERS files (this file should not exist and should definitely require approval)
-/CODEOWNERS                                      @hashgraph/release-engineering @hashgraph/release-engineering-managers
+/CODEOWNERS                                     @hashgraph/release-engineering @hashgraph/release-engineering-managers
 
 # Protect the repository root files
 /README.md                                      @hashgraph/release-engineering @hashgraph/release-engineering-managers


### PR DESCRIPTION
A recent PR was merged that allowed automatic reviewers to be added to a PR based on what types of files were edited in that PR. The `limechain-hedera` team was added to review all PRs, even though a majority of the members of that team have never touched this repo before. Removing them will prevent the addition of these unnecessary reviewers.

**Related issue(s)**:

Fixes #687