### PR TITLE
feat: Added example demo of account creation with EVM public address

### DIFF
--- a/src/sdk/examples/AutoCreateAccountTransferTransactionExample.cc
+++ b/src/sdk/examples/AutoCreateAccountTransferTransactionExample.cc
@@ -116,7 +116,16 @@ int main(int argc, char** argv)
   const TransactionReceipt receipt =
     TransactionReceiptQuery().setTransactionId(response.mTransactionId).setIncludeChildren(true).execute(client);
 
-  const AccountId newAccountId = receipt.mChildren.at(0).mAccountId.value();
+  AccountId newAccountId = receipt.mChildren.at(0).mAccountId.value();
+
+  // Wait some seconds for Mirror Node to update state with the newly created hollow account
+  std::this_thread::sleep_for(std::chrono::seconds(5));
+
+  // Populate the account public EVM Address from Mirror Node
+  newAccountId.populateAccountEvmAddress(client);
+
+  // If Mirror Node contained the account public EVM Address. It should be printed instead of the Hedera AccountID
+  std::cout << newAccountId.toString() << std::endl;
 
   return 0;
 }

--- a/src/sdk/examples/AutoCreateAccountTransferTransactionExample.cc
+++ b/src/sdk/examples/AutoCreateAccountTransferTransactionExample.cc
@@ -29,9 +29,11 @@
 #include "TransactionResponse.h"
 #include "TransferTransaction.h"
 
+#include <chrono>
 #include <dotenv.h>
 #include <iostream>
 #include <memory>
+#include <thread>
 
 using namespace Hedera;
 


### PR DESCRIPTION
**Description**:
Added example demo of account creation with EVM public address. As the SDK supports `HttpClient` and the `populateEvmAddress` function I altered the `AutoCreateAccountTransferTransactionExample` as it demonstrates the flow required by the QA definition and previously the example did not demonstrate/print any results.

**Related issue(s)**:

Fixes https://github.com/hashgraph/hedera-sdk-cpp/issues/622

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
