### PR TITLE
feat: Update BIP39 Mnemonic example to demonstrate regeneration

### DIFF
--- a/src/sdk/examples/GeneratePrivateKeyFromMnemonic.cc
+++ b/src/sdk/examples/GeneratePrivateKeyFromMnemonic.cc
@@ -38,21 +38,42 @@ int main(int argc, char** argv)
   // Generate and print a ED25519PrivateKey and ECDSAsecp256k1PrivateKey from the mnemonic with no passphrase
   std::unique_ptr<PrivateKey> ed25519PrivateKey = mnemonicBip39.toStandardEd25519PrivateKey();
   std::unique_ptr<PrivateKey> ecdsaSecp256k1PrivateKey = mnemonicBip39.toStandardECDSAsecp256k1PrivateKey();
-  std::cout << "Generated ED25519PrivateKey from mnemonic with no passphrase: " << ed25519PrivateKey->toStringRaw()
+  std::cout << std::endl
+            << "Generated ED25519PrivateKey from mnemonic with no passphrase: " << ed25519PrivateKey->toStringRaw()
             << std::endl;
   std::cout << "Generated ECDSAsecp256k1PrivateKey from mnemonic with no passphrase: "
+            << ecdsaSecp256k1PrivateKey->toStringRaw() << std::endl;
+
+  // Regenerate and print a ED25519PrivateKey and ECDSAsecp256k1PrivateKey from the mnemonic with no passphrase
+  ed25519PrivateKey = mnemonicBip39.toStandardEd25519PrivateKey();
+  ecdsaSecp256k1PrivateKey = mnemonicBip39.toStandardECDSAsecp256k1PrivateKey();
+  std::cout << std::endl
+            << "Regenerated ED25519PrivateKey from mnemonic with no passphrase: " << ed25519PrivateKey->toStringRaw()
+            << std::endl;
+  std::cout << "Regenerated ECDSAsecp256k1PrivateKey from mnemonic with no passphrase: "
             << ecdsaSecp256k1PrivateKey->toStringRaw() << std::endl;
 
   // Generate and print a ED25519PrivateKey and ECDSAsecp256k1PrivateKey from the mnemonic with a passphrase
   ed25519PrivateKey = mnemonicBip39.toStandardEd25519PrivateKey(passphrase);
   ecdsaSecp256k1PrivateKey = mnemonicBip39.toStandardECDSAsecp256k1PrivateKey(passphrase);
-  std::cout << "Generated ED25519PrivateKey from mnemonic with passphrase '" << passphrase
+  std::cout << std::endl
+            << "Generated ED25519PrivateKey from mnemonic with passphrase '" << passphrase
             << "': " << ed25519PrivateKey->toStringRaw() << std::endl;
   std::cout << "Generated ECDSAsecp256k1PrivateKey from mnemonic with passphrase '" << passphrase
             << "': " << ecdsaSecp256k1PrivateKey->toStringRaw() << std::endl;
 
+  // Regenerate and print a ED25519PrivateKey and ECDSAsecp256k1PrivateKey from the mnemonic with a passphrase
+  ed25519PrivateKey = mnemonicBip39.toStandardEd25519PrivateKey(passphrase);
+  ecdsaSecp256k1PrivateKey = mnemonicBip39.toStandardECDSAsecp256k1PrivateKey(passphrase);
+  std::cout << std::endl
+            << "Regenerated ED25519PrivateKey from mnemonic with passphrase '" << passphrase
+            << "': " << ed25519PrivateKey->toStringRaw() << std::endl;
+  std::cout << "Regenerated ECDSAsecp256k1PrivateKey from mnemonic with passphrase '" << passphrase
+            << "': " << ecdsaSecp256k1PrivateKey->toStringRaw() << std::endl;
+
   // Start a new section of printing
   std::cout << std::endl;
+  std::cout << "-----------------------------------------------" << std::endl;
 
   // Generate and print a 24-word BIP39 mnemonic
   mnemonicBip39 = MnemonicBIP39::generate24WordBIP39Mnemonic();
@@ -61,17 +82,37 @@ int main(int argc, char** argv)
   // Generate and print a ED25519PrivateKey and ECDSAsecp256k1PrivateKey from the mnemonic with no passphrase
   ed25519PrivateKey = mnemonicBip39.toStandardEd25519PrivateKey();
   ecdsaSecp256k1PrivateKey = mnemonicBip39.toStandardECDSAsecp256k1PrivateKey();
-  std::cout << "Generated ED25519PrivateKey from mnemonic with no passphrase: " << ed25519PrivateKey->toStringRaw()
+  std::cout << std::endl
+            << "Generated ED25519PrivateKey from mnemonic with no passphrase: " << ed25519PrivateKey->toStringRaw()
             << std::endl;
   std::cout << "Generated ECDSAsecp256k1PrivateKey from mnemonic with no passphrase: "
+            << ecdsaSecp256k1PrivateKey->toStringRaw() << std::endl;
+
+  // Regenerate and print a ED25519PrivateKey and ECDSAsecp256k1PrivateKey from the mnemonic with no passphrase
+  ed25519PrivateKey = mnemonicBip39.toStandardEd25519PrivateKey();
+  ecdsaSecp256k1PrivateKey = mnemonicBip39.toStandardECDSAsecp256k1PrivateKey();
+  std::cout << std::endl
+            << "Regenerated ED25519PrivateKey from mnemonic with no passphrase: " << ed25519PrivateKey->toStringRaw()
+            << std::endl;
+  std::cout << "Regenerated ECDSAsecp256k1PrivateKey from mnemonic with no passphrase: "
             << ecdsaSecp256k1PrivateKey->toStringRaw() << std::endl;
 
   // Generate and print a ED25519PrivateKey and ECDSAsecp256k1PrivateKey from the mnemonic with a passphrase
   ed25519PrivateKey = mnemonicBip39.toStandardEd25519PrivateKey(passphrase);
   ecdsaSecp256k1PrivateKey = mnemonicBip39.toStandardECDSAsecp256k1PrivateKey(passphrase);
-  std::cout << "Generated ED25519PrivateKey from mnemonic with passphrase '" << passphrase
+  std::cout << std::endl
+            << "Generated ED25519PrivateKey from mnemonic with passphrase '" << passphrase
             << "': " << ed25519PrivateKey->toStringRaw() << std::endl;
   std::cout << "Generated ECDSAsecp256k1PrivateKey from mnemonic with passphrase '" << passphrase
+            << "': " << ecdsaSecp256k1PrivateKey->toStringRaw() << std::endl;
+
+  // Regenerate and print a ED25519PrivateKey and ECDSAsecp256k1PrivateKey from the mnemonic with a passphrase
+  ed25519PrivateKey = mnemonicBip39.toStandardEd25519PrivateKey(passphrase);
+  ecdsaSecp256k1PrivateKey = mnemonicBip39.toStandardECDSAsecp256k1PrivateKey(passphrase);
+  std::cout << std::endl
+            << "Regenerated ED25519PrivateKey from mnemonic with passphrase '" << passphrase
+            << "': " << ed25519PrivateKey->toStringRaw() << std::endl;
+  std::cout << "Regenerated ECDSAsecp256k1PrivateKey from mnemonic with passphrase '" << passphrase
             << "': " << ecdsaSecp256k1PrivateKey->toStringRaw() << std::endl;
 
   return 0;


### PR DESCRIPTION
**Description**:
This PR modifies the example for generating private keys from mnemonics.

**Related issue(s)**:

Fixes https://github.com/hashgraph/hedera-sdk-cpp/issues/599

**Notes for reviewer**:


**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
