### PR TITLE
fix: don't fill out `accountIdToUpdate` if no account ID was provided

### DIFF
--- a/src/sdk/main/src/AccountUpdateTransaction.cc
+++ b/src/sdk/main/src/AccountUpdateTransaction.cc
@@ -258,7 +258,10 @@ proto::CryptoUpdateTransactionBody* AccountUpdateTransaction::build() const
 {
   auto body = std::make_unique<proto::CryptoUpdateTransactionBody>();
 
-  body->set_allocated_accountidtoupdate(mAccountId.toProtobuf().release());
+  if (!(mAccountId == AccountId()))
+  {
+    body->set_allocated_accountidtoupdate(mAccountId.toProtobuf().release());
+  }
 
   if (mKey)
   {

--- a/src/sdk/tests/integration/AccountUpdateTransactionIntegrationTests.cc
+++ b/src/sdk/tests/integration/AccountUpdateTransactionIntegrationTests.cc
@@ -31,6 +31,7 @@
 #include "TransactionReceipt.h"
 #include "TransactionResponse.h"
 #include "TransferTransaction.h"
+#include "exceptions/PrecheckStatusException.h"
 #include "exceptions/ReceiptStatusException.h"
 
 #include <gtest/gtest.h>
@@ -158,7 +159,7 @@ TEST_F(AccountUpdateTransactionIntegrationTests, CannotUpdateAccountWithoutAccou
                                                       .sign(privateKey)
                                                       .execute(getTestClient())
                                                       .getReceipt(getTestClient()),
-               ReceiptStatusException); // ACCOUNT_ID_DOES_NOT_EXIST
+               PrecheckStatusException); // ACCOUNT_ID_DOES_NOT_EXIST
 
   // Clean up
   ASSERT_NO_THROW(AccountDeleteTransaction()


### PR DESCRIPTION
**Description**:
This PR fixes an issue discovered where `AccountUpdateTransaction`s being sent to the network without an `accountId` were returning `INVALID_ACCOUNT_ID` instead of `ACCOUNT_ID_DOES_NOT_EXIST` because the `accountId` was being filled regardless of if one was provided or not.

**Related issue(s)**:

Fixes #755 

**Checklist**

- [x] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
